### PR TITLE
Accept polymorphic message content in server requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,6 @@ let package = Package(
             ]
         ),
         .testTarget(name: "SwiftletCoreTests", dependencies: ["SwiftletCore"]),
+        .testTarget(name: "SwiftletServerTests", dependencies: ["SwiftletServer"]),
     ]
 )

--- a/Sources/SwiftletServer/main.swift
+++ b/Sources/SwiftletServer/main.swift
@@ -10,8 +10,27 @@ import SwiftletCore
 //
 //   swiftlet-server --model <dir> [--port 8080] [--cache-gb 2]
 
+/// Message content per the OpenAI Chat Completions spec: a plain string, an
+/// array of parts ([{type:"text",text:"..."}]), or null on tool-call turns.
+/// Text parts are joined; non-text parts are dropped; null decodes as "".
+struct ChatContent: Decodable {
+    struct Part: Decodable { let text: String? }
+    let text: String
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if try c.decodeNil() {
+            text = ""
+        } else if let s = try? c.decode(String.self) {
+            text = s
+        } else {
+            text = try c.decode([Part].self).compactMap(\.text).joined()
+        }
+    }
+}
+
+/// OpenAI-compatible Chat Completions request body.
 struct ChatRequest: Decodable {
-    struct Message: Decodable { let role: String; let content: String }
+    struct Message: Decodable { let role: String; let content: ChatContent }
     let messages: [Message]
     let stream: Bool?
     let max_tokens: Int?
@@ -119,7 +138,7 @@ final class HTTPHandler: ChannelInboundHandler {
             respondJSON(context, status: .badRequest, data: jsonData(["error": "malformed request"]))
             return
         }
-        let messages = request.messages.map { ["role": $0.role, "content": $0.content] }
+        let messages = request.messages.map { ["role": $0.role, "content": $0.content.text] }
         let maxNew = request.max_tokens ?? request.max_completion_tokens ?? 512
         let streaming = request.stream ?? false
         let id = "chatcmpl-\(UUID().uuidString.prefix(8))"

--- a/Tests/SwiftletServerTests/ChatRequestTests.swift
+++ b/Tests/SwiftletServerTests/ChatRequestTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import SwiftletServer
+
+@Suite struct ChatRequestTests {
+    private func decode(_ json: String) throws -> ChatRequest {
+        try JSONDecoder().decode(ChatRequest.self, from: Data(json.utf8))
+    }
+
+    @Test func plainStringContent() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"system","content":"sys"},{"role":"user","content":"hi"}],"stream":true,"max_tokens":512,"temperature":0.7}"#
+        )
+        #expect(r.messages.map(\.role) == ["system", "user"])
+        #expect(r.messages.map(\.content.text) == ["sys", "hi"])
+        #expect(r.stream == true)
+        #expect(r.max_tokens == 512)
+    }
+
+    @Test func arrayOfPartsContent() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}"#
+        )
+        #expect(r.messages[0].content.text == "hi")
+    }
+
+    @Test func multipleTextPartsJoined() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}"#
+        )
+        #expect(r.messages[0].content.text == "ab")
+    }
+
+    @Test func imageOnlyPartsDropped() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,xxx"}}]}]}"#
+        )
+        #expect(r.messages[0].content.text == "")
+    }
+
+    @Test func nullContentWithToolCalls() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"bash","arguments":"{}"}}]}]}"#
+        )
+        #expect(r.messages[0].role == "assistant")
+        #expect(r.messages[0].content.text == "")
+    }
+
+    @Test func unknownTopLevelKeysIgnored() throws {
+        let r = try decode(
+            #"{"messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"bash"}}],"stream_options":{},"store":false,"max_completion_tokens":256}"#
+        )
+        #expect(r.messages.count == 1)
+        #expect(r.max_tokens == nil)
+        #expect(r.max_completion_tokens == 256)
+    }
+
+    @Test func malformedInputThrows() {
+        #expect(throws: DecodingError.self) {
+            _ = try decode(#"{"messages":"nope"}"#)
+        }
+    }
+
+    @Test func nonSpecContentTypeThrows() {
+        #expect(throws: DecodingError.self) {
+            _ = try decode(#"{"messages":[{"role":"user","content":42}]}"#)
+        }
+    }
+}


### PR DESCRIPTION
I noticed when using the Pi agent against this running server, I got a 400 malformed error. 
The issue is the current implementation only accepts `string`. However as per the openAPI spec, `content` can either be a string (which is currently supported) or an array of {type,text}, see https://github.com/openai/openai-openapi/blob/master/openapi.yaml.

Added tests to demonstrate that both prior and new formats work fine.