### PR TITLE
cli: complete the usage block

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -275,5 +275,11 @@ default:
     print("usage:")
     print("  swiftlet info <model>            model budget summary (\(ArchConfig.known.keys.sorted().joined(separator: " | ")))")
     print("  swiftlet verify <model-dir> <fixtures.safetensors>   compare CPU forward vs mlx fixture")
-    print("  swiftlet generate <model-dir> --prompt \"...\" [--max-new 32] [--chat]")
+    print("  swiftlet dump-tensor <model-dir> <module-path> <out.safetensors>   dequantized f32 weights of one module")
+    print("  swiftlet generate <model-dir> --prompt \"...\" [--max-new 32] [--chat] [--gpu] [--cache-gb 8] [--lazy]")
+    print("  swiftlet chat <model-dir> [\"turn\" ...] [--max-new 256] [--cache-gb 8] [--greedy] [--system \"...\"]")
+    print("")
+    print("  --gpu       Metal runtime; on a .qpack container experts stream through a bounded cache")
+    print("  --cache-gb  expert cache budget, default 8 (note: swiftlet-server defaults to 2)")
+    print("  --lazy      CPU path only: ~3 GB peak instead of ~10-14 GB, slower per step")
 }


### PR DESCRIPTION
The usage text lists 3 of the 5 subcommands and 3 of the flags that are actually parsed, so `chat`, `dump-tensor`, `--gpu`, `--cache-gb`, `--lazy`, `--greedy` and `--system` are currently discoverable only by reading `main.swift`.

This adds the two missing subcommands and the flags each accepts, plus a short note on the three that are easiest to get wrong.

One of those is worth calling out on its own: **`--cache-gb` defaults to 8 in the CLI but 2 in `swiftlet-server`.** That is easy to trip over when comparing numbers between the two — I did exactly that while benchmarking, and it looked like a memory regression until I checked the source. I have documented the difference rather than changed either default, since the split looks deliberate (one-shot vs long-running).

Text only, no behaviour change. Output after the change, from the built binary:

```
usage:
  swiftlet info <model>            model budget summary (qwen3-next-80b | qwen3.5-397b | qwen3.6-35b)
  swiftlet verify <model-dir> <fixtures.safetensors>   compare CPU forward vs mlx fixture
  swiftlet dump-tensor <model-dir> <module-path> <out.safetensors>   dequantized f32 weights of one module
  swiftlet generate <model-dir> --prompt "..." [--max-new 32] [--chat] [--gpu] [--cache-gb 8] [--lazy]
  swiftlet chat <model-dir> ["turn" ...] [--max-new 256] [--cache-gb 8] [--greedy] [--system "..."]

  --gpu       Metal runtime; on a .qpack container experts stream through a bounded cache
  --cache-gb  expert cache budget, default 8 (note: swiftlet-server defaults to 2)
  --lazy      CPU path only: ~3 GB peak instead of ~10-14 GB, slower per step
```
