### PR TITLE
Fix capitalization inconsistency: 'Colibri' → 'colibri' in PLAN.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -18,7 +18,7 @@ TurboFieldfare took 103 logged experiments because its author had no answer key.
    in C++, including CPU gated-delta-net kernels we can crib the recurrence from.
 3. **TurboFieldfare + colibri are the streaming answer key.** TF's container format, streaming
    installer, pread expert cache, and phase-overlap decode loop are model-agnostic and copyable
-   almost verbatim (file list in section 7). Colibri documents which cache/IO/quant policies
+   almost verbatim (file list in section 7). colibri documents which cache/IO/quant policies
    survived adversarial benchmarking, including the dead ends (section 8).
 4. **Pre-quantized MLX 4-bit checkpoints already exist** for all three target models
    (lmstudio-community / mlx-community). TF's quant format IS MLX affine 4-bit group-64,


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `PLAN.md` (line 21).

## Problem

Inconsistent capitalization: the project name 'colibri' is lowercase in all other instances throughout the document (lines 5, 7, 19, 107, 127, 148, 156, 177, 210), but is capitalized here as 'Colibri'. This breaks the established naming convention.

The problematic text:

```markdown
Colibri documents which cache/IO/quant policies survived adversarial benchmarking
```

## Fix

Replaced with:

```markdown
colibri documents which cache/IO/quant policies survived adversarial benchmarking
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

## Audit Metadata

| Field | Value |
|-------|-------|
| **Fingerprint** | `3bbca95188f4245d` |
| **Severity** | minor |
| **Category** | grammar |
| **Audit Date** | 2026-08-11 |