### PR TITLE
Fix silent stream truncation on multi-byte characters

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -120,12 +120,13 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         if eos.contains(best) { break }
         generated.append(best)
         if let tokenizer {
-            // Reprint only the stable delta so multi-byte tokens render correctly.
+            // Reprint only the stable delta so multi-byte tokens render
+            // correctly; StreamingText holds back incomplete characters.
             let text = tokenizer.decode(tokens: generated)
-            if text.hasPrefix(printed) {
-                print(String(text.dropFirst(printed.count)), terminator: "")
+            if let (delta, newPrinted) = StreamingText.delta(printed: printed, decoded: text) {
+                print(delta, terminator: "")
                 fflush(stdout)
-                printed = text
+                printed = newPrinted
             }
         } else {
             print(best, terminator: " ")
@@ -134,6 +135,10 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         logits = try model.step([best], state: state)
     }
     let decodeSecs = -decodeStart.timeIntervalSinceNow
+    if let tokenizer,
+       let rest = StreamingText.finalDelta(printed: printed, decoded: tokenizer.decode(tokens: generated)) {
+        print(rest, terminator: "")
+    }
     print("")
     FileHandle.standardError.write(Data(String(
         format: "decode: %d tokens in %.1fs (%.2f tok/s)\n",

--- a/Sources/SwiftletCore/StreamingText.swift
+++ b/Sources/SwiftletCore/StreamingText.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Streaming-safe text deltas over an incrementally decoded token sequence.
+///
+/// BPE tokenizers split multi-byte UTF-8 characters (emoji in particular)
+/// across tokens. Decoding a prefix of such a sequence renders the incomplete
+/// tail as U+FFFD; emitting that replacement character is wrong twice over:
+/// the user sees a garbage glyph, and once the next token completes the
+/// character, the emitted text is no longer a prefix of the full decode — a
+/// naive `hasPrefix` delta scheme then goes silent for the rest of the turn.
+///
+/// `delta(printed:decoded:)` holds back any trailing U+FFFD run until the
+/// bytes complete, so the emitted prefix always stays a true prefix of every
+/// future decode.
+public enum StreamingText {
+    /// `decoded` with any trailing U+FFFD run removed (an incomplete
+    /// multi-byte character mid-stream). U+FFFD elsewhere is preserved.
+    public static func stablePrefix(_ decoded: String) -> String {
+        var s = Substring(decoded)
+        while s.hasSuffix("\u{FFFD}") { s.removeLast() }
+        return String(s)
+    }
+
+    /// The next emittable delta, or nil when nothing new can be emitted yet.
+    /// On success, the caller should append `delta` to its output and replace
+    /// its printed-state with `printed`.
+    public static func delta(printed: String, decoded: String) -> (delta: String, printed: String)? {
+        let stable = stablePrefix(decoded)
+        guard stable.hasPrefix(printed), stable.count > printed.count else { return nil }
+        return (String(stable.dropFirst(printed.count)), stable)
+    }
+
+    /// Delta for the END of a turn: the sequence is final, so a trailing
+    /// U+FFFD can never complete and is emitted as-is rather than held back.
+    public static func finalDelta(printed: String, decoded: String) -> String? {
+        guard decoded.hasPrefix(printed), decoded.count > printed.count else { return nil }
+        return String(decoded.dropFirst(printed.count))
+    }
+}

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -320,17 +320,26 @@ public final class SwiftletSession: @unchecked Sendable {
                         generatedCounts[best, default: 0] += 1
                         let text = self.tokenizer.decode(tokens: generated)
                         var terminated = false
-                        if text.hasPrefix(printed) {
-                            let delta = String(text.dropFirst(printed.count))
-                            if !delta.isEmpty {
-                                if case .terminated = continuation.yield(delta) { terminated = true }
-                                printed = text
-                            }
+                        // Streaming-safe delta: an emoji split across tokens
+                        // decodes with a trailing U+FFFD that must be held
+                        // back — printing it desyncs the prefix comparison
+                        // and silences the rest of the turn.
+                        if let (delta, newPrinted) = StreamingText.delta(printed: printed, decoded: text) {
+                            if case .terminated = continuation.yield(delta) { terminated = true }
+                            printed = newPrinted
                         }
                         let t0 = Date()
                         logits = try self.model.step([best], state: self.convState)
                         decodeSeconds += -t0.timeIntervalSinceNow
                         if terminated { cleanEnd = true; stopReason = "consumer-cancelled"; break }
+                    }
+                    // Flush whatever the hold-back logic still owes (a
+                    // character completed by the last token, or a genuinely
+                    // unfinishable U+FFFD when EOS cut an emoji short).
+                    if let rest = StreamingText.finalDelta(
+                        printed: printed, decoded: self.tokenizer.decode(tokens: generated)
+                    ) {
+                        continuation.yield(rest)
                     }
                     print("[SwiftletSession] stop: \(stopReason) after \(generated.count) tokens")
                     if !cleanEnd {

--- a/Tests/SwiftletCoreTests/StreamingTextTests.swift
+++ b/Tests/SwiftletCoreTests/StreamingTextTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import SwiftletCore
+
+/// A multi-byte character split across tokens must never leak a U+FFFD into
+/// the stream, and the emitted prefix must stay valid once the character
+/// completes (the observed failure: one printed "�" silenced the whole rest
+/// of the turn because `hasPrefix` never matched again).
+@Suite struct StreamingTextTests {
+    @Test func plainGrowthEmitsDelta() {
+        let r = StreamingText.delta(printed: "Hallo", decoded: "Hallo Welt")
+        #expect(r?.delta == " Welt" && r?.printed == "Hallo Welt")
+    }
+
+    @Test func incompleteCharacterIsHeldBack() {
+        // Emoji first byte(s) decoded -> trailing U+FFFD is not emitted.
+        let r = StreamingText.delta(printed: "Danke!", decoded: "Danke! \u{FFFD}")
+        #expect(r?.delta == " " && r?.printed == "Danke! ")
+        // Nothing new while the character is still incomplete.
+        #expect(StreamingText.delta(printed: "Danke! ", decoded: "Danke! \u{FFFD}") == nil)
+    }
+
+    @Test func completedCharacterEmitsCleanly() {
+        // Next token completes the emoji: the stream continues seamlessly.
+        let r = StreamingText.delta(printed: "Danke! ", decoded: "Danke! 😊 gerne")
+        #expect(r?.delta == "😊 gerne")
+    }
+
+    @Test func fffdMidStringIsPreserved() {
+        // Only a TRAILING replacement run is provisional.
+        let r = StreamingText.delta(printed: "", decoded: "a\u{FFFD}b")
+        #expect(r?.delta == "a\u{FFFD}b")
+    }
+
+    @Test func divergedPrintedStateDoesNotEmitGarbage() {
+        // Legacy failure state (a "�" was already printed): no crash, no
+        // bogus delta — the turn-final flush is responsible for recovery.
+        #expect(StreamingText.delta(printed: "Hi \u{FFFD}", decoded: "Hi 😊") == nil)
+    }
+
+    @Test func finalFlushEmitsTrailingReplacement() {
+        // EOS right after an incomplete character: final text is emitted
+        // verbatim, replacement char included (it can never complete now).
+        #expect(StreamingText.finalDelta(printed: "Ende ", decoded: "Ende \u{FFFD}") == "\u{FFFD}")
+        #expect(StreamingText.finalDelta(printed: "gleich", decoded: "gleich") == nil)
+    }
+
+    @Test func multiTokenEmojiSequence() {
+        // Simulated 4-byte emoji arriving over three decode steps.
+        var printed = ""
+        var out = ""
+        for decoded in ["Wald", "Wald \u{FFFD}", "Wald \u{FFFD}\u{FFFD}", "Wald 🌲!"] {
+            if let (d, p) = StreamingText.delta(printed: printed, decoded: decoded) {
+                out += d
+                printed = p
+            }
+        }
+        #expect(out == "Wald 🌲!")
+    }
+}


### PR DESCRIPTION
## Problem

When the model emits a multi-byte UTF-8 character split across BPE tokens (emoji are the common case), the streaming paths decode the incomplete prefix, which renders a trailing U+FFFD — and print it. Once the next token completes the character, the emitted text is no longer a prefix of the full decode, the `hasPrefix` comparison never matches again, and **the rest of the turn streams nothing**.

Observed on Qwen3.5-397B-A17B (chat, German):

```
>>> Mir geht es gut, Danke
Das freut mich sehr zu hören! �
```

— the model had produced a full multi-sentence reply (internally intact, `lastReplyText` is correct), but nothing after the replacement character ever reached the terminal.

## Fix

New `StreamingText` helper in SwiftletCore:

- `delta(printed:decoded:)` holds back a trailing U+FFFD run until the character completes, so the emitted prefix stays a true prefix of every future decode. U+FFFD elsewhere in the text is preserved.
- `finalDelta(printed:decoded:)` flushes at end of turn — including a genuine trailing U+FFFD when EOS cut a character short, since it can never complete anymore.

Adopted in `SwiftletSession.streamChat` (which since f5fab7c also covers the server) and the CLI `generate` loop.

## Verification

- Unit tests simulate a 4-byte emoji arriving over three decode steps, the mid-string U+FFFD case, and the legacy diverged-prefix state (no crash, no bogus delta).
- End-to-end: forced-emoji prompt on Qwen3.6-35B streams `🌲🦌🍂` cleanly; the original 397B repro now prints `Das freut mich sehr zu hören! 😊` and the full remainder of the conversation.

Independent of #6 (based directly on current main); `swift test` green.