### PR TITLE
repack: fail fast when the source has no stacked expert tensors

### DIFF
--- a/Sources/SwiftletCore/Qpack.swift
+++ b/Sources/SwiftletCore/Qpack.swift
@@ -110,6 +110,18 @@ public struct QpackRepacker {
                 offset += perExpertBytes
             }
         }
+        // A checkpoint with no stacked expert tensors is not in mlx-lm runtime
+        // format. Without this guard the loop above silently skips every section,
+        // yielding zero-length layer files and a structurally valid container
+        // that only fails much later, at load time.
+        guard !sections.isEmpty else {
+            throw Checkpoint.Error.missingTensor(
+                l0 + "* -- no stacked expert tensors found. This is not an mlx-lm "
+                + "runtime-format checkpoint; convert it with mlx-lm first "
+                + "(raw Hugging Face checkpoints store experts as .mlp.experts.N.*)."
+            )
+        }
+
         let stride = Qpack.align(offset, to: Qpack.pageAlignment)
         let layout = Qpack.Layout(
             expertCount: config.numExperts,

--- a/Sources/SwiftletCore/StreamingInstaller.swift
+++ b/Sources/SwiftletCore/StreamingInstaller.swift
@@ -63,6 +63,7 @@ public final class StreamingInstaller {
         case httpError(String, Int)
         case ioError(String)
         case cancelled
+        case notMLXCheckpoint
 
         public var errorDescription: String? {
             switch self {
@@ -71,6 +72,10 @@ public final class StreamingInstaller {
             case .httpError(let f, let c): return "network error \(c) on \(f)"
             case .ioError(let f): return "could not write \(f)"
             case .cancelled: return "cancelled"
+            case .notMLXCheckpoint:
+                return "no model.layers.0.mlp.switch_mlp.* tensors found -- this is not "
+                    + "an mlx-lm runtime-format checkpoint. Convert it with mlx-lm first "
+                    + "(raw Hugging Face checkpoints store experts as .mlp.experts.N.*)."
             }
         }
     }
@@ -226,6 +231,11 @@ public final class StreamingInstaller {
                 running += perBytes
             }
         }
+        // Same reasoning as QpackRepacker: an empty section table means the source
+        // is not an mlx-lm runtime-format checkpoint. Fail here rather than writing
+        // a container that cannot be loaded.
+        guard !sections.isEmpty else { throw Error.notMLXCheckpoint }
+
         let stride = Qpack.align(running, to: Qpack.pageAlignment)
         log("expert blob payload \(running) B, stride \(stride) B")
 


### PR DESCRIPTION
Both repack paths build the expert section table by looking for
`model.layers.0.mlp.switch_mlp.{gate,up,down}_proj.{weight,scales,biases}` and
skip anything absent with `continue`. When the source is not an mlx-lm
runtime-format checkpoint every lookup misses, and the run still reports success:

- `sections` ends up empty, so `stride = align(0)` is `0` and every
  `packed_experts/layer_NN.bin` is written zero-length;
- raw Hugging Face expert tensors are named `.mlp.experts.N.*` rather than
  `.mlp.switch_mlp.*`, so `isExpert` does not match them and they are
  accumulated into the dense file instead;
- `manifest.json` is written last and the installer logs `container complete`.

The problem only surfaces later, at load, as
`missingTensor("qpack section gate_proj")` — which does not point at the cause.

Reaching for an official Qwen repo is an easy way to hit it, since those are the
obvious ones to try:

```
swiftlet-repack --from-hf Qwen/Qwen3.6-35B-A3B --output out.qpack
```

This adds a guard to both paths (`QpackRepacker` and `StreamingInstaller`) so an
empty section table fails immediately, naming the tensor pattern and pointing at
mlx-lm conversion.

**Before:** streams the whole checkpoint, writes an unloadable container, exits 0.
**After:**

```
planning 26 shard(s)
install failed: no model.layers.0.mlp.switch_mlp.* tensors found -- this is not
an mlx-lm runtime-format checkpoint. Convert it with mlx-lm first (raw Hugging
Face checkpoints store experts as .mlp.experts.N.*).
```

### Verification

macOS 26.6.2, Swift 6.3.3, Apple M1 (8-core GPU, 16 GB):

- `swift build -c release` clean.
- Existing suite still green — **39 tests in 12 suites**. That doubles as the
  negative control that the guard does not fire on valid input: two real
  containers repacked from `mlx-community/Qwen3.6-35B-A3B-8bit` and
  `mlx-community/Qwen3.6-35B-A3B-4bit` are unaffected, and both load and generate.
- `--from-hf Qwen/Qwen3.6-35B-A3B` now stops after the aux files with the message
  above and writes no expert sections, instead of streaming the full checkpoint.

One note: the aux files (~22 MB) are still fetched before the guard runs, since
the section table is derived from the safetensors headers. Happy to move the
check earlier if you would prefer it fail before any download.
