### PR TITLE
Elide intermediate LM-head projections for multi-token prompt calls

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -130,6 +130,13 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
     var logits = try model.step(ids, state: state)
     let prefillSecs = -prefillStart.timeIntervalSinceNow
     FileHandle.standardError.write(Data(String(format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs).utf8))
+    if let metal = model as? QwenMetalModel {
+        FileHandle.standardError.write(Data(String(
+            format: "LM-head elision: %d encoded, %d intermediate skipped\n",
+            metal.lastStepMetrics.logitProjections,
+            metal.lastStepMetrics.avoidedLogitProjections
+        ).utf8))
+    }
 
     var generated: [Int] = []
     var printed = ""

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -7,6 +7,15 @@ import Metal
 /// delta recurrence, attention softmax over cached KV, top-k routing), all of
 /// it microseconds per token. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
+    public struct StepMetrics: Equatable, Sendable {
+        public let tokensProcessed: Int
+        public let logitProjections: Int
+
+        public var avoidedLogitProjections: Int {
+            max(0, tokensProcessed - logitProjections)
+        }
+    }
+
     public let config: QwenConfig
     let ckpt: Checkpoint
     let engine: MetalEngine
@@ -72,6 +81,9 @@ public final class QwenMetalModel {
     let xBuf: MTLBuffer
     let yBuf: MTLBuffer
     let logitsBuf: MTLBuffer
+    public private(set) var lastStepMetrics = StepMetrics(
+        tokensProcessed: 0, logitProjections: 0
+    )
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -357,16 +369,42 @@ public final class QwenMetalModel {
 
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+        lastStepMetrics = StepMetrics(tokensProcessed: 0, logitProjections: 0)
+        var tokensProcessed = 0
+        var logitProjections = 0
+        defer {
+            lastStepMetrics = StepMetrics(
+                tokensProcessed: tokensProcessed,
+                logitProjections: logitProjections
+            )
+        }
+
         var logits: [Float] = []
-        for t in tokens {
-            logits = try stepOne(t, state: state)
+        for (index, t) in tokens.enumerated() {
+            // S1a LM-head elision: a multi-token call consumes only the final
+            // position's logits, so intermediate vocabulary projections are
+            // unnecessary.
+            let projectLogits = index == tokens.count - 1
+            logits = try stepOne(
+                t, state: state, projectLogits: projectLogits,
+                logitProjections: &logitProjections
+            )
             state.position += 1
+            tokensProcessed += 1
         }
         return logits
     }
 
-    private func stepOne(_ token: Int, state: QwenCPUModel.DecodeState) throws -> [Float] {
-        if sBuf != nil { return try stepOneFast(token, state: state) }
+    private func stepOne(
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
+        logitProjections: inout Int
+    ) throws -> [Float] {
+        if sBuf != nil {
+            return try stepOneFast(
+                token, state: state, projectLogits: projectLogits,
+                logitProjections: &logitProjections
+            )
+        }
         let cfg = config
         let D = cfg.hiddenSize
         var h = try ckpt.moduleWeightSlice("model.embed_tokens", rowRange: token..<(token + 1))
@@ -391,11 +429,13 @@ public final class QwenMetalModel {
             for i in 0..<D { h[i] += m[i] }
         }
 
+        guard projectLogits else { return [] }
         QwenCPUModel.rmsNorm(&h, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
         loadX(h)
         try runPhase { enc in
             try engine.encodeGemv(enc, lmHead, x: xBuf, y: logitsBuf, yOff: 0)
         }
+        logitProjections += 1
         return Array(UnsafeBufferPointer(
             start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
             count: cfg.vocabSize
@@ -891,7 +931,10 @@ extension QwenMetalModel {
         return (picks, weights)
     }
 
-    func stepOneFast(_ token: Int, state: QwenCPUModel.DecodeState) throws -> [Float] {
+    func stepOneFast(
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
+        logitProjections: inout Int
+    ) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
         if boundStateID != ObjectIdentifier(state) || state.position == 0 {
@@ -963,23 +1006,28 @@ extension QwenMetalModel {
             pending = PendingMoE(bufs: bufs, weights: weights, stacksLayer: li, picks: picks)
         }
 
-        // Final: last layer's experts + final norm + lm head.
+        // Always apply the last layer's experts. Only the final token in a
+        // multi-token call also needs final norm + vocabulary projection.
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         if let p = pending { try encodePendingMoE(enc, p) }
-        enc.setComputePipelineState(try engine.pipeline("norm_copy"))
-        var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
-        enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
-        setBytesParams(enc, &np, index: 3)
-        dispatchRows(enc, rows: 1)
-        barrier(enc)
-        try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+        if projectLogits {
+            enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+            var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
+            enc.setBuffer(hBuf!, offset: 0, index: 0)
+            enc.setBuffer(sBuf!, offset: 0, index: 1)
+            enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
+            setBytesParams(enc, &np, index: 3)
+            dispatchRows(enc, rows: 1)
+            barrier(enc)
+            try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            logitProjections += 1
+        }
         enc.endEncoding()
         cb.commit()
         cb.waitUntilCompleted()
 
+        guard projectLogits else { return [] }
         return Array(UnsafeBufferPointer(
             start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
             count: cfg.vocabSize))

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -12,32 +12,78 @@ import Testing
         .deletingLastPathComponent()
         .appendingPathComponent("fixtures")
 
+    static func maxAbsDiff(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count else { return .infinity }
+        var result: Float = 0
+        for i in lhs.indices { result = max(result, abs(lhs[i] - rhs[i])) }
+        return result
+    }
+
+    static func expectMatchingKV(
+        _ lhs: QwenCPUModel.DecodeState, _ rhs: QwenCPUModel.DecodeState,
+        label: String
+    ) {
+        #expect(lhs.position == rhs.position, "\(label): positions diverged")
+        #expect(Set(lhs.kv.keys) == Set(rhs.kv.keys), "\(label): KV layers diverged")
+        for layer in lhs.kv.keys {
+            guard let l = lhs.kv[layer], let r = rhs.kv[layer] else { continue }
+            #expect(l.k.count == r.k.count, "\(label): layer \(layer) K size diverged")
+            #expect(l.v.count == r.v.count, "\(label): layer \(layer) V size diverged")
+            #expect(Self.maxAbsDiff(l.k, r.k) < 1e-6, "\(label): layer \(layer) K diverged")
+            #expect(Self.maxAbsDiff(l.v, r.v) < 1e-6, "\(label): layer \(layer) V diverged")
+        }
+    }
+
     static func compare(_ modelName: String) throws {
         let dir = fixturesDir.appendingPathComponent(modelName)
         let cpu = try QwenCPUModel(modelDir: dir)
         cpu.retainAllLayers = true
-        let gpu = try QwenMetalModel(modelDir: dir)
+        let sequentialGPU = try QwenMetalModel(modelDir: dir)
+        let elidingGPU = try QwenMetalModel(modelDir: dir)
         let tokens = [1, 5, 9, 42, 7]
 
         let cpuState = QwenCPUModel.DecodeState()
-        let gpuState = QwenCPUModel.DecodeState()
+        let sequentialState = QwenCPUModel.DecodeState()
         var cpuLogits: [Float] = []
-        var gpuLogits: [Float] = []
+        var sequentialLogits: [Float] = []
         for t in tokens {
             cpuLogits = try cpu.step([t], state: cpuState)
-            gpuLogits = try gpu.step([t], state: gpuState)
+            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
+            #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
+            #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
 
-        var maxDiff: Float = 0
-        for i in 0..<cpuLogits.count { maxDiff = max(maxDiff, abs(cpuLogits[i] - gpuLogits[i])) }
+        let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "\(modelName): GPU vs CPU logits maxAbsDiff \(maxDiff)")
+
+        // S1a intermediate LM-head elision must retain token-at-a-time output
+        // and state. Separate instances isolate GPU-resident recurrence.
+        let elidingState = QwenCPUModel.DecodeState()
+        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
+        #expect(elisionDiff < 2e-3, "\(modelName): LM-head elision logits maxAbsDiff \(elisionDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
+
+        let continuation = 11
+        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
+        #expect(continuationDiff < 2e-3, "\(modelName): continuation maxAbsDiff \(continuationDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == 1)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == 0)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
 
         func argmax(_ v: [Float]) -> Int {
             var b = 0
             for i in 1..<v.count where v[i] > v[b] { b = i }
             return b
         }
-        #expect(argmax(cpuLogits) == argmax(gpuLogits), "\(modelName): greedy diverged")
+        #expect(argmax(cpuLogits) == argmax(sequentialLogits), "\(modelName): greedy diverged")
     }
 
     @Test func gpuMatchesCPUOnQuantizedTiny() throws {
@@ -57,23 +103,46 @@ import Testing
 
         let cpu = try QwenCPUModel(modelDir: src)
         cpu.retainAllLayers = true
-        let gpu = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
-        #expect(gpu.expertCache != nil, "qpack mode not engaged")
+        let sequentialGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        let elidingGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        #expect(sequentialGPU.expertCache != nil, "qpack mode not engaged")
+        #expect(elidingGPU.expertCache != nil, "qpack mode not engaged")
 
         let tokens = [1, 5, 9, 42, 7, 99]
         let cpuState = QwenCPUModel.DecodeState()
-        let gpuState = QwenCPUModel.DecodeState()
+        let sequentialState = QwenCPUModel.DecodeState()
         var cpuLogits: [Float] = []
-        var gpuLogits: [Float] = []
+        var sequentialLogits: [Float] = []
         for t in tokens {
             cpuLogits = try cpu.step([t], state: cpuState)
-            gpuLogits = try gpu.step([t], state: gpuState)
+            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
+            #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
+            #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
-        var maxDiff: Float = 0
-        for i in 0..<cpuLogits.count { maxDiff = max(maxDiff, abs(cpuLogits[i] - gpuLogits[i])) }
+        let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
-        let cache = gpu.expertCache!
-        #expect(cache.hits + cache.misses > 0)
+
+        let elidingState = QwenCPUModel.DecodeState()
+        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
+        #expect(elisionDiff < 2e-3, "qpack LM-head elision maxAbsDiff \(elisionDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
+
+        let continuation = 11
+        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
+        #expect(continuationDiff < 2e-3, "qpack continuation maxAbsDiff \(continuationDiff)")
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")
+
+        for cache in [sequentialGPU.expertCache!, elidingGPU.expertCache!] {
+            #expect(cache.hits + cache.misses > 0)
+        }
     }
 
     @Test func gpuMatchesCPUOnQwen35Tiny() throws {


### PR DESCRIPTION
## What this changes

For a multi-token prompt call, `step()` now projects logits only for the final position instead of running the vocab-size LM-head GEMV for every intermediate prefill token, in both the slow and fast paths. A `StepMetrics` counter struct records encoded vs skipped projections, and the CLI prints a one-line summary to stderr.

## Why

The README roadmap lists batched prefill as the top item ("long prompts currently process at decode speed"). This is a first slice of that work, not full batching — tokens still step sequentially; only the LM-head projection (the largest single GEMV on large-vocab models) is elided per intermediate token. It is a strict win for any multi-token prompt call and does not change the schedule otherwise.

## Validation

On an Apple M4 Max (macOS 26.6.2), `swift test`: full suite passes (50 tests / 13 suites). The added tests assert:

- a multi-token prompt call performs exactly one LM-head projection;
- sequential and multi-token paths produce matching final logits;
- the next continuation token and recurrent/KV state remain equivalent.
