### PR TITLE
Add aggregate Metal step instrumentation with pinned dispatch baselines

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -130,6 +130,13 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
     var logits = try model.step(ids, state: state)
     let prefillSecs = -prefillStart.timeIntervalSinceNow
     FileHandle.standardError.write(Data(String(format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs).utf8))
+    if let metal = model as? QwenMetalModel {
+        FileHandle.standardError.write(Data(String(
+            format: "LM-head elision: %d encoded, %d intermediate skipped\n",
+            metal.lastStepMetrics.logitProjections,
+            metal.lastStepMetrics.avoidedLogitProjections
+        ).utf8))
+    }
 
     var generated: [Int] = []
     var printed = ""

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -5,6 +5,40 @@ import Tokenizers
 func gib(_ bytes: Int) -> String { String(format: "%.2f GiB", Double(bytes) / Double(1 << 30)) }
 func mib(_ bytes: Int) -> String { String(format: "%.1f MiB", Double(bytes) / Double(1 << 20)) }
 
+/// S3a decode totals only. They establish an aggregate baseline, not phase or
+/// command-buffer timeline diagnosis.
+private struct MetalStepAggregate {
+    var steps = 0
+    var commandBuffersCommitted = 0
+    var blockingWaits = 0
+    var blockingWaitSeconds = 0.0
+    var computeDispatchesEncoded = 0
+    var commandBufferErrors = 0
+    var gpuExecutionSeconds = 0.0
+    var gpuTimedCommandBuffers = 0
+    var gpuUntimedCommandBuffers = 0
+
+    mutating func add(_ metrics: QwenMetalModel.StepMetrics) {
+        steps += 1
+        commandBuffersCommitted += metrics.commandBuffersCommitted
+        blockingWaits += metrics.blockingWaits
+        blockingWaitSeconds += metrics.blockingWaitSeconds
+        computeDispatchesEncoded += metrics.computeDispatchesEncoded
+        commandBufferErrors += metrics.commandBufferErrors
+        gpuExecutionSeconds += metrics.gpuExecutionSeconds
+        gpuTimedCommandBuffers += metrics.gpuTimedCommandBuffers
+        gpuUntimedCommandBuffers += metrics.gpuUntimedCommandBuffers
+    }
+}
+
+private func gpuTimingSummary(
+    seconds: Double, timed: Int, untimed: Int
+) -> String {
+    timed > 0
+        ? String(format: "%.3fs/%d timed/%d n/a", seconds, timed, untimed)
+        : "n/a/\(untimed)cb"
+}
+
 func runInfo(_ modelKey: String) {
     guard let cfg = ArchConfig.known[modelKey] else {
         print("unknown model \(modelKey); known: \(ArchConfig.known.keys.sorted().joined(separator: ", "))")
@@ -129,17 +163,29 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
     let prefillStart = Date()
     var logits = try model.step(ids, state: state)
     let prefillSecs = -prefillStart.timeIntervalSinceNow
-    FileHandle.standardError.write(Data(String(format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs).utf8))
     if let metal = model as? QwenMetalModel {
+        let m = metal.lastStepMetrics
+        let gpu = gpuTimingSummary(
+            seconds: m.gpuExecutionSeconds,
+            timed: m.gpuTimedCommandBuffers,
+            untimed: m.gpuUntimedCommandBuffers
+        )
+        let line = String(format:
+            "prefill S3a: %d tok wall=%.3fs wait=%.3fs/%d cb=%d err=%d dispatch=%d lm=%d skip=%d",
+            ids.count, m.stepWallSeconds, m.blockingWaitSeconds, m.blockingWaits,
+            m.commandBuffersCommitted, m.commandBufferErrors, m.computeDispatchesEncoded,
+            m.logitProjections, m.avoidedLogitProjections
+        ) + " gpu=\(gpu)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    } else {
         FileHandle.standardError.write(Data(String(
-            format: "LM-head elision: %d encoded, %d intermediate skipped\n",
-            metal.lastStepMetrics.logitProjections,
-            metal.lastStepMetrics.avoidedLogitProjections
+            format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs
         ).utf8))
     }
 
     var generated: [Int] = []
     var printed = ""
+    var decodeMetal = MetalStepAggregate()
     let decodeStart = Date()
     for _ in 0..<maxNew {
         var best = 0
@@ -160,6 +206,9 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             fflush(stdout)
         }
         logits = try model.step([best], state: state)
+        if let metal = model as? QwenMetalModel {
+            decodeMetal.add(metal.lastStepMetrics)
+        }
     }
     let decodeSecs = -decodeStart.timeIntervalSinceNow
     if let tokenizer,
@@ -171,6 +220,20 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         format: "decode: %d tokens in %.1fs (%.2f tok/s)\n",
         generated.count, decodeSecs, Double(generated.count) / max(decodeSecs, 0.001)
     ).utf8))
+    if model is QwenMetalModel {
+        let gpu = gpuTimingSummary(
+            seconds: decodeMetal.gpuExecutionSeconds,
+            timed: decodeMetal.gpuTimedCommandBuffers,
+            untimed: decodeMetal.gpuUntimedCommandBuffers
+        )
+        let line = String(format:
+            "decode Metal S3a: steps=%d cb=%d err=%d wait=%.3fs/%d dispatch=%d",
+            decodeMetal.steps, decodeMetal.commandBuffersCommitted,
+            decodeMetal.commandBufferErrors, decodeMetal.blockingWaitSeconds,
+            decodeMetal.blockingWaits, decodeMetal.computeDispatchesEncoded
+        ) + " gpu=\(gpu)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
     if let metal = model as? QwenMetalModel, let cache = metal.expertCache {
         let total = cache.hits + cache.misses
         FileHandle.standardError.write(Data(String(

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -89,6 +89,19 @@ public final class MetalEngine {
 
     // MARK: - Encoder-level API (persistent-buffer runtime path)
 
+    /// Set only while QwenMetalModel.step is active. Keeping the hook here
+    /// counts actual dispatch encodes across both fast and fallback paths.
+    var computeDispatchObserver: (() -> Void)?
+
+    func dispatchThreads(
+        _ enc: MTLComputeCommandEncoder,
+        threads: MTLSize,
+        threadsPerThreadgroup: MTLSize
+    ) {
+        enc.dispatchThreads(threads, threadsPerThreadgroup: threadsPerThreadgroup)
+        computeDispatchObserver?()
+    }
+
     /// Encode one GEMV over a shard-resident linear. `wExtra`/`sExtra`/`bExtra`
     /// advance into stacked tensors (expert slicing), in the same units as the
     /// descriptor offsets. Output rows land at `y[yOff...]`.
@@ -125,8 +138,8 @@ public final class MetalEngine {
                 enc.setBuffer(lin.bBuffer, offset: 0, index: 3)
                 enc.setBuffer(y, offset: 0, index: 4)
                 enc.setBytes(&p, length: MemoryLayout<GemvParams>.stride, index: 5)
-                enc.dispatchThreads(
-                    MTLSize(width: 32, height: outDim, depth: 1),
+                dispatchThreads(
+                    enc, threads: MTLSize(width: 32, height: outDim, depth: 1),
                     threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
                 )
                 return
@@ -146,8 +159,8 @@ public final class MetalEngine {
             enc.setBuffer(lin.bBuffer, offset: 0, index: 3)
             enc.setBuffer(y, offset: 0, index: 4)
             enc.setBytes(&p, length: MemoryLayout<GemvParams>.stride, index: 5)
-            enc.dispatchThreads(
-                MTLSize(width: outDim, height: 1, depth: 1),
+            dispatchThreads(
+                enc, threads: MTLSize(width: outDim, height: 1, depth: 1),
                 threadsPerThreadgroup: MTLSize(width: min(64, outDim), height: 1, depth: 1)
             )
         } else {
@@ -162,8 +175,8 @@ public final class MetalEngine {
             enc.setBuffer(lin.wBuffer, offset: 0, index: 1)
             enc.setBuffer(y, offset: 0, index: 2)
             enc.setBytes(&p, length: MemoryLayout<GemvPlainParams>.stride, index: 3)
-            enc.dispatchThreads(
-                MTLSize(width: outDim, height: 1, depth: 1),
+            dispatchThreads(
+                enc, threads: MTLSize(width: outDim, height: 1, depth: 1),
                 threadsPerThreadgroup: MTLSize(width: min(64, outDim), height: 1, depth: 1)
             )
         }
@@ -180,8 +193,8 @@ public final class MetalEngine {
         enc.setBuffer(buf, offset: 0, index: 1)
         enc.setBuffer(buf, offset: 0, index: 2)
         enc.setBytes(&p, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
-        enc.dispatchThreads(
-            MTLSize(width: count, height: 1, depth: 1),
+        dispatchThreads(
+            enc, threads: MTLSize(width: count, height: 1, depth: 1),
             threadsPerThreadgroup: MTLSize(width: min(64, count), height: 1, depth: 1)
         )
     }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -7,13 +7,45 @@ import Metal
 /// delta recurrence, attention softmax over cached KV, top-k routing), all of
 /// it microseconds per token. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
+    /// S3a whole-step aggregate baseline. These totals do not identify phases,
+    /// layer costs, overlap, or command-buffer timeline gaps.
     public struct StepMetrics: Equatable, Sendable {
         public let tokensProcessed: Int
         public let logitProjections: Int
+        public let commandBuffersCommitted: Int
+        public let blockingWaits: Int
+        /// Wall time spent inside the existing waitUntilCompleted calls.
+        public let blockingWaitSeconds: Double
+        /// Compute dispatch calls encoded, including partial work if step throws.
+        public let computeDispatchesEncoded: Int
+        public let stepWallSeconds: Double
+        /// Buffers whose status was not completed after waitUntilCompleted.
+        public let commandBufferErrors: Int
+        /// Sum of valid per-command-buffer GPU durations, not an elapsed span.
+        public let gpuExecutionSeconds: Double
+        public let gpuTimedCommandBuffers: Int
+        /// Completed buffers with unavailable or invalid GPU timestamps.
+        public let gpuUntimedCommandBuffers: Int
+        /// False when step exited by throwing after publishing partial counters.
+        public let completedWithoutThrow: Bool
 
         public var avoidedLogitProjections: Int {
             max(0, tokensProcessed - logitProjections)
         }
+    }
+
+    private final class StepCounters {
+        var tokensProcessed = 0
+        var logitProjections = 0
+        var commandBuffersCommitted = 0
+        var blockingWaits = 0
+        var blockingWaitSeconds = 0.0
+        var computeDispatchesEncoded = 0
+        var commandBufferErrors = 0
+        var gpuExecutionSeconds = 0.0
+        var gpuTimedCommandBuffers = 0
+        var gpuUntimedCommandBuffers = 0
+        var completedWithoutThrow = false
     }
 
     public let config: QwenConfig
@@ -81,9 +113,15 @@ public final class QwenMetalModel {
     let xBuf: MTLBuffer
     let yBuf: MTLBuffer
     let logitsBuf: MTLBuffer
+    /// Latest step snapshot. A throwing step publishes its partial counters.
     public private(set) var lastStepMetrics = StepMetrics(
-        tokensProcessed: 0, logitProjections: 0
+        tokensProcessed: 0, logitProjections: 0,
+        commandBuffersCommitted: 0, blockingWaits: 0, blockingWaitSeconds: 0,
+        computeDispatchesEncoded: 0, stepWallSeconds: 0, commandBufferErrors: 0,
+        gpuExecutionSeconds: 0, gpuTimedCommandBuffers: 0, gpuUntimedCommandBuffers: 0,
+        completedWithoutThrow: false
     )
+    private var activeStepCounters: StepCounters?
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -349,13 +387,36 @@ public final class QwenMetalModel {
         }
     }
 
+    private func commitAndWait(_ cb: MTLCommandBuffer) {
+        cb.commit()
+        activeStepCounters?.commandBuffersCommitted += 1
+        let waitStart = ProcessInfo.processInfo.systemUptime
+        cb.waitUntilCompleted()
+        activeStepCounters?.blockingWaits += 1
+        activeStepCounters?.blockingWaitSeconds += max(
+            0, ProcessInfo.processInfo.systemUptime - waitStart
+        )
+
+        guard cb.status == .completed else {
+            activeStepCounters?.commandBufferErrors += 1
+            return
+        }
+        let start = cb.gpuStartTime
+        let end = cb.gpuEndTime
+        guard start.isFinite, end.isFinite, start > 0, end > 0, end >= start else {
+            activeStepCounters?.gpuUntimedCommandBuffers += 1
+            return
+        }
+        activeStepCounters?.gpuExecutionSeconds += end - start
+        activeStepCounters?.gpuTimedCommandBuffers += 1
+    }
+
     private func runPhase(_ body: (MTLComputeCommandEncoder) throws -> Void) throws {
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         try body(enc)
         enc.endEncoding()
-        cb.commit()
-        cb.waitUntilCompleted()
+        commitAndWait(cb)
     }
 
     private func readY(_ offset: Int, _ count: Int) -> [Float] {
@@ -369,13 +430,26 @@ public final class QwenMetalModel {
 
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
-        lastStepMetrics = StepMetrics(tokensProcessed: 0, logitProjections: 0)
-        var tokensProcessed = 0
-        var logitProjections = 0
+        let counters = StepCounters()
+        let wallStart = ProcessInfo.processInfo.systemUptime
+        activeStepCounters = counters
+        engine.computeDispatchObserver = { counters.computeDispatchesEncoded += 1 }
         defer {
+            engine.computeDispatchObserver = nil
+            activeStepCounters = nil
             lastStepMetrics = StepMetrics(
-                tokensProcessed: tokensProcessed,
-                logitProjections: logitProjections
+                tokensProcessed: counters.tokensProcessed,
+                logitProjections: counters.logitProjections,
+                commandBuffersCommitted: counters.commandBuffersCommitted,
+                blockingWaits: counters.blockingWaits,
+                blockingWaitSeconds: counters.blockingWaitSeconds,
+                computeDispatchesEncoded: counters.computeDispatchesEncoded,
+                stepWallSeconds: max(0, ProcessInfo.processInfo.systemUptime - wallStart),
+                commandBufferErrors: counters.commandBufferErrors,
+                gpuExecutionSeconds: counters.gpuExecutionSeconds,
+                gpuTimedCommandBuffers: counters.gpuTimedCommandBuffers,
+                gpuUntimedCommandBuffers: counters.gpuUntimedCommandBuffers,
+                completedWithoutThrow: counters.completedWithoutThrow
             )
         }
 
@@ -385,25 +459,19 @@ public final class QwenMetalModel {
             // position's logits, so intermediate vocabulary projections are
             // unnecessary.
             let projectLogits = index == tokens.count - 1
-            logits = try stepOne(
-                t, state: state, projectLogits: projectLogits,
-                logitProjections: &logitProjections
-            )
+            logits = try stepOne(t, state: state, projectLogits: projectLogits)
             state.position += 1
-            tokensProcessed += 1
+            counters.tokensProcessed += 1
         }
+        counters.completedWithoutThrow = true
         return logits
     }
 
     private func stepOne(
-        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
-        logitProjections: inout Int
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool
     ) throws -> [Float] {
         if sBuf != nil {
-            return try stepOneFast(
-                token, state: state, projectLogits: projectLogits,
-                logitProjections: &logitProjections
-            )
+            return try stepOneFast(token, state: state, projectLogits: projectLogits)
         }
         let cfg = config
         let D = cfg.hiddenSize
@@ -435,7 +503,7 @@ public final class QwenMetalModel {
         try runPhase { enc in
             try engine.encodeGemv(enc, lmHead, x: xBuf, y: logitsBuf, yOff: 0)
         }
-        logitProjections += 1
+        activeStepCounters?.logitProjections += 1
         return Array(UnsafeBufferPointer(
             start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
             count: cfg.vocabSize
@@ -767,15 +835,15 @@ extension QwenMetalModel {
     }
 
     private func dispatchRows(_ enc: MTLComputeCommandEncoder, rows: Int) {
-        enc.dispatchThreads(
-            MTLSize(width: 32, height: rows, depth: 1),
+        engine.dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: rows, depth: 1),
             threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
         )
     }
 
     private func dispatchN(_ enc: MTLComputeCommandEncoder, _ n: Int) {
-        enc.dispatchThreads(
-            MTLSize(width: n, height: 1, depth: 1),
+        engine.dispatchThreads(
+            enc, threads: MTLSize(width: n, height: 1, depth: 1),
             threadsPerThreadgroup: MTLSize(width: min(64, n), height: 1, depth: 1)
         )
     }
@@ -932,8 +1000,7 @@ extension QwenMetalModel {
     }
 
     func stepOneFast(
-        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
-        logitProjections: inout Int
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool
     ) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
@@ -959,8 +1026,7 @@ extension QwenMetalModel {
                 if let p = pending { try encodePendingMoE(enc, p); pending = nil }
                 try encDeltaLayer(enc, delta: delta, fl: fl, moeGate: L.moe.gate)
                 enc.endEncoding()
-                cb.commit()
-                cb.waitUntilCompleted()
+                commitAndWait(cb)
             } else {
                 // Attention: projections, CPU core, then out-proj + router.
                 let cb1 = engine.queue.makeCommandBuffer()!
@@ -973,8 +1039,7 @@ extension QwenMetalModel {
                 try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
                 try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
                 e1.endEncoding()
-                cb1.commit()
-                cb1.waitUntilCompleted()
+                commitAndWait(cb1)
 
                 let attnOut = attnCoreCPU(layerIndex: li, state: state, attn: attn)
                 writeS(reg.att, attnOut)
@@ -994,8 +1059,7 @@ extension QwenMetalModel {
                 barrier(e2)
                 try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
                 e2.endEncoding()
-                cb2.commit()
-                cb2.waitUntilCompleted()
+                commitAndWait(cb2)
             }
 
             let (picks, weights) = routerPicks()
@@ -1021,11 +1085,10 @@ extension QwenMetalModel {
             dispatchRows(enc, rows: 1)
             barrier(enc)
             try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
-            logitProjections += 1
+            activeStepCounters?.logitProjections += 1
         }
         enc.endEncoding()
-        cb.commit()
-        cb.waitUntilCompleted()
+        commitAndWait(cb)
 
         guard projectLogits else { return [] }
         return Array(UnsafeBufferPointer(
@@ -1103,8 +1166,10 @@ extension QwenMetalModel {
         enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
         enc.setBuffer(fl.state!, offset: 0, index: 7)
         setBytesParams(enc, &delp, index: 8)
-        enc.dispatchThreads(MTLSize(width: 32, height: dv, depth: nv),
-                            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1))
+        engine.dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: dv, depth: nv),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
+        )
         barrier(enc)
 
         enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -7,6 +7,15 @@ import Metal
 /// delta recurrence, attention softmax over cached KV, top-k routing), all of
 /// it microseconds per token. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
+    public struct StepMetrics: Equatable, Sendable {
+        public let tokensProcessed: Int
+        public let logitProjections: Int
+
+        public var avoidedLogitProjections: Int {
+            max(0, tokensProcessed - logitProjections)
+        }
+    }
+
     public let config: QwenConfig
     let ckpt: Checkpoint
     let engine: MetalEngine
@@ -72,6 +81,9 @@ public final class QwenMetalModel {
     let xBuf: MTLBuffer
     let yBuf: MTLBuffer
     let logitsBuf: MTLBuffer
+    public private(set) var lastStepMetrics = StepMetrics(
+        tokensProcessed: 0, logitProjections: 0
+    )
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -357,16 +369,42 @@ public final class QwenMetalModel {
 
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+        lastStepMetrics = StepMetrics(tokensProcessed: 0, logitProjections: 0)
+        var tokensProcessed = 0
+        var logitProjections = 0
+        defer {
+            lastStepMetrics = StepMetrics(
+                tokensProcessed: tokensProcessed,
+                logitProjections: logitProjections
+            )
+        }
+
         var logits: [Float] = []
-        for t in tokens {
-            logits = try stepOne(t, state: state)
+        for (index, t) in tokens.enumerated() {
+            // S1a LM-head elision: a multi-token call consumes only the final
+            // position's logits, so intermediate vocabulary projections are
+            // unnecessary.
+            let projectLogits = index == tokens.count - 1
+            logits = try stepOne(
+                t, state: state, projectLogits: projectLogits,
+                logitProjections: &logitProjections
+            )
             state.position += 1
+            tokensProcessed += 1
         }
         return logits
     }
 
-    private func stepOne(_ token: Int, state: QwenCPUModel.DecodeState) throws -> [Float] {
-        if sBuf != nil { return try stepOneFast(token, state: state) }
+    private func stepOne(
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
+        logitProjections: inout Int
+    ) throws -> [Float] {
+        if sBuf != nil {
+            return try stepOneFast(
+                token, state: state, projectLogits: projectLogits,
+                logitProjections: &logitProjections
+            )
+        }
         let cfg = config
         let D = cfg.hiddenSize
         var h = try ckpt.moduleWeightSlice("model.embed_tokens", rowRange: token..<(token + 1))
@@ -391,11 +429,13 @@ public final class QwenMetalModel {
             for i in 0..<D { h[i] += m[i] }
         }
 
+        guard projectLogits else { return [] }
         QwenCPUModel.rmsNorm(&h, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
         loadX(h)
         try runPhase { enc in
             try engine.encodeGemv(enc, lmHead, x: xBuf, y: logitsBuf, yOff: 0)
         }
+        logitProjections += 1
         return Array(UnsafeBufferPointer(
             start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
             count: cfg.vocabSize
@@ -891,7 +931,10 @@ extension QwenMetalModel {
         return (picks, weights)
     }
 
-    func stepOneFast(_ token: Int, state: QwenCPUModel.DecodeState) throws -> [Float] {
+    func stepOneFast(
+        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool,
+        logitProjections: inout Int
+    ) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
         if boundStateID != ObjectIdentifier(state) || state.position == 0 {
@@ -963,23 +1006,28 @@ extension QwenMetalModel {
             pending = PendingMoE(bufs: bufs, weights: weights, stacksLayer: li, picks: picks)
         }
 
-        // Final: last layer's experts + final norm + lm head.
+        // Always apply the last layer's experts. Only the final token in a
+        // multi-token call also needs final norm + vocabulary projection.
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         if let p = pending { try encodePendingMoE(enc, p) }
-        enc.setComputePipelineState(try engine.pipeline("norm_copy"))
-        var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
-        enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
-        setBytesParams(enc, &np, index: 3)
-        dispatchRows(enc, rows: 1)
-        barrier(enc)
-        try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+        if projectLogits {
+            enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+            var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
+            enc.setBuffer(hBuf!, offset: 0, index: 0)
+            enc.setBuffer(sBuf!, offset: 0, index: 1)
+            enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
+            setBytesParams(enc, &np, index: 3)
+            dispatchRows(enc, rows: 1)
+            barrier(enc)
+            try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            logitProjections += 1
+        }
         enc.endEncoding()
         cb.commit()
         cb.waitUntilCompleted()
 
+        guard projectLogits else { return [] }
         return Array(UnsafeBufferPointer(
             start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
             count: cfg.vocabSize))

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -6,6 +6,35 @@ import Testing
 /// near-identical logits, on both quantized (int4) and plain (f32) tiny models
 /// and both DeltaNet layouts.
 @Suite struct MetalModelTests {
+    /// S3a whole-step aggregate regression baseline. These counts intentionally
+    /// do not assign work to phases or make timeline/performance claims.
+    struct FastPathBaseline {
+        let commandBuffersPerToken: Int
+        let intermediateDispatches: Int
+        let finalDispatches: Int
+
+        func commandBuffers(tokens: Int) -> Int {
+            commandBuffersPerToken * tokens
+        }
+
+        func dispatches(tokens: Int) -> Int {
+            guard tokens > 0 else { return 0 }
+            return intermediateDispatches * (tokens - 1) + finalDispatches
+        }
+    }
+
+    static let commandBuffersPerToken = 11
+    static let q4Baseline = FastPathBaseline(
+        commandBuffersPerToken: commandBuffersPerToken,
+        intermediateDispatches: 212,
+        finalDispatches: 214
+    )
+    static let q35Baseline = FastPathBaseline(
+        commandBuffersPerToken: commandBuffersPerToken,
+        intermediateDispatches: 218,
+        finalDispatches: 220
+    )
+
     static let fixturesDir = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
@@ -34,7 +63,35 @@ import Testing
         }
     }
 
-    static func compare(_ modelName: String) throws {
+    static func expectInstrumentation(
+        _ metrics: QwenMetalModel.StepMetrics, tokens: Int, label: String
+    ) {
+        #expect(metrics.completedWithoutThrow, "\(label): step threw")
+        #expect(metrics.tokensProcessed == tokens, "\(label): token count")
+        #expect(metrics.logitProjections == 1, "\(label): LM-head count")
+        #expect(metrics.commandBuffersCommitted > 0, "\(label): no command buffers")
+        #expect(metrics.blockingWaits == metrics.commandBuffersCommitted,
+                "\(label): commit/wait mismatch")
+        #expect(metrics.commandBufferErrors == 0, "\(label): command-buffer error")
+        #expect(metrics.computeDispatchesEncoded > 0, "\(label): no compute dispatches")
+        #expect(metrics.gpuTimedCommandBuffers + metrics.gpuUntimedCommandBuffers
+                + metrics.commandBufferErrors == metrics.commandBuffersCommitted,
+                "\(label): GPU timing samples")
+    }
+
+    static func expectFastPathBaseline(
+        _ metrics: QwenMetalModel.StepMetrics,
+        tokens: Int,
+        baseline: FastPathBaseline,
+        label: String
+    ) {
+        #expect(metrics.commandBuffersCommitted == baseline.commandBuffers(tokens: tokens),
+                "\(label): fast-path command-buffer baseline changed")
+        #expect(metrics.computeDispatchesEncoded == baseline.dispatches(tokens: tokens),
+                "\(label): fast-path dispatch baseline changed")
+    }
+
+    static func compare(_ modelName: String, baseline: FastPathBaseline) throws {
         let dir = fixturesDir.appendingPathComponent(modelName)
         let cpu = try QwenCPUModel(modelDir: dir)
         cpu.retainAllLayers = true
@@ -53,6 +110,11 @@ import Testing
             #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
             #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
+        let singleMetrics = sequentialGPU.lastStepMetrics
+        Self.expectInstrumentation(singleMetrics, tokens: 1, label: "\(modelName) one token")
+        Self.expectFastPathBaseline(
+            singleMetrics, tokens: 1, baseline: baseline, label: "\(modelName) one token"
+        )
 
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "\(modelName): GPU vs CPU logits maxAbsDiff \(maxDiff)")
@@ -61,11 +123,16 @@ import Testing
         // and state. Separate instances isolate GPU-resident recurrence.
         let elidingState = QwenCPUModel.DecodeState()
         let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let multiMetrics = elidingGPU.lastStepMetrics
         let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
         #expect(elisionDiff < 2e-3, "\(modelName): LM-head elision logits maxAbsDiff \(elisionDiff)")
         #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
         #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
         #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectInstrumentation(multiMetrics, tokens: tokens.count, label: "\(modelName) multi token")
+        Self.expectFastPathBaseline(
+            multiMetrics, tokens: tokens.count, baseline: baseline, label: "\(modelName) multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
 
         let continuation = 11
@@ -76,6 +143,13 @@ import Testing
         #expect(elidingGPU.lastStepMetrics.tokensProcessed == 1)
         #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
         #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == 0)
+        Self.expectInstrumentation(
+            elidingGPU.lastStepMetrics, tokens: 1, label: "\(modelName) continuation"
+        )
+        Self.expectFastPathBaseline(
+            elidingGPU.lastStepMetrics, tokens: 1,
+            baseline: baseline, label: "\(modelName) continuation"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
 
         func argmax(_ v: [Float]) -> Int {
@@ -87,7 +161,7 @@ import Testing
     }
 
     @Test func gpuMatchesCPUOnQuantizedTiny() throws {
-        try Self.compare("tiny-model-q4")
+        try Self.compare("tiny-model-q4", baseline: Self.q4Baseline)
     }
 
     /// Full streaming path: repack tiny model to .qpack, run the GPU model in
@@ -120,16 +194,27 @@ import Testing
             #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
             #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
+        let singleMetrics = sequentialGPU.lastStepMetrics
+        Self.expectInstrumentation(singleMetrics, tokens: 1, label: "qpack one token")
+        Self.expectFastPathBaseline(
+            singleMetrics, tokens: 1, baseline: Self.q4Baseline, label: "qpack one token"
+        )
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
 
         let elidingState = QwenCPUModel.DecodeState()
         let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let multiMetrics = elidingGPU.lastStepMetrics
         let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
         #expect(elisionDiff < 2e-3, "qpack LM-head elision maxAbsDiff \(elisionDiff)")
         #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
         #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
         #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectInstrumentation(multiMetrics, tokens: tokens.count, label: "qpack multi token")
+        Self.expectFastPathBaseline(
+            multiMetrics, tokens: tokens.count,
+            baseline: Self.q4Baseline, label: "qpack multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
 
         let continuation = 11
@@ -138,6 +223,13 @@ import Testing
         let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
         #expect(continuationDiff < 2e-3, "qpack continuation maxAbsDiff \(continuationDiff)")
         #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        Self.expectInstrumentation(
+            elidingGPU.lastStepMetrics, tokens: 1, label: "qpack continuation"
+        )
+        Self.expectFastPathBaseline(
+            elidingGPU.lastStepMetrics, tokens: 1,
+            baseline: Self.q4Baseline, label: "qpack continuation"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")
 
         for cache in [sequentialGPU.expertCache!, elidingGPU.expertCache!] {
@@ -146,6 +238,6 @@ import Testing
     }
 
     @Test func gpuMatchesCPUOnQwen35Tiny() throws {
-        try Self.compare("tiny-model-q35")
+        try Self.compare("tiny-model-q35", baseline: Self.q35Baseline)
     }
 }

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -12,32 +12,78 @@ import Testing
         .deletingLastPathComponent()
         .appendingPathComponent("fixtures")
 
+    static func maxAbsDiff(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count else { return .infinity }
+        var result: Float = 0
+        for i in lhs.indices { result = max(result, abs(lhs[i] - rhs[i])) }
+        return result
+    }
+
+    static func expectMatchingKV(
+        _ lhs: QwenCPUModel.DecodeState, _ rhs: QwenCPUModel.DecodeState,
+        label: String
+    ) {
+        #expect(lhs.position == rhs.position, "\(label): positions diverged")
+        #expect(Set(lhs.kv.keys) == Set(rhs.kv.keys), "\(label): KV layers diverged")
+        for layer in lhs.kv.keys {
+            guard let l = lhs.kv[layer], let r = rhs.kv[layer] else { continue }
+            #expect(l.k.count == r.k.count, "\(label): layer \(layer) K size diverged")
+            #expect(l.v.count == r.v.count, "\(label): layer \(layer) V size diverged")
+            #expect(Self.maxAbsDiff(l.k, r.k) < 1e-6, "\(label): layer \(layer) K diverged")
+            #expect(Self.maxAbsDiff(l.v, r.v) < 1e-6, "\(label): layer \(layer) V diverged")
+        }
+    }
+
     static func compare(_ modelName: String) throws {
         let dir = fixturesDir.appendingPathComponent(modelName)
         let cpu = try QwenCPUModel(modelDir: dir)
         cpu.retainAllLayers = true
-        let gpu = try QwenMetalModel(modelDir: dir)
+        let sequentialGPU = try QwenMetalModel(modelDir: dir)
+        let elidingGPU = try QwenMetalModel(modelDir: dir)
         let tokens = [1, 5, 9, 42, 7]
 
         let cpuState = QwenCPUModel.DecodeState()
-        let gpuState = QwenCPUModel.DecodeState()
+        let sequentialState = QwenCPUModel.DecodeState()
         var cpuLogits: [Float] = []
-        var gpuLogits: [Float] = []
+        var sequentialLogits: [Float] = []
         for t in tokens {
             cpuLogits = try cpu.step([t], state: cpuState)
-            gpuLogits = try gpu.step([t], state: gpuState)
+            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
+            #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
+            #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
 
-        var maxDiff: Float = 0
-        for i in 0..<cpuLogits.count { maxDiff = max(maxDiff, abs(cpuLogits[i] - gpuLogits[i])) }
+        let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "\(modelName): GPU vs CPU logits maxAbsDiff \(maxDiff)")
+
+        // S1a intermediate LM-head elision must retain token-at-a-time output
+        // and state. Separate instances isolate GPU-resident recurrence.
+        let elidingState = QwenCPUModel.DecodeState()
+        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
+        #expect(elisionDiff < 2e-3, "\(modelName): LM-head elision logits maxAbsDiff \(elisionDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
+
+        let continuation = 11
+        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
+        #expect(continuationDiff < 2e-3, "\(modelName): continuation maxAbsDiff \(continuationDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == 1)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == 0)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
 
         func argmax(_ v: [Float]) -> Int {
             var b = 0
             for i in 1..<v.count where v[i] > v[b] { b = i }
             return b
         }
-        #expect(argmax(cpuLogits) == argmax(gpuLogits), "\(modelName): greedy diverged")
+        #expect(argmax(cpuLogits) == argmax(sequentialLogits), "\(modelName): greedy diverged")
     }
 
     @Test func gpuMatchesCPUOnQuantizedTiny() throws {
@@ -57,23 +103,46 @@ import Testing
 
         let cpu = try QwenCPUModel(modelDir: src)
         cpu.retainAllLayers = true
-        let gpu = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
-        #expect(gpu.expertCache != nil, "qpack mode not engaged")
+        let sequentialGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        let elidingGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        #expect(sequentialGPU.expertCache != nil, "qpack mode not engaged")
+        #expect(elidingGPU.expertCache != nil, "qpack mode not engaged")
 
         let tokens = [1, 5, 9, 42, 7, 99]
         let cpuState = QwenCPUModel.DecodeState()
-        let gpuState = QwenCPUModel.DecodeState()
+        let sequentialState = QwenCPUModel.DecodeState()
         var cpuLogits: [Float] = []
-        var gpuLogits: [Float] = []
+        var sequentialLogits: [Float] = []
         for t in tokens {
             cpuLogits = try cpu.step([t], state: cpuState)
-            gpuLogits = try gpu.step([t], state: gpuState)
+            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
+            #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
+            #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
         }
-        var maxDiff: Float = 0
-        for i in 0..<cpuLogits.count { maxDiff = max(maxDiff, abs(cpuLogits[i] - gpuLogits[i])) }
+        let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
-        let cache = gpu.expertCache!
-        #expect(cache.hits + cache.misses > 0)
+
+        let elidingState = QwenCPUModel.DecodeState()
+        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
+        #expect(elisionDiff < 2e-3, "qpack LM-head elision maxAbsDiff \(elisionDiff)")
+        #expect(elidingGPU.lastStepMetrics.tokensProcessed == tokens.count)
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        #expect(elidingGPU.lastStepMetrics.avoidedLogitProjections == tokens.count - 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
+
+        let continuation = 11
+        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
+        #expect(continuationDiff < 2e-3, "qpack continuation maxAbsDiff \(continuationDiff)")
+        #expect(elidingGPU.lastStepMetrics.logitProjections == 1)
+        Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")
+
+        for cache in [sequentialGPU.expertCache!, elidingGPU.expertCache!] {
+            #expect(cache.hits + cache.misses > 0)
+        }
     }
 
     @Test func gpuMatchesCPUOnQwen35Tiny() throws {


### PR DESCRIPTION
## What this adds

Aggregate Metal execution instrumentation on `StepMetrics`: command buffers committed, blocking waits and wait wall time, compute dispatches encoded, GPU execution seconds from `MTLCommandBuffer` GPU timestamps (with timed/untimed/error counts), and step wall time — published throw-safely on partial failure. The CLI aggregates decode-loop totals to stderr.

These are whole-step aggregates, deliberately not a per-phase timeline; the docstrings scope them accordingly. The tests pin regression baselines for the current schedule: 11 command buffers per token, 212/214 dispatches (tiny Q4 intermediate/final) and 218/220 (tiny Qwen3.5), equal commit/wait counts, and zero command-buffer errors.

## Why

There is currently no visibility into where a decode step spends time. The wait-vs-GPU-time split is the measurement needed to attack the roadmap's "fewer GPU dispatches per token" item, and speaks directly to #18 — whether identical throughput at 40% vs 74% cache hit rate means the bottleneck is dispatch/wait rather than compute or storage.

## Validation

On an Apple M4 Max (macOS 26.6.2), `swift test`: full suite passes (50 tests / 13 suites), including the baseline assertions above on a real Metal device.

## Dependency

Stacked on #19; this PR's diff includes that commit until it merges.
