### PR TITLE
Add phase-labeled Metal step timeline with probed per-phase GPU split

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -20,6 +20,9 @@ private struct MetalStepAggregate {
     var gpuUntimedCommandBuffers = 0
     var phaseDispatches: [QwenMetalModel.StepPhase: Int] = [:]
     var phaseEncodeSeconds: [QwenMetalModel.StepPhase: Double] = [:]
+    /// Per-phase GPU seconds; non-nil only when the device measured them
+    /// (dispatch-boundary counters — see QwenMetalModel.PhaseGpuSplitSupport).
+    var phaseGpuSeconds: [QwenMetalModel.StepPhase: Double]?
     var bufferCounts: [String: Int] = [:]
     var bufferWaitSeconds: [String: Double] = [:]
     var bufferGpuSeconds: [String: Double] = [:]
@@ -41,6 +44,11 @@ private struct MetalStepAggregate {
         for (phase, s) in metrics.phaseEncodeSeconds {
             phaseEncodeSeconds[phase, default: 0] += s
         }
+        if let measured = metrics.phaseGpuSeconds {
+            var merged = phaseGpuSeconds ?? [:]
+            for (phase, s) in measured { merged[phase, default: 0] += s }
+            phaseGpuSeconds = merged
+        }
         for sample in metrics.commandBufferTimeline {
             let label = sample.phases.map(\.rawValue).joined(separator: "+")
             bufferCounts[label, default: 0] += 1
@@ -61,9 +69,14 @@ private func phaseSummaryLines(_ prefix: String, _ agg: MetalStepAggregate) -> [
         agg.phaseDispatches[$0, default: 0] > 0 || agg.phaseEncodeSeconds[$0, default: 0] > 0
     }
     if !phases.isEmpty {
-        let cells = phases.map {
-            "\($0.rawValue) enc=" + String(format: "%.3fs", agg.phaseEncodeSeconds[$0, default: 0])
-                + " disp=\(agg.phaseDispatches[$0, default: 0])"
+        let cells = phases.map { phase -> String in
+            var cell = "\(phase.rawValue) enc="
+                + String(format: "%.3fs", agg.phaseEncodeSeconds[phase, default: 0])
+                + " disp=\(agg.phaseDispatches[phase, default: 0])"
+            if let gpu = agg.phaseGpuSeconds {
+                cell += String(format: " gpu=%.3fs", gpu[phase, default: 0])
+            }
+            return cell
         }
         lines.append("\(prefix) S3b encode phases: " + cells.joined(separator: " | "))
     }
@@ -183,7 +196,19 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         // Metal runtime: weights stay quantized; experts stream via the
         // bounded cache (--cache-gb) when the model is a .qpack container.
         let cacheGB = Double(flagValue(CommandLine.arguments, "--cache-gb") ?? "8") ?? 8
-        model = try QwenMetalModel(modelDir: url, cacheBudgetGB: cacheGB)
+        let metal = try QwenMetalModel(modelDir: url, cacheBudgetGB: cacheGB)
+        // S3b follow-up: what the device's counters can actually sample, and
+        // whether the per-phase GPU split is measured or honestly absent.
+        let split: String
+        switch metal.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            split = "per-phase GPU split: measured (dispatch-boundary counters)"
+        case .unsupported(let reason):
+            split = "per-phase GPU split: unsupported (\(reason))"
+        }
+        FileHandle.standardError.write(Data(
+            "S3b counters: \(metal.counterSamplingSupport.summary)\n\(split)\n".utf8))
+        model = metal
     } else {
         let cpu = try QwenCPUModel(modelDir: url)
         // --lazy: ~3 GB peak instead of ~10-14 GB, at the cost of re-dequantizing

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -5,8 +5,9 @@ import Tokenizers
 func gib(_ bytes: Int) -> String { String(format: "%.2f GiB", Double(bytes) / Double(1 << 30)) }
 func mib(_ bytes: Int) -> String { String(format: "%.1f MiB", Double(bytes) / Double(1 << 20)) }
 
-/// S3a decode totals only. They establish an aggregate baseline, not phase or
-/// command-buffer timeline diagnosis.
+/// S3a whole-run totals plus S3b phase/timeline folds. Encode-side cost is
+/// exact per phase; wait/GPU cost is only available per command-buffer label
+/// because one buffer can span several phases.
 private struct MetalStepAggregate {
     var steps = 0
     var commandBuffersCommitted = 0
@@ -17,6 +18,12 @@ private struct MetalStepAggregate {
     var gpuExecutionSeconds = 0.0
     var gpuTimedCommandBuffers = 0
     var gpuUntimedCommandBuffers = 0
+    var phaseDispatches: [QwenMetalModel.StepPhase: Int] = [:]
+    var phaseEncodeSeconds: [QwenMetalModel.StepPhase: Double] = [:]
+    var bufferCounts: [String: Int] = [:]
+    var bufferWaitSeconds: [String: Double] = [:]
+    var bufferGpuSeconds: [String: Double] = [:]
+    var bufferGpuTimed: [String: Int] = [:]
 
     mutating func add(_ metrics: QwenMetalModel.StepMetrics) {
         steps += 1
@@ -28,7 +35,51 @@ private struct MetalStepAggregate {
         gpuExecutionSeconds += metrics.gpuExecutionSeconds
         gpuTimedCommandBuffers += metrics.gpuTimedCommandBuffers
         gpuUntimedCommandBuffers += metrics.gpuUntimedCommandBuffers
+        for (phase, n) in metrics.phaseDispatchesEncoded {
+            phaseDispatches[phase, default: 0] += n
+        }
+        for (phase, s) in metrics.phaseEncodeSeconds {
+            phaseEncodeSeconds[phase, default: 0] += s
+        }
+        for sample in metrics.commandBufferTimeline {
+            let label = sample.phases.map(\.rawValue).joined(separator: "+")
+            bufferCounts[label, default: 0] += 1
+            bufferWaitSeconds[label, default: 0] += sample.waitSeconds
+            if let gpu = sample.gpuSeconds {
+                bufferGpuSeconds[label, default: 0] += gpu
+                bufferGpuTimed[label, default: 0] += 1
+            }
+        }
     }
+}
+
+/// S3b stderr lines: exact encode-side phase split, then wait/GPU folded by
+/// command-buffer label (the honest granularity for those two costs).
+private func phaseSummaryLines(_ prefix: String, _ agg: MetalStepAggregate) -> [String] {
+    var lines: [String] = []
+    let phases = QwenMetalModel.StepPhase.allCases.filter {
+        agg.phaseDispatches[$0, default: 0] > 0 || agg.phaseEncodeSeconds[$0, default: 0] > 0
+    }
+    if !phases.isEmpty {
+        let cells = phases.map {
+            "\($0.rawValue) enc=" + String(format: "%.3fs", agg.phaseEncodeSeconds[$0, default: 0])
+                + " disp=\(agg.phaseDispatches[$0, default: 0])"
+        }
+        lines.append("\(prefix) S3b encode phases: " + cells.joined(separator: " | "))
+    }
+    if !agg.bufferCounts.isEmpty {
+        let cells = agg.bufferCounts.keys.sorted().map { label -> String in
+            let timed = agg.bufferGpuTimed[label, default: 0]
+            let gpu = timed > 0
+                ? String(format: "%.3fs/%d timed", agg.bufferGpuSeconds[label, default: 0], timed)
+                : "n/a"
+            return "\(label) cb=\(agg.bufferCounts[label, default: 0])"
+                + String(format: " wait=%.3fs", agg.bufferWaitSeconds[label, default: 0])
+                + " gpu=\(gpu)"
+        }
+        lines.append("\(prefix) S3b buffers: " + cells.joined(separator: " | "))
+    }
+    return lines
 }
 
 private func gpuTimingSummary(
@@ -177,6 +228,11 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             m.logitProjections, m.avoidedLogitProjections
         ) + " gpu=\(gpu)\n"
         FileHandle.standardError.write(Data(line.utf8))
+        var prefillAgg = MetalStepAggregate()
+        prefillAgg.add(m)
+        for extra in phaseSummaryLines("prefill", prefillAgg) {
+            FileHandle.standardError.write(Data((extra + "\n").utf8))
+        }
     } else {
         FileHandle.standardError.write(Data(String(
             format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs
@@ -233,6 +289,9 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             decodeMetal.blockingWaits, decodeMetal.computeDispatchesEncoded
         ) + " gpu=\(gpu)\n"
         FileHandle.standardError.write(Data(line.utf8))
+        for extra in phaseSummaryLines("decode", decodeMetal) {
+            FileHandle.standardError.write(Data((extra + "\n").utf8))
+        }
     }
     if let metal = model as? QwenMetalModel, let cache = metal.expertCache {
         let total = cache.hits + cache.misses

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -44,6 +44,125 @@ public final class MetalEngine {
         return p
     }
 
+    // MARK: - Counter sampling probe (S3b follow-up)
+
+    /// What this device's Metal counter machinery can actually sample —
+    /// probed at runtime, never assumed. Capabilities come straight from
+    /// `supportsCounterSampling`; `stageBoundarySampleValid` is the result of
+    /// really running a sample pass, so "yes" means counters were exercised
+    /// on this device, not just advertised.
+    public struct CounterSamplingSupport: Equatable, Sendable {
+        public let deviceName: String
+        /// The MTLCommonCounterSet.timestamp counter set exists on the device.
+        public let hasTimestampCounterSet: Bool
+        public let atStageBoundary: Bool
+        public let atDispatchBoundary: Bool
+        public let atDrawBoundary: Bool
+        public let atBlitBoundary: Bool
+        public let atTileDispatchBoundary: Bool
+        /// Functional check: one trivial compute pass ran with stage-boundary
+        /// (encoder start/end) timestamp samples attached and both resolved
+        /// to a monotone, non-error pair. nil when stage-boundary sampling or
+        /// the timestamp set is unavailable, so the pass was never attempted.
+        public let stageBoundarySampleValid: Bool?
+
+        public var summary: String {
+            func yn(_ b: Bool) -> String { b ? "yes" : "no" }
+            let stageProbe: String
+            switch stageBoundarySampleValid {
+            case .some(true): stageProbe = "(sample resolved)"
+            case .some(false): stageProbe = "(sample did NOT resolve)"
+            case .none: stageProbe = "(not probed)"
+            }
+            return "device=\(deviceName) timestampSet=\(yn(hasTimestampCounterSet))"
+                + " stage=\(yn(atStageBoundary))\(stageProbe)"
+                + " dispatch=\(yn(atDispatchBoundary))"
+                + " draw=\(yn(atDrawBoundary))"
+                + " blit=\(yn(atBlitBoundary))"
+                + " tileDispatch=\(yn(atTileDispatchBoundary))"
+        }
+    }
+
+    private var counterSamplingCache: CounterSamplingSupport?
+
+    /// The device's timestamp counter set, if it exposes one.
+    var timestampCounterSet: MTLCounterSet? {
+        device.counterSets?.first {
+            $0.name.caseInsensitiveCompare(MTLCommonCounterSet.timestamp.rawValue) == .orderedSame
+        }
+    }
+
+    /// Probes counter-sampling capabilities once and caches the verdict.
+    /// Runs a real stage-boundary sample pass when the device advertises one,
+    /// so the report is evidence rather than a table of claims.
+    public func probeCounterSampling() -> CounterSamplingSupport {
+        if let cached = counterSamplingCache { return cached }
+        let tsSet = timestampCounterSet
+        let stage = device.supportsCounterSampling(.atStageBoundary)
+        var stageValid: Bool?
+        if stage, let tsSet {
+            stageValid = runStageBoundaryTimestampProbe(counterSet: tsSet)
+        }
+        let support = CounterSamplingSupport(
+            deviceName: device.name,
+            hasTimestampCounterSet: tsSet != nil,
+            atStageBoundary: stage,
+            atDispatchBoundary: device.supportsCounterSampling(.atDispatchBoundary),
+            atDrawBoundary: device.supportsCounterSampling(.atDrawBoundary),
+            atBlitBoundary: device.supportsCounterSampling(.atBlitBoundary),
+            atTileDispatchBoundary: device.supportsCounterSampling(.atTileDispatchBoundary),
+            stageBoundarySampleValid: stageValid
+        )
+        counterSamplingCache = support
+        return support
+    }
+
+    /// One tiny silu_mul dispatch in its own encoder with encoder start/end
+    /// timestamp samples attached — the boundary Apple GPUs support. True
+    /// when both samples resolve to a monotone, non-error pair. Deliberately
+    /// bypasses `dispatchThreads` so the probe never pollutes step counters.
+    private func runStageBoundaryTimestampProbe(counterSet: MTLCounterSet) -> Bool {
+        let desc = MTLCounterSampleBufferDescriptor()
+        desc.counterSet = counterSet
+        desc.storageMode = .shared
+        desc.sampleCount = 2
+        guard let sampleBuffer = try? device.makeCounterSampleBuffer(descriptor: desc),
+              let scratch = device.makeBuffer(length: 64, options: .storageModeShared),
+              let pipe = try? pipeline("silu_mul"),
+              let cb = queue.makeCommandBuffer()
+        else { return false }
+        let pass = MTLComputePassDescriptor()
+        guard let attachment = pass.sampleBufferAttachments[0] else { return false }
+        attachment.sampleBuffer = sampleBuffer
+        attachment.startOfEncoderSampleIndex = 0
+        attachment.endOfEncoderSampleIndex = 1
+        guard let enc = cb.makeComputeCommandEncoder(descriptor: pass) else { return false }
+        enc.setComputePipelineState(pipe)
+        var p = SIMD4<UInt32>(4, 0, 4, 8)
+        enc.setBuffer(scratch, offset: 0, index: 0)
+        enc.setBuffer(scratch, offset: 0, index: 1)
+        enc.setBuffer(scratch, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
+        enc.dispatchThreads(
+            MTLSize(width: 4, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 4, height: 1, depth: 1)
+        )
+        enc.endEncoding()
+        cb.commit()
+        cb.waitUntilCompleted()
+        guard cb.status == .completed,
+              let data = try? sampleBuffer.resolveCounterRange(0..<2),
+              data.count >= 2 * MemoryLayout<MTLCounterResultTimestamp>.stride
+        else { return false }
+        let stamps = data.withUnsafeBytes { raw -> (UInt64, UInt64) in
+            let t = raw.bindMemory(to: MTLCounterResultTimestamp.self)
+            return (t[0].timestamp, t[1].timestamp)
+        }
+        return stamps.0 != 0 && stamps.1 != 0
+            && stamps.0 != .max && stamps.1 != .max
+            && stamps.1 >= stamps.0
+    }
+
     struct GemvParams {
         var wOff: UInt64 = 0   // byte offsets, 64-bit (shards exceed 4 GB)
         var sOff: UInt64 = 0

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Metal
+import os.signpost
 
 /// GPU runtime: every linear (dense projections, router, experts, lm_head)
 /// runs as a quantized GEMV directly on mmapped checkpoint bytes — weights are
@@ -25,11 +26,29 @@ public final class QwenMetalModel {
         case other
     }
 
+    /// How real a per-phase GPU/wait split can be on this device without
+    /// changing the schedule. The fast path deliberately encodes several
+    /// phases into one encoder per command buffer, so splitting a shared
+    /// buffer's GPU time by phase requires timestamp samples *inside* the
+    /// encoder — dispatch-boundary counter sampling. Devices that sample only
+    /// at encoder/stage boundaries (Apple GPUs) cannot provide that split for
+    /// this schedule, and the API says so instead of inventing numbers.
+    public enum PhaseGpuSplitSupport: Equatable, Sendable {
+        /// The device samples GPU timestamps at compute dispatch boundaries;
+        /// per-phase GPU time is measured inside shared buffers.
+        case dispatchBoundaryCounters
+        /// No in-encoder sampling on this device; per-phase GPU time is
+        /// absent (nil), never zeros. The reason names the device and the
+        /// missing capability.
+        case unsupported(reason: String)
+    }
+
     /// One committed command buffer, in commit order. Encode time and
     /// dispatch counts are attributed to phases exactly (encoding is CPU work
-    /// under our control); blocking-wait and GPU time exist only at
-    /// command-buffer granularity, so a buffer spanning several phases cannot
-    /// split them per phase.
+    /// under our control); blocking-wait time exists only at command-buffer
+    /// granularity, and GPU time splits per phase only when the device
+    /// supports dispatch-boundary counter sampling (see PhaseGpuSplitSupport)
+    /// — otherwise a buffer spanning several phases cannot split it.
     public struct CommandBufferSample: Equatable, Sendable {
         /// Compute dispatches encoded into this buffer, per phase.
         public let phaseDispatches: [StepPhase: Int]
@@ -42,6 +61,11 @@ public final class QwenMetalModel {
         /// GPU start-to-end duration; nil when the buffer failed or reported
         /// invalid timestamps. Not proof of exclusive GPU occupancy.
         public let gpuSeconds: Double?
+        /// GPU seconds per phase from dispatch-boundary counter samples
+        /// resolved for this buffer. nil when the device cannot sample inside
+        /// an encoder, or when any of this buffer's samples failed to resolve
+        /// — a partial split would silently under-report a phase.
+        public let phaseGpuSeconds: [StepPhase: Double]?
         /// Whether status was .completed after the blocking wait.
         public let completed: Bool
 
@@ -90,10 +114,23 @@ public final class QwenMetalModel {
         /// CPU wall time inside per-phase encode scopes; same partial-work
         /// semantics as phaseDispatchesEncoded.
         public let phaseEncodeSeconds: [StepPhase: Double]
+        /// GPU seconds per phase, summed over the buffers whose
+        /// dispatch-boundary counter samples resolved. nil whenever the
+        /// device cannot sample inside an encoder (phaseGpuSplitSupport is
+        /// .unsupported) — absent, never zeros that look like measurements.
+        public let phaseGpuSeconds: [StepPhase: Double]?
 
         public var avoidedLogitProjections: Int {
             max(0, tokensProcessed - logitProjections)
         }
+    }
+
+    /// Count of os_signpost intervals one step emitted, per interval name.
+    /// Rebuilt per step; exists so tests can pin emission to the timeline.
+    struct SignpostTally: Equatable {
+        var stepIntervals = 0
+        var phaseIntervals = 0
+        var commandBufferIntervals = 0
     }
 
     private final class StepCounters {
@@ -111,11 +148,23 @@ public final class QwenMetalModel {
         var timeline: [CommandBufferSample] = []
         var phaseDispatches: [StepPhase: Int] = [:]
         var phaseEncodeSeconds: [StepPhase: Double] = [:]
+        /// Step totals of resolved per-phase GPU seconds; nil unless the
+        /// device supports dispatch-boundary sampling.
+        var phaseGpuSeconds: [StepPhase: Double]?
         var currentPhase: StepPhase?
         var bufferOpen = false
         var bufferEncodeStart = 0.0
         var bufferPhaseDispatches: [StepPhase: Int] = [:]
         var bufferPhaseEncodeSeconds: [StepPhase: Double] = [:]
+        /// Encoder of the open buffer, for in-encoder counter samples only.
+        var currentEncoder: MTLComputeCommandEncoder?
+        var bufferSampleBuffer: MTLCounterSampleBuffer?
+        var bufferSampleIndex = 0
+        var bufferPhaseSampleRanges: [(phase: StepPhase, start: Int, end: Int)] = []
+        var bufferSamplingBroken = false
+        /// CPU/GPU correlation captured when the open buffer began encoding.
+        var bufferCorrelationStart: (cpu: MTLTimestamp, gpu: MTLTimestamp)?
+        var signpostTally = SignpostTally()
     }
 
     public let config: QwenConfig
@@ -190,9 +239,25 @@ public final class QwenMetalModel {
         computeDispatchesEncoded: 0, stepWallSeconds: 0, commandBufferErrors: 0,
         gpuExecutionSeconds: 0, gpuTimedCommandBuffers: 0, gpuUntimedCommandBuffers: 0,
         completedWithoutThrow: false,
-        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:]
+        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:],
+        phaseGpuSeconds: nil
     )
     private var activeStepCounters: StepCounters?
+    /// Whether a per-phase GPU split is real on this device, decided by the
+    /// runtime counter probe at init — never assumed from the OS or GPU name.
+    public let phaseGpuSplitSupport: PhaseGpuSplitSupport
+    /// The raw probe behind phaseGpuSplitSupport, for reporting.
+    public var counterSamplingSupport: MetalEngine.CounterSamplingSupport {
+        engine.probeCounterSampling()
+    }
+    /// Signpost intervals emitted by the latest step; mirrors the timeline.
+    internal private(set) var lastSignpostTally = SignpostTally()
+    /// os_signpost log for step/phase/commandBuffer intervals. Instruments'
+    /// os_signpost instrument groups them under subsystem "Swiftlet".
+    private static let signpostLog = OSLog(subsystem: "Swiftlet", category: "MetalStep")
+    /// Sample slots per command buffer: the fast path encodes at most three
+    /// phase scopes per buffer (2 samples each); headroom is harmless.
+    private static let maxPhaseSamplesPerBuffer = 16
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -227,6 +292,7 @@ public final class QwenMetalModel {
         ckpt = try Checkpoint(dir: modelDir)
         engine = try MetalEngine()
         store = MetalShardStore(device: engine.device)
+        phaseGpuSplitSupport = Self.probePhaseGpuSplit(engine: engine)
 
         let cfg = config
         let ckpt = self.ckpt
@@ -458,8 +524,30 @@ public final class QwenMetalModel {
         }
     }
 
+    /// Decides whether a per-phase GPU split is measurable here. The frozen
+    /// schedule shares one encoder across phases, so the split needs
+    /// dispatch-boundary sampling; anything less gets an explicit reason.
+    private static func probePhaseGpuSplit(engine: MetalEngine) -> PhaseGpuSplitSupport {
+        let probe = engine.probeCounterSampling()
+        if probe.atDispatchBoundary && probe.hasTimestampCounterSet {
+            return .dispatchBoundaryCounters
+        }
+        if !probe.hasTimestampCounterSet {
+            return .unsupported(reason:
+                "device \(probe.deviceName) exposes no timestamp counter set")
+        }
+        return .unsupported(reason:
+            "device \(probe.deviceName) samples timestamps only at encoder boundaries"
+            + " (stage=\(probe.atStageBoundary)), and the fast-path schedule encodes"
+            + " several phases into one encoder per command buffer; an in-buffer"
+            + " per-phase GPU split cannot be measured without changing the schedule")
+    }
+
     /// Starts a step command buffer and opens its S3b timeline accumulator so
-    /// encode time and dispatches attribute to this buffer until commit.
+    /// encode time and dispatches attribute to this buffer until commit. When
+    /// the device supports dispatch-boundary sampling, a fresh counter sample
+    /// buffer and a CPU/GPU correlation point are attached for the per-phase
+    /// GPU split; on other devices this adds nothing to the hot path.
     private func beginStepCommandBuffer() -> (MTLCommandBuffer, MTLComputeCommandEncoder) {
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
@@ -468,17 +556,53 @@ public final class QwenMetalModel {
             counters.bufferEncodeStart = ProcessInfo.processInfo.systemUptime
             counters.bufferPhaseDispatches = [:]
             counters.bufferPhaseEncodeSeconds = [:]
+            counters.currentEncoder = enc
+            counters.bufferSampleBuffer = nil
+            counters.bufferSampleIndex = 0
+            counters.bufferPhaseSampleRanges = []
+            counters.bufferSamplingBroken = false
+            counters.bufferCorrelationStart = nil
+            if case .dispatchBoundaryCounters = phaseGpuSplitSupport,
+               let tsSet = engine.timestampCounterSet {
+                let desc = MTLCounterSampleBufferDescriptor()
+                desc.counterSet = tsSet
+                desc.storageMode = .shared
+                desc.sampleCount = Self.maxPhaseSamplesPerBuffer
+                counters.bufferSampleBuffer =
+                    try? engine.device.makeCounterSampleBuffer(descriptor: desc)
+                counters.bufferSamplingBroken = counters.bufferSampleBuffer == nil
+                counters.bufferCorrelationStart = engine.device.sampleTimestamps()
+            }
         }
         return (cb, enc)
     }
 
     /// Attributes encode-side work (CPU encode wall time and dispatch counts)
-    /// to a phase label. Scopes never nest in the current schedule; if one
+    /// to a phase label, emits one os_signpost interval per scope, and — on
+    /// devices with dispatch-boundary sampling — brackets the scope with GPU
+    /// timestamp samples. Scopes never nest in the current schedule; if one
     /// ever did, its elapsed time would double-count, so keep call sites flat.
     private func phase<T>(_ p: StepPhase, _ body: () throws -> T) rethrows -> T {
         guard let counters = activeStepCounters else { return try body() }
         let previous = counters.currentPhase
         counters.currentPhase = p
+        let signpostID = OSSignpostID(log: Self.signpostLog)
+        os_signpost(.begin, log: Self.signpostLog, name: "phase",
+                    signpostID: signpostID, "%{public}@", p.rawValue)
+        counters.signpostTally.phaseIntervals += 1
+        var sampleStart = -1
+        if let sb = counters.bufferSampleBuffer, counters.bufferOpen,
+           let enc = counters.currentEncoder, !counters.bufferSamplingBroken {
+            if counters.bufferSampleIndex + 1 < Self.maxPhaseSamplesPerBuffer {
+                sampleStart = counters.bufferSampleIndex
+                counters.bufferSampleIndex += 2
+                enc.sampleCounters(sampleBuffer: sb, sampleIndex: sampleStart, barrier: true)
+            } else {
+                // Out of slots: drop the whole buffer's split rather than
+                // publish a partial one.
+                counters.bufferSamplingBroken = true
+            }
+        }
         let start = ProcessInfo.processInfo.systemUptime
         defer {
             let elapsed = max(0, ProcessInfo.processInfo.systemUptime - start)
@@ -486,6 +610,14 @@ public final class QwenMetalModel {
             if counters.bufferOpen {
                 counters.bufferPhaseEncodeSeconds[p, default: 0] += elapsed
             }
+            if sampleStart >= 0, let sb = counters.bufferSampleBuffer,
+               let enc = counters.currentEncoder, !counters.bufferSamplingBroken {
+                enc.sampleCounters(sampleBuffer: sb, sampleIndex: sampleStart + 1, barrier: true)
+                counters.bufferPhaseSampleRanges.append(
+                    (phase: p, start: sampleStart, end: sampleStart + 1))
+            }
+            os_signpost(.end, log: Self.signpostLog, name: "phase",
+                        signpostID: signpostID, "%{public}@", p.rawValue)
             counters.currentPhase = previous
         }
         return try body()
@@ -498,6 +630,11 @@ public final class QwenMetalModel {
             encodeSeconds = max(
                 0, ProcessInfo.processInfo.systemUptime - counters.bufferEncodeStart
             )
+        }
+        let signpostID = OSSignpostID(log: Self.signpostLog)
+        if counters != nil {
+            os_signpost(.begin, log: Self.signpostLog, name: "commandBuffer", signpostID: signpostID)
+            counters?.signpostTally.commandBufferIntervals += 1
         }
         cb.commit()
         counters?.commandBuffersCommitted += 1
@@ -523,17 +660,86 @@ public final class QwenMetalModel {
             }
         }
         guard let counters else { return }
+
+        var phaseGpu: [StepPhase: Double]?
+        if completed, let sb = counters.bufferSampleBuffer,
+           !counters.bufferSamplingBroken, !counters.bufferPhaseSampleRanges.isEmpty,
+           let correlationStart = counters.bufferCorrelationStart {
+            phaseGpu = resolvePhaseGpuSeconds(
+                sampleBuffer: sb, sampleCount: counters.bufferSampleIndex,
+                ranges: counters.bufferPhaseSampleRanges,
+                correlationStart: correlationStart
+            )
+            if let resolved = phaseGpu, counters.phaseGpuSeconds != nil {
+                for (p, s) in resolved {
+                    counters.phaseGpuSeconds![p, default: 0] += s
+                }
+            }
+        }
+
+        let label = StepPhase.allCases.filter {
+            counters.bufferPhaseDispatches[$0] != nil
+                || counters.bufferPhaseEncodeSeconds[$0] != nil
+        }.map(\.rawValue).joined(separator: "+")
+        os_signpost(.end, log: Self.signpostLog, name: "commandBuffer",
+                    signpostID: signpostID, "%{public}@ wait=%.6f gpu=%.6f",
+                    label, waitSeconds, gpuSeconds ?? -1)
+
         counters.timeline.append(CommandBufferSample(
             phaseDispatches: counters.bufferPhaseDispatches,
             phaseEncodeSeconds: counters.bufferPhaseEncodeSeconds,
             encodeSeconds: encodeSeconds,
             waitSeconds: waitSeconds,
             gpuSeconds: gpuSeconds,
+            phaseGpuSeconds: phaseGpu,
             completed: completed
         ))
         counters.bufferOpen = false
         counters.bufferPhaseDispatches = [:]
         counters.bufferPhaseEncodeSeconds = [:]
+        counters.currentEncoder = nil
+        counters.bufferSampleBuffer = nil
+        counters.bufferSampleIndex = 0
+        counters.bufferPhaseSampleRanges = []
+        counters.bufferSamplingBroken = false
+        counters.bufferCorrelationStart = nil
+    }
+
+    /// Converts resolved dispatch-boundary timestamp samples into per-phase
+    /// GPU seconds using a linear CPU/GPU correlation across the buffer's
+    /// lifetime (device.sampleTimestamps at encode start and now; CPU
+    /// timestamps are nanoseconds). Any unresolved or non-monotone sample
+    /// voids the whole buffer's split — partial splits under-report silently.
+    /// Only reachable on devices whose probe reports dispatch-boundary
+    /// sampling; Apple GPUs never enter here.
+    private func resolvePhaseGpuSeconds(
+        sampleBuffer: MTLCounterSampleBuffer,
+        sampleCount: Int,
+        ranges: [(phase: StepPhase, start: Int, end: Int)],
+        correlationStart: (cpu: MTLTimestamp, gpu: MTLTimestamp)
+    ) -> [StepPhase: Double]? {
+        let correlationEnd = engine.device.sampleTimestamps()
+        guard correlationEnd.cpu > correlationStart.cpu,
+              correlationEnd.gpu > correlationStart.gpu else { return nil }
+        let cpuSeconds = Double(correlationEnd.cpu - correlationStart.cpu) / 1e9
+        let ticksPerSecond = Double(correlationEnd.gpu - correlationStart.gpu) / cpuSeconds
+        guard ticksPerSecond > 0,
+              let data = try? sampleBuffer.resolveCounterRange(0..<sampleCount),
+              data.count >= sampleCount * MemoryLayout<MTLCounterResultTimestamp>.stride
+        else { return nil }
+        return data.withUnsafeBytes { raw -> [StepPhase: Double]? in
+            let stamps = raw.bindMemory(to: MTLCounterResultTimestamp.self)
+            var result: [StepPhase: Double] = [:]
+            for range in ranges {
+                let t0 = stamps[range.start].timestamp
+                let t1 = stamps[range.end].timestamp
+                guard t0 != 0, t1 != 0, t0 != .max, t1 != .max, t1 >= t0 else {
+                    return nil
+                }
+                result[range.phase, default: 0] += Double(t1 - t0) / ticksPerSecond
+            }
+            return result
+        }
     }
 
     private func runPhase(
@@ -557,8 +763,15 @@ public final class QwenMetalModel {
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
         let counters = StepCounters()
+        if case .dispatchBoundaryCounters = phaseGpuSplitSupport {
+            counters.phaseGpuSeconds = [:]
+        }
         let wallStart = ProcessInfo.processInfo.systemUptime
         activeStepCounters = counters
+        let stepSignpostID = OSSignpostID(log: Self.signpostLog)
+        os_signpost(.begin, log: Self.signpostLog, name: "step",
+                    signpostID: stepSignpostID, "tokens=%d", tokens.count)
+        counters.signpostTally.stepIntervals += 1
         engine.computeDispatchObserver = {
             counters.computeDispatchesEncoded += 1
             let bucket = counters.currentPhase ?? .other
@@ -570,6 +783,9 @@ public final class QwenMetalModel {
         defer {
             engine.computeDispatchObserver = nil
             activeStepCounters = nil
+            os_signpost(.end, log: Self.signpostLog, name: "step",
+                        signpostID: stepSignpostID)
+            lastSignpostTally = counters.signpostTally
             lastStepMetrics = StepMetrics(
                 tokensProcessed: counters.tokensProcessed,
                 logitProjections: counters.logitProjections,
@@ -585,7 +801,8 @@ public final class QwenMetalModel {
                 completedWithoutThrow: counters.completedWithoutThrow,
                 commandBufferTimeline: counters.timeline,
                 phaseDispatchesEncoded: counters.phaseDispatches,
-                phaseEncodeSeconds: counters.phaseEncodeSeconds
+                phaseEncodeSeconds: counters.phaseEncodeSeconds,
+                phaseGpuSeconds: counters.phaseGpuSeconds
             )
         }
 

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -7,8 +7,60 @@ import Metal
 /// delta recurrence, attention softmax over cached KV, top-k routing), all of
 /// it microseconds per token. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
-    /// S3a whole-step aggregate baseline. These totals do not identify phases,
-    /// layer costs, overlap, or command-buffer timeline gaps.
+    /// S3b command-buffer phase labels. A label names the work a phase scope
+    /// encoded; it claims nothing about when the GPU actually ran that work.
+    public enum StepPhase: String, CaseIterable, Sendable {
+        /// Attention norm + q/k/v projections, output projection, residual add.
+        case attention
+        /// DeltaNet mixer: projections, conv step, recurrence, gated norm,
+        /// output projection, residual add.
+        case delta
+        /// Routed expert GEMVs plus the shared-expert chain and accumulation.
+        case moe
+        /// Pre-MoE norm and the router logits projection.
+        case router
+        /// Final norm and vocabulary projection.
+        case lmHead
+        /// Dispatches encoded outside every labeled scope (must stay empty).
+        case other
+    }
+
+    /// One committed command buffer, in commit order. Encode time and
+    /// dispatch counts are attributed to phases exactly (encoding is CPU work
+    /// under our control); blocking-wait and GPU time exist only at
+    /// command-buffer granularity, so a buffer spanning several phases cannot
+    /// split them per phase.
+    public struct CommandBufferSample: Equatable, Sendable {
+        /// Compute dispatches encoded into this buffer, per phase.
+        public let phaseDispatches: [StepPhase: Int]
+        /// CPU wall time inside each phase's encode scope for this buffer.
+        public let phaseEncodeSeconds: [StepPhase: Double]
+        /// CPU wall time from encoder creation to commit (>= the phase sum).
+        public let encodeSeconds: Double
+        /// Wall time inside this buffer's waitUntilCompleted call.
+        public let waitSeconds: Double
+        /// GPU start-to-end duration; nil when the buffer failed or reported
+        /// invalid timestamps. Not proof of exclusive GPU occupancy.
+        public let gpuSeconds: Double?
+        /// Whether status was .completed after the blocking wait.
+        public let completed: Bool
+
+        /// Phases encoded into this buffer, in declaration order (a canonical
+        /// label, not the encode order within the buffer).
+        public var phases: [StepPhase] {
+            StepPhase.allCases.filter {
+                phaseDispatches[$0] != nil || phaseEncodeSeconds[$0] != nil
+            }
+        }
+
+        public var dispatchesEncoded: Int { phaseDispatches.values.reduce(0, +) }
+    }
+
+    /// S3a whole-step aggregates plus the S3b committed-buffer timeline.
+    /// The aggregates still cannot identify overlap; the timeline labels each
+    /// buffer's encoded phases and reports per-buffer encode/wait/GPU cost,
+    /// but it is not an Instruments trace: it cannot see gaps between buffers
+    /// or split a multi-phase buffer's wait/GPU time by phase.
     public struct StepMetrics: Equatable, Sendable {
         public let tokensProcessed: Int
         public let logitProjections: Int
@@ -28,6 +80,16 @@ public final class QwenMetalModel {
         public let gpuUntimedCommandBuffers: Int
         /// False when step exited by throwing after publishing partial counters.
         public let completedWithoutThrow: Bool
+        /// S3b: committed command buffers in commit order. A throwing step's
+        /// never-committed encodes are absent here but still counted in
+        /// computeDispatchesEncoded and the phase totals below.
+        public let commandBufferTimeline: [CommandBufferSample]
+        /// Encode-side dispatch totals per phase, including partial work from
+        /// a buffer the step never committed before throwing.
+        public let phaseDispatchesEncoded: [StepPhase: Int]
+        /// CPU wall time inside per-phase encode scopes; same partial-work
+        /// semantics as phaseDispatchesEncoded.
+        public let phaseEncodeSeconds: [StepPhase: Double]
 
         public var avoidedLogitProjections: Int {
             max(0, tokensProcessed - logitProjections)
@@ -46,6 +108,14 @@ public final class QwenMetalModel {
         var gpuTimedCommandBuffers = 0
         var gpuUntimedCommandBuffers = 0
         var completedWithoutThrow = false
+        var timeline: [CommandBufferSample] = []
+        var phaseDispatches: [StepPhase: Int] = [:]
+        var phaseEncodeSeconds: [StepPhase: Double] = [:]
+        var currentPhase: StepPhase?
+        var bufferOpen = false
+        var bufferEncodeStart = 0.0
+        var bufferPhaseDispatches: [StepPhase: Int] = [:]
+        var bufferPhaseEncodeSeconds: [StepPhase: Double] = [:]
     }
 
     public let config: QwenConfig
@@ -119,7 +189,8 @@ public final class QwenMetalModel {
         commandBuffersCommitted: 0, blockingWaits: 0, blockingWaitSeconds: 0,
         computeDispatchesEncoded: 0, stepWallSeconds: 0, commandBufferErrors: 0,
         gpuExecutionSeconds: 0, gpuTimedCommandBuffers: 0, gpuUntimedCommandBuffers: 0,
-        completedWithoutThrow: false
+        completedWithoutThrow: false,
+        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:]
     )
     private var activeStepCounters: StepCounters?
 
@@ -387,34 +458,89 @@ public final class QwenMetalModel {
         }
     }
 
-    private func commitAndWait(_ cb: MTLCommandBuffer) {
-        cb.commit()
-        activeStepCounters?.commandBuffersCommitted += 1
-        let waitStart = ProcessInfo.processInfo.systemUptime
-        cb.waitUntilCompleted()
-        activeStepCounters?.blockingWaits += 1
-        activeStepCounters?.blockingWaitSeconds += max(
-            0, ProcessInfo.processInfo.systemUptime - waitStart
-        )
-
-        guard cb.status == .completed else {
-            activeStepCounters?.commandBufferErrors += 1
-            return
-        }
-        let start = cb.gpuStartTime
-        let end = cb.gpuEndTime
-        guard start.isFinite, end.isFinite, start > 0, end > 0, end >= start else {
-            activeStepCounters?.gpuUntimedCommandBuffers += 1
-            return
-        }
-        activeStepCounters?.gpuExecutionSeconds += end - start
-        activeStepCounters?.gpuTimedCommandBuffers += 1
-    }
-
-    private func runPhase(_ body: (MTLComputeCommandEncoder) throws -> Void) throws {
+    /// Starts a step command buffer and opens its S3b timeline accumulator so
+    /// encode time and dispatches attribute to this buffer until commit.
+    private func beginStepCommandBuffer() -> (MTLCommandBuffer, MTLComputeCommandEncoder) {
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
-        try body(enc)
+        if let counters = activeStepCounters {
+            counters.bufferOpen = true
+            counters.bufferEncodeStart = ProcessInfo.processInfo.systemUptime
+            counters.bufferPhaseDispatches = [:]
+            counters.bufferPhaseEncodeSeconds = [:]
+        }
+        return (cb, enc)
+    }
+
+    /// Attributes encode-side work (CPU encode wall time and dispatch counts)
+    /// to a phase label. Scopes never nest in the current schedule; if one
+    /// ever did, its elapsed time would double-count, so keep call sites flat.
+    private func phase<T>(_ p: StepPhase, _ body: () throws -> T) rethrows -> T {
+        guard let counters = activeStepCounters else { return try body() }
+        let previous = counters.currentPhase
+        counters.currentPhase = p
+        let start = ProcessInfo.processInfo.systemUptime
+        defer {
+            let elapsed = max(0, ProcessInfo.processInfo.systemUptime - start)
+            counters.phaseEncodeSeconds[p, default: 0] += elapsed
+            if counters.bufferOpen {
+                counters.bufferPhaseEncodeSeconds[p, default: 0] += elapsed
+            }
+            counters.currentPhase = previous
+        }
+        return try body()
+    }
+
+    private func commitAndWait(_ cb: MTLCommandBuffer) {
+        let counters = activeStepCounters
+        var encodeSeconds = 0.0
+        if let counters, counters.bufferOpen {
+            encodeSeconds = max(
+                0, ProcessInfo.processInfo.systemUptime - counters.bufferEncodeStart
+            )
+        }
+        cb.commit()
+        counters?.commandBuffersCommitted += 1
+        let waitStart = ProcessInfo.processInfo.systemUptime
+        cb.waitUntilCompleted()
+        counters?.blockingWaits += 1
+        let waitSeconds = max(0, ProcessInfo.processInfo.systemUptime - waitStart)
+        counters?.blockingWaitSeconds += waitSeconds
+
+        let completed = cb.status == .completed
+        var gpuSeconds: Double?
+        if !completed {
+            counters?.commandBufferErrors += 1
+        } else {
+            let start = cb.gpuStartTime
+            let end = cb.gpuEndTime
+            if start.isFinite, end.isFinite, start > 0, end > 0, end >= start {
+                gpuSeconds = end - start
+                counters?.gpuExecutionSeconds += end - start
+                counters?.gpuTimedCommandBuffers += 1
+            } else {
+                counters?.gpuUntimedCommandBuffers += 1
+            }
+        }
+        guard let counters else { return }
+        counters.timeline.append(CommandBufferSample(
+            phaseDispatches: counters.bufferPhaseDispatches,
+            phaseEncodeSeconds: counters.bufferPhaseEncodeSeconds,
+            encodeSeconds: encodeSeconds,
+            waitSeconds: waitSeconds,
+            gpuSeconds: gpuSeconds,
+            completed: completed
+        ))
+        counters.bufferOpen = false
+        counters.bufferPhaseDispatches = [:]
+        counters.bufferPhaseEncodeSeconds = [:]
+    }
+
+    private func runPhase(
+        _ label: StepPhase, _ body: (MTLComputeCommandEncoder) throws -> Void
+    ) throws {
+        let (cb, enc) = beginStepCommandBuffer()
+        try phase(label) { try body(enc) }
         enc.endEncoding()
         commitAndWait(cb)
     }
@@ -433,7 +559,14 @@ public final class QwenMetalModel {
         let counters = StepCounters()
         let wallStart = ProcessInfo.processInfo.systemUptime
         activeStepCounters = counters
-        engine.computeDispatchObserver = { counters.computeDispatchesEncoded += 1 }
+        engine.computeDispatchObserver = {
+            counters.computeDispatchesEncoded += 1
+            let bucket = counters.currentPhase ?? .other
+            counters.phaseDispatches[bucket, default: 0] += 1
+            if counters.bufferOpen {
+                counters.bufferPhaseDispatches[bucket, default: 0] += 1
+            }
+        }
         defer {
             engine.computeDispatchObserver = nil
             activeStepCounters = nil
@@ -449,7 +582,10 @@ public final class QwenMetalModel {
                 gpuExecutionSeconds: counters.gpuExecutionSeconds,
                 gpuTimedCommandBuffers: counters.gpuTimedCommandBuffers,
                 gpuUntimedCommandBuffers: counters.gpuUntimedCommandBuffers,
-                completedWithoutThrow: counters.completedWithoutThrow
+                completedWithoutThrow: counters.completedWithoutThrow,
+                commandBufferTimeline: counters.timeline,
+                phaseDispatchesEncoded: counters.phaseDispatches,
+                phaseEncodeSeconds: counters.phaseEncodeSeconds
             )
         }
 
@@ -500,7 +636,7 @@ public final class QwenMetalModel {
         guard projectLogits else { return [] }
         QwenCPUModel.rmsNorm(&h, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
         loadX(h)
-        try runPhase { enc in
+        try runPhase(.lmHead) { enc in
             try engine.encodeGemv(enc, lmHead, x: xBuf, y: logitsBuf, yOff: 0)
         }
         activeStepCounters?.logitProjections += 1
@@ -521,7 +657,7 @@ public final class QwenMetalModel {
         let kvDim = KVH * hd
 
         loadX(x)
-        try runPhase { enc in
+        try runPhase(.attention) { enc in
             try engine.encodeGemv(enc, w.qProj, x: xBuf, y: yBuf, yOff: 0)
             try engine.encodeGemv(enc, w.kProj, x: xBuf, y: yBuf, yOff: qOutDim)
             try engine.encodeGemv(enc, w.vProj, x: xBuf, y: yBuf, yOff: qOutDim + kvDim)
@@ -571,7 +707,7 @@ public final class QwenMetalModel {
         for i in 0..<attnOut.count { attnOut[i] *= QwenCPUModel.sigmoid(gate[i]) }
 
         loadX(attnOut)
-        try runPhase { enc in
+        try runPhase(.attention) { enc in
             try engine.encodeGemv(enc, w.oProj, x: xBuf, y: yBuf, yOff: 0)
         }
         return readY(0, cfg.hiddenSize)
@@ -614,7 +750,7 @@ public final class QwenMetalModel {
         switch cfg.deltaLayout {
         case .fusedInterleaved:
             let qkvzDim = 2 * keyDim + 2 * valueDim
-            try runPhase { enc in
+            try runPhase(.delta) { enc in
                 try engine.encodeGemv(enc, w.qkvz!, x: xBuf, y: yBuf, yOff: 0)
                 try engine.encodeGemv(enc, w.ba!, x: xBuf, y: yBuf, yOff: qkvzDim)
             }
@@ -644,7 +780,7 @@ public final class QwenMetalModel {
                 }
             }
         case .split:
-            try runPhase { enc in
+            try runPhase(.delta) { enc in
                 try engine.encodeGemv(enc, w.qkv!, x: xBuf, y: yBuf, yOff: 0)
                 try engine.encodeGemv(enc, w.zProj!, x: xBuf, y: yBuf, yOff: convDim)
                 try engine.encodeGemv(enc, w.bProj!, x: xBuf, y: yBuf, yOff: convDim + valueDim)
@@ -706,7 +842,7 @@ public final class QwenMetalModel {
         for i in 0..<normed.count { normed[i] *= QwenCPUModel.silu(z[i]) }
 
         loadX(normed)
-        try runPhase { enc in
+        try runPhase(.delta) { enc in
             try engine.encodeGemv(enc, w.outProj, x: xBuf, y: yBuf, yOff: 0)
         }
         return readY(0, cfg.hiddenSize)
@@ -721,7 +857,7 @@ public final class QwenMetalModel {
         let topK = cfg.numExpertsPerTok
 
         loadX(x)
-        try runPhase { enc in
+        try runPhase(.router) { enc in
             try engine.encodeGemv(enc, w.gate, x: xBuf, y: yBuf, yOff: 0)
         }
         var router = readY(0, E)
@@ -756,7 +892,7 @@ public final class QwenMetalModel {
             expertBufs = try cache.buffers(layer: layerIndex, experts: picks.map { $0.0 })
         }
 
-        try runPhase { enc in
+        try runPhase(.moe) { enc in
             for (ki, pick) in picks.enumerated() {
                 let e = pick.0
                 if let projs = expertProjs {
@@ -1021,43 +1157,52 @@ extension QwenMetalModel {
             let fl = fastLayers[li]
 
             if let delta = L.delta {
-                let cb = engine.queue.makeCommandBuffer()!
-                let enc = cb.makeComputeCommandEncoder()!
-                if let p = pending { try encodePendingMoE(enc, p); pending = nil }
+                let (cb, enc) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodePendingMoE(enc, p) }
+                    pending = nil
+                }
                 try encDeltaLayer(enc, delta: delta, fl: fl, moeGate: L.moe.gate)
                 enc.endEncoding()
                 commitAndWait(cb)
             } else {
                 // Attention: projections, CPU core, then out-proj + router.
-                let cb1 = engine.queue.makeCommandBuffer()!
-                let e1 = cb1.makeComputeCommandEncoder()!
-                if let p = pending { try encodePendingMoE(e1, p); pending = nil }
-                try encNormCopy(e1, w: fl.inputNorm, dstOff: reg.x0)
-                barrier(e1)
+                let (cb1, e1) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodePendingMoE(e1, p) }
+                    pending = nil
+                }
                 let attn = L.attn!
-                try engine.encodeGemv(e1, attn.qProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qout)
-                try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
-                try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
+                try phase(.attention) {
+                    try encNormCopy(e1, w: fl.inputNorm, dstOff: reg.x0)
+                    barrier(e1)
+                    try engine.encodeGemv(e1, attn.qProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qout)
+                    try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
+                    try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
+                }
                 e1.endEncoding()
                 commitAndWait(cb1)
 
                 let attnOut = attnCoreCPU(layerIndex: li, state: state, attn: attn)
                 writeS(reg.att, attnOut)
 
-                let cb2 = engine.queue.makeCommandBuffer()!
-                let e2 = cb2.makeComputeCommandEncoder()!
-                try engine.encodeGemv(e2, attn.oProj, x: sBuf!, xOff: reg.att, y: sBuf!, yOff: reg.r)
-                barrier(e2)
-                var np = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-                e2.setComputePipelineState(try engine.pipeline("add_inplace"))
-                e2.setBuffer(hBuf!, offset: 0, index: 0)
-                e2.setBuffer(sBuf!, offset: 0, index: 1)
-                setBytesParams(e2, &np, index: 2)
-                dispatchN(e2, D)
-                barrier(e2)
-                try encNormCopy(e2, w: fl.postNorm, dstOff: reg.xmoe)
-                barrier(e2)
-                try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+                let (cb2, e2) = beginStepCommandBuffer()
+                try phase(.attention) {
+                    try engine.encodeGemv(e2, attn.oProj, x: sBuf!, xOff: reg.att, y: sBuf!, yOff: reg.r)
+                    barrier(e2)
+                    var np = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
+                    e2.setComputePipelineState(try engine.pipeline("add_inplace"))
+                    e2.setBuffer(hBuf!, offset: 0, index: 0)
+                    e2.setBuffer(sBuf!, offset: 0, index: 1)
+                    setBytesParams(e2, &np, index: 2)
+                    dispatchN(e2, D)
+                    barrier(e2)
+                }
+                try phase(.router) {
+                    try encNormCopy(e2, w: fl.postNorm, dstOff: reg.xmoe)
+                    barrier(e2)
+                    try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+                }
                 e2.endEncoding()
                 commitAndWait(cb2)
             }
@@ -1072,19 +1217,20 @@ extension QwenMetalModel {
 
         // Always apply the last layer's experts. Only the final token in a
         // multi-token call also needs final norm + vocabulary projection.
-        let cb = engine.queue.makeCommandBuffer()!
-        let enc = cb.makeComputeCommandEncoder()!
-        if let p = pending { try encodePendingMoE(enc, p) }
+        let (cb, enc) = beginStepCommandBuffer()
+        if let p = pending { try phase(.moe) { try encodePendingMoE(enc, p) } }
         if projectLogits {
-            enc.setComputePipelineState(try engine.pipeline("norm_copy"))
-            var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
-            enc.setBuffer(hBuf!, offset: 0, index: 0)
-            enc.setBuffer(sBuf!, offset: 0, index: 1)
-            enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
-            setBytesParams(enc, &np, index: 3)
-            dispatchRows(enc, rows: 1)
-            barrier(enc)
-            try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            try phase(.lmHead) {
+                enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+                var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
+                enc.setBuffer(hBuf!, offset: 0, index: 0)
+                enc.setBuffer(sBuf!, offset: 0, index: 1)
+                enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
+                setBytesParams(enc, &np, index: 3)
+                dispatchRows(enc, rows: 1)
+                barrier(enc)
+                try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            }
             activeStepCounters?.logitProjections += 1
         }
         enc.endEncoding()
@@ -1103,97 +1249,101 @@ extension QwenMetalModel {
         let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
         let keyDim = cfg.keyDim, convDim = cfg.convDim
 
-        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0)
-        barrier(enc)
-        switch config.deltaLayout {
-        case .split:
-            try engine.encodeGemv(enc, delta.qkv!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkv)
-            try engine.encodeGemv(enc, delta.zProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.z)
-            try engine.encodeGemv(enc, delta.bProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.b)
-            try engine.encodeGemv(enc, delta.aProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.a)
+        try phase(.delta) {
+            try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0)
             barrier(enc)
-        case .fusedInterleaved:
-            try engine.encodeGemv(enc, delta.qkvz!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkvzStage)
-            try engine.encodeGemv(enc, delta.ba!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.baStage)
-            barrier(enc)
-            enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
-            struct DeintParams {
-                var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
-                var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
-                var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+            switch config.deltaLayout {
+            case .split:
+                try engine.encodeGemv(enc, delta.qkv!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkv)
+                try engine.encodeGemv(enc, delta.zProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.z)
+                try engine.encodeGemv(enc, delta.bProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.b)
+                try engine.encodeGemv(enc, delta.aProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.a)
+                barrier(enc)
+            case .fusedInterleaved:
+                try engine.encodeGemv(enc, delta.qkvz!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkvzStage)
+                try engine.encodeGemv(enc, delta.ba!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.baStage)
+                barrier(enc)
+                enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
+                struct DeintParams {
+                    var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
+                    var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
+                    var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+                }
+                var dip = DeintParams(
+                    nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
+                    keyDim: UInt32(keyDim), srcOff: UInt32(reg.qkvzStage), baOff: UInt32(reg.baStage),
+                    qkvOff: UInt32(reg.qkv), zOff: UInt32(reg.z), bOff: UInt32(reg.b), aOff: UInt32(reg.a)
+                )
+                enc.setBuffer(sBuf!, offset: 0, index: 0)
+                setBytesParams(enc, &dip, index: 1)
+                dispatchN(enc, nk)
+                barrier(enc)
             }
-            var dip = DeintParams(
-                nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
-                keyDim: UInt32(keyDim), srcOff: UInt32(reg.qkvzStage), baOff: UInt32(reg.baStage),
-                qkvOff: UInt32(reg.qkv), zOff: UInt32(reg.z), bOff: UInt32(reg.b), aOff: UInt32(reg.a)
-            )
+
+            enc.setComputePipelineState(try engine.pipeline("conv_step"))
+            var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim), UInt32(reg.qkv), UInt32(reg.conv))
             enc.setBuffer(sBuf!, offset: 0, index: 0)
-            setBytesParams(enc, &dip, index: 1)
-            dispatchN(enc, nk)
+            enc.setBuffer(fl.hist!, offset: 0, index: 1)
+            enc.setBuffer(fl.convW!, offset: 0, index: 2)
+            setBytesParams(enc, &cp, index: 3)
+            dispatchN(enc, convDim)
+
+            enc.setComputePipelineState(try engine.pipeline("delta_pre"))
+            var dp = SIMD4<UInt32>(UInt32(nv), UInt32(reg.a), UInt32(reg.b), UInt32(reg.gb))
+            enc.setBuffer(sBuf!, offset: 0, index: 0)
+            enc.setBuffer(fl.aLog!, offset: 0, index: 1)
+            enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
+            setBytesParams(enc, &dp, index: 3)
+            dispatchN(enc, nv)
+            barrier(enc)
+
+            let invScale = 1 / Float(dk).squareRoot()
+            try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil, scale: invScale * invScale, eps: 1e-6)
+            try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil, scale: invScale, eps: 1e-6)
+            barrier(enc)
+
+            enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
+            var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
+            enc.setBuffer(sBuf!, offset: reg.conv * 4, index: 0)                    // q
+            enc.setBuffer(sBuf!, offset: (reg.conv + keyDim) * 4, index: 1)         // k
+            enc.setBuffer(sBuf!, offset: (reg.conv + 2 * keyDim) * 4, index: 2)     // v
+            enc.setBuffer(sBuf!, offset: reg.gb * 4, index: 3)                      // g
+            enc.setBuffer(sBuf!, offset: (reg.gb + nv) * 4, index: 4)               // beta
+            enc.setBuffer(fl.state!, offset: 0, index: 5)
+            enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
+            enc.setBuffer(fl.state!, offset: 0, index: 7)
+            setBytesParams(enc, &delp, index: 8)
+            engine.dispatchThreads(
+                enc, threads: MTLSize(width: 32, height: dv, depth: nv),
+                threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
+            )
+            barrier(enc)
+
+            enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
+            struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
+            var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
+                         yOff: UInt32(reg.dy), zOff: UInt32(reg.z), outOff: UInt32(reg.dn))
+            enc.setBuffer(sBuf!, offset: 0, index: 0)
+            enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
+            setBytesParams(enc, &gp, index: 2)
+            dispatchRows(enc, rows: nv)
+            barrier(enc)
+
+            try engine.encodeGemv(enc, delta.outProj, x: sBuf!, xOff: reg.dn, y: sBuf!, yOff: reg.r)
+            barrier(enc)
+            var ap = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
+            enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+            enc.setBuffer(hBuf!, offset: 0, index: 0)
+            enc.setBuffer(sBuf!, offset: 0, index: 1)
+            setBytesParams(enc, &ap, index: 2)
+            dispatchN(enc, D)
             barrier(enc)
         }
-
-        enc.setComputePipelineState(try engine.pipeline("conv_step"))
-        var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim), UInt32(reg.qkv), UInt32(reg.conv))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.hist!, offset: 0, index: 1)
-        enc.setBuffer(fl.convW!, offset: 0, index: 2)
-        setBytesParams(enc, &cp, index: 3)
-        dispatchN(enc, convDim)
-
-        enc.setComputePipelineState(try engine.pipeline("delta_pre"))
-        var dp = SIMD4<UInt32>(UInt32(nv), UInt32(reg.a), UInt32(reg.b), UInt32(reg.gb))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.aLog!, offset: 0, index: 1)
-        enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
-        setBytesParams(enc, &dp, index: 3)
-        dispatchN(enc, nv)
-        barrier(enc)
-
-        let invScale = 1 / Float(dk).squareRoot()
-        try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil, scale: invScale * invScale, eps: 1e-6)
-        try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil, scale: invScale, eps: 1e-6)
-        barrier(enc)
-
-        enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
-        var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
-        enc.setBuffer(sBuf!, offset: reg.conv * 4, index: 0)                    // q
-        enc.setBuffer(sBuf!, offset: (reg.conv + keyDim) * 4, index: 1)         // k
-        enc.setBuffer(sBuf!, offset: (reg.conv + 2 * keyDim) * 4, index: 2)     // v
-        enc.setBuffer(sBuf!, offset: reg.gb * 4, index: 3)                      // g
-        enc.setBuffer(sBuf!, offset: (reg.gb + nv) * 4, index: 4)               // beta
-        enc.setBuffer(fl.state!, offset: 0, index: 5)
-        enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
-        enc.setBuffer(fl.state!, offset: 0, index: 7)
-        setBytesParams(enc, &delp, index: 8)
-        engine.dispatchThreads(
-            enc, threads: MTLSize(width: 32, height: dv, depth: nv),
-            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
-        )
-        barrier(enc)
-
-        enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
-        struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
-        var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
-                     yOff: UInt32(reg.dy), zOff: UInt32(reg.z), outOff: UInt32(reg.dn))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
-        setBytesParams(enc, &gp, index: 2)
-        dispatchRows(enc, rows: nv)
-        barrier(enc)
-
-        try engine.encodeGemv(enc, delta.outProj, x: sBuf!, xOff: reg.dn, y: sBuf!, yOff: reg.r)
-        barrier(enc)
-        var ap = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-        enc.setComputePipelineState(try engine.pipeline("add_inplace"))
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
-        setBytesParams(enc, &ap, index: 2)
-        dispatchN(enc, D)
-        barrier(enc)
-        try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe)
-        barrier(enc)
-        try engine.encodeGemv(enc, moeGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+        try phase(.router) {
+            try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe)
+            barrier(enc)
+            try engine.encodeGemv(enc, moeGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+        }
     }
 
     private func attnCoreCPU(layerIndex: Int, state: QwenCPUModel.DecodeState, attn: AttnGPU) -> [Float] {

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -91,6 +91,90 @@ import Testing
                 "\(label): fast-path dispatch baseline changed")
     }
 
+    /// S3b: the committed command-buffer timeline must label every buffer,
+    /// follow the fast-path schedule exactly, and account for the S3a
+    /// aggregates without inventing timing the buffers never reported.
+    /// Only meaningful for a step that completed without throwing.
+    static func expectPhaseTimeline(
+        _ metrics: QwenMetalModel.StepMetrics,
+        config: QwenConfig,
+        tokens: Int,
+        label: String
+    ) {
+        let timeline = metrics.commandBufferTimeline
+        #expect(timeline.count == metrics.commandBuffersCommitted,
+                "\(label): timeline misses committed buffers")
+        #expect(timeline.map(\.phases) == Self.expectedTimelinePhases(config: config, tokens: tokens),
+                "\(label): phase labels diverged from the fast-path schedule")
+
+        let phaseDispatchTotal = metrics.phaseDispatchesEncoded.values.reduce(0, +)
+        #expect(phaseDispatchTotal == metrics.computeDispatchesEncoded,
+                "\(label): phase dispatch totals leak dispatches")
+        #expect(metrics.phaseDispatchesEncoded[.other, default: 0] == 0,
+                "\(label): dispatches encoded outside every labeled phase")
+
+        var waitSum = 0.0
+        var gpuSum = 0.0
+        var timed = 0
+        var untimed = 0
+        var failed = 0
+        var timelineDispatches = 0
+        for sample in timeline {
+            #expect(!sample.phases.isEmpty, "\(label): unlabeled command buffer")
+            #expect(sample.completed, "\(label): failed buffer in timeline")
+            #expect(sample.encodeSeconds >= 0 && sample.waitSeconds >= 0,
+                    "\(label): negative buffer timing")
+            let phaseEncode = sample.phaseEncodeSeconds.values.reduce(0, +)
+            #expect(phaseEncode <= sample.encodeSeconds + 1e-6,
+                    "\(label): phase encode time exceeds the buffer's encode span")
+            waitSum += sample.waitSeconds
+            if !sample.completed {
+                failed += 1
+            } else if let gpu = sample.gpuSeconds {
+                #expect(gpu >= 0, "\(label): negative GPU duration")
+                gpuSum += gpu
+                timed += 1
+            } else {
+                untimed += 1
+            }
+            timelineDispatches += sample.dispatchesEncoded
+        }
+        #expect(abs(waitSum - metrics.blockingWaitSeconds) < 1e-6,
+                "\(label): timeline wait diverged from the S3a aggregate")
+        #expect(abs(gpuSum - metrics.gpuExecutionSeconds) < 1e-6,
+                "\(label): timeline GPU time diverged from the S3a aggregate")
+        #expect(timed == metrics.gpuTimedCommandBuffers, "\(label): timed buffer count")
+        #expect(untimed == metrics.gpuUntimedCommandBuffers, "\(label): untimed buffer count")
+        #expect(failed == metrics.commandBufferErrors, "\(label): failed buffer count")
+        #expect(timelineDispatches == metrics.computeDispatchesEncoded,
+                "\(label): timeline dispatches diverged from the S3a aggregate")
+        #expect(timeline.filter { $0.phases.contains(.lmHead) }.count == metrics.logitProjections,
+                "\(label): LM-head buffer count")
+    }
+
+    /// The label sequence the current fast-path schedule must produce: per
+    /// token, one buffer per DeltaNet layer, two per attention layer, and a
+    /// tail buffer that flushes the last layer's experts (adding the LM head
+    /// only on the final token). Labels are in canonical declaration order.
+    static func expectedTimelinePhases(
+        config: QwenConfig, tokens: Int
+    ) -> [[QwenMetalModel.StepPhase]] {
+        var expected: [[QwenMetalModel.StepPhase]] = []
+        for token in 0..<tokens {
+            for layer in 0..<config.numHiddenLayers {
+                let flushesMoE = layer > 0
+                if config.isLinearLayer(layer) {
+                    expected.append(flushesMoE ? [.delta, .moe, .router] : [.delta, .router])
+                } else {
+                    expected.append(flushesMoE ? [.attention, .moe] : [.attention])
+                    expected.append([.attention, .router])
+                }
+            }
+            expected.append(token == tokens - 1 ? [.moe, .lmHead] : [.moe])
+        }
+        return expected
+    }
+
     static func compare(_ modelName: String, baseline: FastPathBaseline) throws {
         let dir = fixturesDir.appendingPathComponent(modelName)
         let cpu = try QwenCPUModel(modelDir: dir)
@@ -115,6 +199,10 @@ import Testing
         Self.expectFastPathBaseline(
             singleMetrics, tokens: 1, baseline: baseline, label: "\(modelName) one token"
         )
+        Self.expectPhaseTimeline(
+            singleMetrics, config: sequentialGPU.config, tokens: 1,
+            label: "\(modelName) one token"
+        )
 
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "\(modelName): GPU vs CPU logits maxAbsDiff \(maxDiff)")
@@ -133,6 +221,10 @@ import Testing
         Self.expectFastPathBaseline(
             multiMetrics, tokens: tokens.count, baseline: baseline, label: "\(modelName) multi token"
         )
+        Self.expectPhaseTimeline(
+            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            label: "\(modelName) multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
 
         let continuation = 11
@@ -150,6 +242,10 @@ import Testing
             elidingGPU.lastStepMetrics, tokens: 1,
             baseline: baseline, label: "\(modelName) continuation"
         )
+        Self.expectPhaseTimeline(
+            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            label: "\(modelName) continuation"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
 
         func argmax(_ v: [Float]) -> Int {
@@ -162,6 +258,35 @@ import Testing
 
     @Test func gpuMatchesCPUOnQuantizedTiny() throws {
         try Self.compare("tiny-model-q4", baseline: Self.q4Baseline)
+    }
+
+    /// S3b: the phase/timeline instrumentation must label the whole step,
+    /// stay within the step wall clock, and rebuild per step call rather than
+    /// accumulate across calls.
+    @Test func phaseTimelineAccountsForWholeStep() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let multi = model.lastStepMetrics
+        Self.expectInstrumentation(multi, tokens: 3, label: "timeline multi")
+        Self.expectFastPathBaseline(
+            multi, tokens: 3, baseline: Self.q4Baseline, label: "timeline multi"
+        )
+        Self.expectPhaseTimeline(
+            multi, config: model.config, tokens: 3, label: "timeline multi"
+        )
+        let encodeSum = multi.commandBufferTimeline.reduce(0.0) { $0 + $1.encodeSeconds }
+        #expect(encodeSum + multi.blockingWaitSeconds <= multi.stepWallSeconds + 1e-3,
+                "timeline multi: encode+wait exceeds the step wall clock")
+
+        _ = try model.step([11], state: state)
+        let single = model.lastStepMetrics
+        Self.expectPhaseTimeline(
+            single, config: model.config, tokens: 1, label: "timeline continuation"
+        )
+        #expect(single.commandBufferTimeline.count == Self.commandBuffersPerToken,
+                "timeline continuation: timeline accumulated across steps")
     }
 
     /// Full streaming path: repack tiny model to .qpack, run the GPU model in
@@ -199,6 +324,9 @@ import Testing
         Self.expectFastPathBaseline(
             singleMetrics, tokens: 1, baseline: Self.q4Baseline, label: "qpack one token"
         )
+        Self.expectPhaseTimeline(
+            singleMetrics, config: sequentialGPU.config, tokens: 1, label: "qpack one token"
+        )
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
 
@@ -215,6 +343,10 @@ import Testing
             multiMetrics, tokens: tokens.count,
             baseline: Self.q4Baseline, label: "qpack multi token"
         )
+        Self.expectPhaseTimeline(
+            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            label: "qpack multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
 
         let continuation = 11
@@ -229,6 +361,10 @@ import Testing
         Self.expectFastPathBaseline(
             elidingGPU.lastStepMetrics, tokens: 1,
             baseline: Self.q4Baseline, label: "qpack continuation"
+        )
+        Self.expectPhaseTimeline(
+            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            label: "qpack continuation"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")
 

--- a/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
+++ b/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S3b follow-up: the per-phase GPU/wait split is real only where the device
+/// can sample timestamps inside a compute encoder (dispatch-boundary
+/// counters). Everywhere else the API must report absence instead of
+/// publishing zeros that look like measurements, and os_signpost intervals
+/// must cover exactly the scopes the timeline already reports so Instruments
+/// can see the phases.
+@Suite struct PhaseGpuSplitTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    /// The probe is runtime evidence, not an assumption: capabilities are
+    /// read from the device, and when stage-boundary sampling is advertised a
+    /// real sample pass must have resolved. Probing twice must agree.
+    @Test func counterProbeIsStableAndFunctional() throws {
+        let engine = try MetalEngine()
+        let probe = engine.probeCounterSampling()
+        #expect(probe == engine.probeCounterSampling(), "probe not deterministic")
+        #expect(!probe.deviceName.isEmpty)
+        if probe.atStageBoundary && probe.hasTimestampCounterSet {
+            #expect(probe.stageBoundarySampleValid == true,
+                    "stage-boundary timestamp sampling advertised but a real sample pass did not resolve")
+        } else {
+            #expect(probe.stageBoundarySampleValid == nil,
+                    "functional stage probe ran without the advertised capability")
+        }
+    }
+
+    /// The model's split support must be derived from the probe, and an
+    /// unsupported verdict must carry a reason naming the device.
+    @Test func phaseGpuSplitSupportMatchesProbe() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let probe = model.counterSamplingSupport
+        switch model.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            #expect(probe.atDispatchBoundary && probe.hasTimestampCounterSet,
+                    "split claimed without the capability that makes it real")
+        case .unsupported(let reason):
+            #expect(!(probe.atDispatchBoundary && probe.hasTimestampCounterSet),
+                    "capability present but split reported unsupported")
+            #expect(!reason.isEmpty, "unsupported verdict without a reason")
+            #expect(reason.contains(probe.deviceName), "reason does not name the device")
+        }
+    }
+
+    /// The discriminator: with dispatch-boundary counters, per-phase GPU sums
+    /// must land near the per-buffer GPU totals; without them, the API must
+    /// report nil — absent, not zeros-that-look-real.
+    @Test func phaseGpuSecondsDiscriminateBySupport() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let metrics = model.lastStepMetrics
+        #expect(metrics.completedWithoutThrow)
+
+        switch model.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            let totals = try #require(
+                metrics.phaseGpuSeconds, "split supported but step totals absent")
+            #expect(totals.values.allSatisfy { $0 >= 0 }, "negative per-phase GPU time")
+            var attributed = 0.0
+            var attributedBuffers = 0
+            for sample in metrics.commandBufferTimeline {
+                guard let phaseGpu = sample.phaseGpuSeconds else { continue }
+                attributedBuffers += 1
+                let sum = phaseGpu.values.reduce(0, +)
+                #expect(phaseGpu.values.allSatisfy { $0 >= 0 },
+                        "negative per-phase GPU time in a buffer")
+                if let gpu = sample.gpuSeconds {
+                    // Counter clock vs command-buffer clock: generous but
+                    // discriminating — the phase sum must be the same order
+                    // as the buffer total, never wildly above it.
+                    #expect(sum <= gpu * 1.5 + 5e-4,
+                            "phase GPU sum exceeds the buffer's GPU span")
+                }
+                attributed += sum
+            }
+            #expect(attributedBuffers > 0, "split supported but no buffer was attributed")
+            let totalSum = totals.values.reduce(0, +)
+            #expect(abs(attributed - totalSum) < 1e-6,
+                    "step totals diverge from the per-buffer attribution")
+            #expect(abs(totalSum - metrics.gpuExecutionSeconds)
+                    <= max(0.5 * metrics.gpuExecutionSeconds, 2e-3),
+                    "per-phase GPU sum far from the per-buffer GPU total")
+        case .unsupported:
+            #expect(metrics.phaseGpuSeconds == nil,
+                    "unsupported split must be absent, not zeros")
+            for sample in metrics.commandBufferTimeline {
+                #expect(sample.phaseGpuSeconds == nil,
+                        "unsupported split leaked per-buffer phase GPU values")
+            }
+        }
+    }
+
+    /// Signpost intervals mirror the timeline exactly: one step interval, one
+    /// per committed command buffer, one per phase scope — so an Instruments
+    /// trace lines up with the published metrics. The tally rebuilds per step.
+    @Test func signpostIntervalsMirrorTheTimeline() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let metrics = model.lastStepMetrics
+        let tally = model.lastSignpostTally
+        #expect(tally.stepIntervals == 1, "step interval count")
+        #expect(tally.commandBufferIntervals == metrics.commandBuffersCommitted,
+                "command-buffer intervals diverge from committed buffers")
+        let phaseScopes = metrics.commandBufferTimeline.reduce(0) { $0 + $1.phases.count }
+        #expect(tally.phaseIntervals == phaseScopes,
+                "phase intervals diverge from the timeline's phase scopes")
+
+        _ = try model.step([11], state: state)
+        let single = model.lastSignpostTally
+        #expect(single.stepIntervals == 1, "tally accumulated across steps")
+        #expect(single.commandBufferIntervals
+                == model.lastStepMetrics.commandBuffersCommitted,
+                "tally accumulated across steps")
+    }
+}


### PR DESCRIPTION
## What this adds

Builds on the S3a aggregates (#20 / `aaa910a`) with a phase-labeled view of each step:

1. **Phase timeline**: a `StepPhase` classification (attention, delta, moe, router, lmHead) with encode-side CPU time and dispatch counts attributed exactly per phase, and wait/GPU time reported per committed command buffer labeled by the phase set it encoded — the honest granularity, since the fast path packs a layer's MoE flush into the next layer's buffer.
2. **Per-phase GPU split, probed not assumed**: where a device supports dispatch-boundary counter sampling, `phaseGpuSeconds` carries measured values (any unresolved sample voids the whole buffer's split). Apple GPUs sample timestamps only at encoder boundaries, so they report `unsupported(reason:)` with nil fields — never zeros that look real. The probe is functional: a real `MTLCounterSampleBuffer` pass runs and resolves at encoder boundaries on Apple silicon.
3. **`os_signpost` intervals** (`Swiftlet`/`MetalStep`) for step, each phase encode scope, and each command buffer's commit→completion span, pinned 1:1 to the published timeline by test.

Zero schedule change: the #20 baselines (11 command buffers/token, 212/214 and 218/220 dispatches) are still asserted unchanged, and conservation tests tie every timeline entry back to the aggregates.

## Validation

M4 Max, macOS 26.6.2: full suite green. Counter probe result on that device: `timestampSet=yes stage=yes(sample resolved) dispatch=no` → split honestly unsupported there; the supported arm carries a self-consistency test (per-phase sums ≈ per-buffer totals).
