### PR TITLE
fix: harden streamed request lifecycle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,9 @@ let package = Package(
             ]
         ),
         .testTarget(name: "SwiftletCoreTests", dependencies: ["SwiftletCore"]),
-        .testTarget(name: "SwiftletServerTests", dependencies: ["SwiftletServer"]),
+        .testTarget(
+            name: "SwiftletServerTests",
+            dependencies: ["SwiftletServer", "SwiftletCore"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -146,13 +146,16 @@ Swiftlet is a library first:
 
 1. **The Swift package.** Add SwiftletCore to any macOS or iOS app and use
    `SwiftletSession` for chat with streaming deltas, conversation caching,
-   sampling with repetition control, and memory-pressure handling built in.
+   sampling with repetition control, cooperative cancellation, and
+   memory-pressure handling built in.
 2. **The CLI.** `swiftlet chat` and `swiftlet generate` for local use and
    benchmarking, `swiftlet-repack` to build containers from MLX checkpoints
    (including streaming straight from Hugging Face with resume).
 3. **The server.** `swiftlet-server` speaks the OpenAI chat-completions API
    on loopback, so any chat UI that talks to OpenAI-compatible endpoints can
-   use a streamed local model.
+   use a streamed local model. It honors string/array `stop`, reports `stop`
+   versus `length`, and cancels queued or active generation when the client
+   disconnects.
 4. **An app.** [Priv AI](https://apps.apple.com/us/app/priv-ai/id6765706001)
    on iOS embeds SwiftletCore as its streamed-model engine. End users tap
    Download and chat. Nothing here is terminal-only. The app itself is open

--- a/Sources/SwiftletCore/GenerationControl.swift
+++ b/Sources/SwiftletCore/GenerationControl.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Cooperative cancellation shared by an embedding app, the loopback server,
+/// and the blocking model loop. Cancellation is observed only at model-safe
+/// boundaries: before/after a CPU step and between Metal token/layer command
+/// buffers. It never abandons a command buffer while GPU work is in flight.
+public final class GenerationCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    public init() {}
+
+    public func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    public var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+/// Why generation ended. `stop` covers model EOS and caller-supplied stop
+/// strings; `length` means the requested token budget was exhausted.
+public enum GenerationFinishReason: String, Sendable {
+    case stop
+    case length
+    case cancelled
+}
+
+/// Internal control-flow error used to unwind a partially processed prompt or
+/// token. Callers must discard the associated DecodeState when this is thrown.
+enum GenerationInterruption: Swift.Error {
+    case cancelled
+    case invalidTextStream
+}
+
+@inline(__always)
+func checkGenerationCancellation(_ shouldCancel: () -> Bool) throws {
+    if shouldCancel() { throw GenerationInterruption.cancelled }
+}

--- a/Sources/SwiftletCore/GenerationControl.swift
+++ b/Sources/SwiftletCore/GenerationControl.swift
@@ -31,9 +31,10 @@ public enum GenerationFinishReason: String, Sendable {
     case cancelled
 }
 
-/// Internal control-flow error used to unwind a partially processed prompt or
-/// token. Callers must discard the associated DecodeState when this is thrown.
-enum GenerationInterruption: Swift.Error {
+/// Control-flow error used to unwind a partially processed prompt or token.
+/// Public so API callers can tell a cooperative cancellation from a failure.
+/// Callers must discard the associated DecodeState when this is thrown.
+public enum GenerationInterruption: Swift.Error {
     case cancelled
     case invalidTextStream
 }

--- a/Sources/SwiftletCore/QwenCPUModel.swift
+++ b/Sources/SwiftletCore/QwenCPUModel.swift
@@ -236,6 +236,19 @@ public final class QwenCPUModel {
     /// the last position's logits. Used for prefill (many tokens) and decode
     /// (one token at a time).
     public func step(_ tokens: [Int], state: DecodeState) throws -> [Float] {
+        try step(tokens, state: state, shouldCancel: { false })
+    }
+
+    /// Cancellable incremental step. The reference path checks only between
+    /// complete decoder layers, where no BLAS operation is in flight. A
+    /// cancellation after an earlier layer may leave `state` partially
+    /// updated, so the caller must discard it (SwiftletSession does).
+    public func step(
+        _ tokens: [Int],
+        state: DecodeState,
+        shouldCancel: () -> Bool
+    ) throws -> [Float] {
+        try checkGenerationCancellation(shouldCancel)
         let cfg = config
         let S = tokens.count
         let D = cfg.hiddenSize
@@ -245,13 +258,18 @@ public final class QwenCPUModel {
             for i in 0..<D { h[s * D + i] = embed[t * D + i] }
         }
         for li in 0..<cfg.numHiddenLayers {
+            try checkGenerationCancellation(shouldCancel)
             h = try layerForward(h, S: S, layerIndex: li, state: state)
         }
+        try checkGenerationCancellation(shouldCancel)
         state.position += S
 
         var last = Array(h[(S - 1) * D..<S * D])
         Self.rmsNorm(&last, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
-        return Self.linear(last, rows: 1, inDim: D, weight: lmHead, outDim: cfg.vocabSize)
+        try checkGenerationCancellation(shouldCancel)
+        let logits = Self.linear(last, rows: 1, inDim: D, weight: lmHead, outDim: cfg.vocabSize)
+        try checkGenerationCancellation(shouldCancel)
+        return logits
     }
 
     /// One decoder layer: norm -> (DeltaNet | gated GQA) -> residual -> norm -> MoE -> residual.

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -430,6 +430,18 @@ public final class QwenMetalModel {
 
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+        try step(tokens, state: state, shouldCancel: { false })
+    }
+
+    /// Cancellable Metal step. Checks happen only while no command buffer is
+    /// in flight; a cancelled partial token is abandoned with its DecodeState.
+    /// Cancellation exits by throwing, so StepMetrics is published through the
+    /// same `defer` as any other failure with `completedWithoutThrow == false`.
+    public func step(
+        _ tokens: [Int],
+        state: QwenCPUModel.DecodeState,
+        shouldCancel: () -> Bool
+    ) throws -> [Float] {
         let counters = StepCounters()
         let wallStart = ProcessInfo.processInfo.systemUptime
         activeStepCounters = counters
@@ -455,11 +467,15 @@ public final class QwenMetalModel {
 
         var logits: [Float] = []
         for (index, t) in tokens.enumerated() {
+            try checkGenerationCancellation(shouldCancel)
             // S1a LM-head elision: a multi-token call consumes only the final
             // position's logits, so intermediate vocabulary projections are
             // unnecessary.
             let projectLogits = index == tokens.count - 1
-            logits = try stepOne(t, state: state, projectLogits: projectLogits)
+            logits = try stepOne(
+                t, state: state, projectLogits: projectLogits, shouldCancel: shouldCancel
+            )
+            try checkGenerationCancellation(shouldCancel)
             state.position += 1
             counters.tokensProcessed += 1
         }
@@ -468,10 +484,15 @@ public final class QwenMetalModel {
     }
 
     private func stepOne(
-        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool
+        _ token: Int,
+        state: QwenCPUModel.DecodeState,
+        projectLogits: Bool,
+        shouldCancel: () -> Bool
     ) throws -> [Float] {
         if sBuf != nil {
-            return try stepOneFast(token, state: state, projectLogits: projectLogits)
+            return try stepOneFast(
+                token, state: state, projectLogits: projectLogits, shouldCancel: shouldCancel
+            )
         }
         let cfg = config
         let D = cfg.hiddenSize
@@ -479,6 +500,7 @@ public final class QwenMetalModel {
         precondition(h.count == D)
 
         for li in 0..<cfg.numHiddenLayers {
+            try checkGenerationCancellation(shouldCancel)
             let layer = layers[li]
             var x = h
             QwenCPUModel.rmsNorm(&x, rows: 1, dim: D, weight: layer.inputNorm, eps: Float(cfg.rmsNormEps))
@@ -497,6 +519,7 @@ public final class QwenMetalModel {
             for i in 0..<D { h[i] += m[i] }
         }
 
+        try checkGenerationCancellation(shouldCancel)
         guard projectLogits else { return [] }
         QwenCPUModel.rmsNorm(&h, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
         loadX(h)
@@ -1000,7 +1023,10 @@ extension QwenMetalModel {
     }
 
     func stepOneFast(
-        _ token: Int, state: QwenCPUModel.DecodeState, projectLogits: Bool
+        _ token: Int,
+        state: QwenCPUModel.DecodeState,
+        projectLogits: Bool,
+        shouldCancel: () -> Bool = { false }
     ) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
@@ -1017,6 +1043,7 @@ extension QwenMetalModel {
         var pending: PendingMoE? = nil
 
         for li in 0..<cfg.numHiddenLayers {
+            try checkGenerationCancellation(shouldCancel)
             let L = layers[li]
             let fl = fastLayers[li]
 
@@ -1027,6 +1054,7 @@ extension QwenMetalModel {
                 try encDeltaLayer(enc, delta: delta, fl: fl, moeGate: L.moe.gate)
                 enc.endEncoding()
                 commitAndWait(cb)
+                try checkGenerationCancellation(shouldCancel)
             } else {
                 // Attention: projections, CPU core, then out-proj + router.
                 let cb1 = engine.queue.makeCommandBuffer()!
@@ -1040,6 +1068,7 @@ extension QwenMetalModel {
                 try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
                 e1.endEncoding()
                 commitAndWait(cb1)
+                try checkGenerationCancellation(shouldCancel)
 
                 let attnOut = attnCoreCPU(layerIndex: li, state: state, attn: attn)
                 writeS(reg.att, attnOut)
@@ -1060,11 +1089,13 @@ extension QwenMetalModel {
                 try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
                 e2.endEncoding()
                 commitAndWait(cb2)
+                try checkGenerationCancellation(shouldCancel)
             }
 
             let (picks, weights) = routerPicks()
             var bufs: [MTLBuffer] = []
             if let cache = expertCache {
+                try checkGenerationCancellation(shouldCancel)
                 bufs = try cache.buffers(layer: li, experts: picks.map { $0.0 })
             }
             pending = PendingMoE(bufs: bufs, weights: weights, stacksLayer: li, picks: picks)
@@ -1072,6 +1103,7 @@ extension QwenMetalModel {
 
         // Always apply the last layer's experts. Only the final token in a
         // multi-token call also needs final norm + vocabulary projection.
+        try checkGenerationCancellation(shouldCancel)
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         if let p = pending { try encodePendingMoE(enc, p) }
@@ -1089,6 +1121,7 @@ extension QwenMetalModel {
         }
         enc.endEncoding()
         commitAndWait(cb)
+        try checkGenerationCancellation(shouldCancel)
 
         guard projectLogits else { return [] }
         return Array(UnsafeBufferPointer(

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -475,9 +475,9 @@ public final class QwenMetalModel {
             logits = try stepOne(
                 t, state: state, projectLogits: projectLogits, shouldCancel: shouldCancel
             )
-            try checkGenerationCancellation(shouldCancel)
             state.position += 1
             counters.tokensProcessed += 1
+            try checkGenerationCancellation(shouldCancel)
         }
         counters.completedWithoutThrow = true
         return logits

--- a/Sources/SwiftletCore/StreamingText.swift
+++ b/Sources/SwiftletCore/StreamingText.swift
@@ -77,10 +77,14 @@ public struct StopSequenceFilter {
     private var stopped = false
 
     public init(stopSequences: [String]) {
-        var seen = Set<String>()
+        // Swift String equality is canonically equivalent, but stop matching
+        // is deliberately scalar-exact. Keep precomposed and decomposed forms
+        // as distinct entries so each can match its own wire representation.
+        var seen = Set<[Unicode.Scalar]>()
         stops = stopSequences.compactMap { text in
-            guard !text.isEmpty, seen.insert(text).inserted else { return nil }
-            return (text, Array(text.unicodeScalars))
+            let scalars = Array(text.unicodeScalars)
+            guard !scalars.isEmpty, seen.insert(scalars).inserted else { return nil }
+            return (text, scalars)
         }
     }
 
@@ -104,20 +108,7 @@ public struct StopSequenceFilter {
             return Update(delta: nil, matchedStop: nil, isConsistent: false)
         }
 
-        var earliest: (index: Int, stop: (text: String, scalars: [Unicode.Scalar]))?
-        if !stops.isEmpty {
-            for index in emitted.count...stable.count {
-                for stop in stops where index + stop.scalars.count <= stable.count {
-                    if stable[index..<(index + stop.scalars.count)].elementsEqual(stop.scalars) {
-                        earliest = (index, stop)
-                        break
-                    }
-                }
-                if earliest != nil { break }
-            }
-        }
-
-        if let match = earliest {
+        if let match = earliestMatch(in: stable) {
             let delta = append(stable[emitted.count..<match.index])
             stopped = true
             return Update(delta: delta, matchedStop: match.stop.text, isConsistent: true)
@@ -146,12 +137,47 @@ public struct StopSequenceFilter {
     }
 
     /// Releases a non-matching held prefix when EOS or the length limit ends
-    /// the turn. It is deliberately not called for cancellation or a match.
+    /// the turn. For callers that also need to distinguish a final raw-text
+    /// stop match, use `finishUpdate(decoded:)`.
     public mutating func finish(decoded: String) -> String? {
-        guard !stopped else { return nil }
+        finishUpdate(decoded: decoded).delta
+    }
+
+    /// Finalizes against the raw scalar stream. Unlike `consume`, this does
+    /// not trim a trailing U+FFFD: at EOS/length it can no longer complete, and
+    /// it may itself complete a caller-supplied stop sequence.
+    public mutating func finishUpdate(decoded: String) -> Update {
+        guard !stopped else {
+            return Update(delta: nil, matchedStop: nil, isConsistent: true)
+        }
         let scalars = Array(decoded.unicodeScalars)
-        guard scalars.starts(with: emitted) else { return nil }
-        return append(scalars[emitted.count..<scalars.count])
+        guard scalars.starts(with: emitted) else {
+            return Update(delta: nil, matchedStop: nil, isConsistent: false)
+        }
+        if let match = earliestMatch(in: scalars) {
+            let delta = append(scalars[emitted.count..<match.index])
+            stopped = true
+            return Update(delta: delta, matchedStop: match.stop.text, isConsistent: true)
+        }
+        return Update(
+            delta: append(scalars[emitted.count..<scalars.count]),
+            matchedStop: nil,
+            isConsistent: true
+        )
+    }
+
+    private func earliestMatch(
+        in scalars: [Unicode.Scalar]
+    ) -> (index: Int, stop: (text: String, scalars: [Unicode.Scalar]))? {
+        guard !stops.isEmpty else { return nil }
+        for index in emitted.count...scalars.count {
+            for stop in stops where index + stop.scalars.count <= scalars.count {
+                if scalars[index..<(index + stop.scalars.count)].elementsEqual(stop.scalars) {
+                    return (index, stop)
+                }
+            }
+        }
+        return nil
     }
 
     private mutating func append<C: Collection>(_ scalars: C) -> String?

--- a/Sources/SwiftletCore/StreamingText.swift
+++ b/Sources/SwiftletCore/StreamingText.swift
@@ -53,3 +53,112 @@ public enum StreamingText {
         return String(String.UnicodeScalarView(decodedScalars[printedScalars.count...]))
     }
 }
+
+/// Incremental text-stop filtering for a cumulatively decoded token stream.
+///
+/// A suffix that could still become a stop string is held back instead of
+/// being sent to the caller. This is what lets `"END"` match when `"E"`,
+/// `"N"`, and `"D"` arrive in separate tokens without leaking `"EN"` first.
+/// Matching and slicing use Unicode scalars for the same reason StreamingText
+/// does: a later token may extend a previously complete grapheme cluster.
+public struct StopSequenceFilter {
+    public struct Update: Sendable {
+        public let delta: String?
+        public let matchedStop: String?
+        /// False only when cumulative tokenizer output no longer has the text
+        /// already exposed to the caller as a Unicode-scalar prefix.
+        public let isConsistent: Bool
+
+        public var didStop: Bool { matchedStop != nil }
+    }
+
+    private let stops: [(text: String, scalars: [Unicode.Scalar])]
+    private var emitted: [Unicode.Scalar] = []
+    private var stopped = false
+
+    public init(stopSequences: [String]) {
+        var seen = Set<String>()
+        stops = stopSequences.compactMap { text in
+            guard !text.isEmpty, seen.insert(text).inserted else { return nil }
+            return (text, Array(text.unicodeScalars))
+        }
+    }
+
+    /// Text released to the caller so far. If a stop matched, this excludes
+    /// both the stop itself and any text decoded after it in the same token.
+    public var output: String {
+        String(String.UnicodeScalarView(emitted))
+    }
+
+    /// Consumes the tokenizer's full cumulative decode for the current token.
+    public mutating func consume(decoded: String) -> Update {
+        guard !stopped else {
+            return Update(delta: nil, matchedStop: nil, isConsistent: true)
+        }
+        let stable = Array(StreamingText.stablePrefix(decoded).unicodeScalars)
+
+        // Tokenizer output is expected to grow by scalar prefix. If a custom
+        // tokenizer violates that contract, fail closed instead of duplicating
+        // or emitting text from an ambiguous offset.
+        guard stable.starts(with: emitted) else {
+            return Update(delta: nil, matchedStop: nil, isConsistent: false)
+        }
+
+        var earliest: (index: Int, stop: (text: String, scalars: [Unicode.Scalar]))?
+        if !stops.isEmpty {
+            for index in emitted.count...stable.count {
+                for stop in stops where index + stop.scalars.count <= stable.count {
+                    if stable[index..<(index + stop.scalars.count)].elementsEqual(stop.scalars) {
+                        earliest = (index, stop)
+                        break
+                    }
+                }
+                if earliest != nil { break }
+            }
+        }
+
+        if let match = earliest {
+            let delta = append(stable[emitted.count..<match.index])
+            stopped = true
+            return Update(delta: delta, matchedStop: match.stop.text, isConsistent: true)
+        }
+
+        // Hold the longest suffix that is a proper prefix of any stop. A full
+        // stop was handled above, so limiting to count-1 is sufficient.
+        let uncommittedCount = stable.count - emitted.count
+        var hold = 0
+        for stop in stops where stop.scalars.count > 1 {
+            let limit = min(stop.scalars.count - 1, uncommittedCount)
+            guard limit > hold else { continue }
+            for count in stride(from: limit, through: hold + 1, by: -1) {
+                if stable.suffix(count).elementsEqual(stop.scalars.prefix(count)) {
+                    hold = count
+                    break
+                }
+            }
+        }
+        let safeEnd = stable.count - hold
+        return Update(
+            delta: append(stable[emitted.count..<safeEnd]),
+            matchedStop: nil,
+            isConsistent: true
+        )
+    }
+
+    /// Releases a non-matching held prefix when EOS or the length limit ends
+    /// the turn. It is deliberately not called for cancellation or a match.
+    public mutating func finish(decoded: String) -> String? {
+        guard !stopped else { return nil }
+        let scalars = Array(decoded.unicodeScalars)
+        guard scalars.starts(with: emitted) else { return nil }
+        return append(scalars[emitted.count..<scalars.count])
+    }
+
+    private mutating func append<C: Collection>(_ scalars: C) -> String?
+    where C.Element == Unicode.Scalar {
+        guard !scalars.isEmpty else { return nil }
+        let delta = String(String.UnicodeScalarView(Array(scalars)))
+        emitted.append(contentsOf: scalars)
+        return delta
+    }
+}

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -458,14 +458,26 @@ public final class SwiftletSession: @unchecked Sendable {
                     }
 
                     if control.isCancelled { finishReason = .cancelled }
-                    // On EOS/length, release a non-matching potential stop
-                    // prefix and any final U+FFFD. A matched stop and a
-                    // cancelled turn deliberately release nothing further.
-                    if finishReason != .cancelled, !matchedTextStop,
-                       let rest = stopFilter.finish(
+                    // On EOS/length, inspect the final raw scalar stream before
+                    // releasing held text. This both flushes a non-matching
+                    // prefix/U+FFFD and catches a stop that itself ends in the
+                    // now-terminal U+FFFD. Cancellation and prior matches do
+                    // not release anything further.
+                    if finishReason != .cancelled, !matchedTextStop {
+                        let finalUpdate = stopFilter.finishUpdate(
                             decoded: self.tokenizer.decode(tokens: generated)
-                       ), case .terminated = continuation.yield(rest) {
-                        finishReason = .cancelled
+                        )
+                        guard finalUpdate.isConsistent else {
+                            throw GenerationInterruption.invalidTextStream
+                        }
+                        if finalUpdate.didStop {
+                            matchedTextStop = true
+                            finishReason = .stop
+                        }
+                        if let rest = finalUpdate.delta,
+                           case .terminated = continuation.yield(rest) {
+                            finishReason = .cancelled
+                        }
                     }
                     // Cancellation can race the final EOS/length flush. Make
                     // the reuse decision only after one last observation so a

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -176,9 +176,16 @@ public final class SwiftletSession: @unchecked Sendable {
     private var statePrimed = false
 
     /// Drops the cached conversation (e.g. when the user starts a new chat).
-    /// A reset requested during generation is ordered after that request so
-    /// it cannot replace DecodeState while the model is using it.
+    /// A generation in flight is cancelled first, then the reset is ordered
+    /// behind it on the generation queue so it cannot replace DecodeState while
+    /// the model is using it. The caller therefore waits for at most one
+    /// model-safe boundary (a CPU step or Metal command buffer), not for the
+    /// remainder of the interrupted reply.
     public func resetConversation() {
+        genLock.lock()
+        let active = activeControl
+        genLock.unlock()
+        active?.cancel()
         generationQueue.sync {
             resetConversationState()
         }
@@ -198,6 +205,17 @@ public final class SwiftletSession: @unchecked Sendable {
     // replies whenever a memory warning landed mid-generation). The warning
     // handler only sets a flag; the decode thread applies it between tokens.
     private let genLock = NSLock()
+
+    /// Cancellation owner of the request currently executing on
+    /// `generationQueue`, so `resetConversation()` can interrupt it instead of
+    /// waiting for it to run to completion. Guarded by `genLock`.
+    private var activeControl: GenerationCancellation?
+
+    private func setActiveControl(_ control: GenerationCancellation?) {
+        genLock.lock()
+        activeControl = control
+        genLock.unlock()
+    }
     private var generationActive = false
     private var pendingShrinkGB: Double?
     /// Conversation state and the underlying model are both mutable. This is
@@ -415,8 +433,10 @@ public final class SwiftletSession: @unchecked Sendable {
             }
             self.generationQueue.async {
                 self.beginGeneration()
+                self.setActiveControl(control)
                 var terminalError: Swift.Error?
                 defer {
+                    self.setActiveControl(nil)
                     self.endGeneration()
                     if let terminalError {
                         continuation.finish(throwing: terminalError)

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -64,7 +64,10 @@ public final class SwiftletSession: @unchecked Sendable {
     public let config: QwenConfig
     private let model: any InferenceModel
     private let generator: TextGenerator
-    private let tokenizer: Tokenizer
+    private let encodeText: (String) -> [Int]
+    private let decodeTokens: ([Int]) -> String
+    private let renderMessages: ([[String: String]]) throws -> [Int]
+    private let generationCleanupHook: (() -> Void)?
     private let metricsLock = NSLock()
     private var _lastMetrics = Metrics()
     /// True when running on the Metal engine (vs the CPU reference fallback).
@@ -82,7 +85,11 @@ public final class SwiftletSession: @unchecked Sendable {
     public init(modelDir: URL, retainAllLayers: Bool = false, cacheBudgetGB: Double = 2) async throws {
         self.modelDir = modelDir
         print("[SwiftletSession] loading tokenizer...")
-        tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        let tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        encodeText = { tokenizer.encode(text: $0) }
+        decodeTokens = { tokenizer.decode(tokens: $0) }
+        renderMessages = { try tokenizer.applyChatTemplate(messages: $0) }
+        generationCleanupHook = nil
         print("[SwiftletSession] tokenizer ok; building Metal model...")
         if let gpu = try? QwenMetalModel(modelDir: modelDir, cacheBudgetGB: cacheBudgetGB) {
             model = gpu
@@ -128,6 +135,31 @@ public final class SwiftletSession: @unchecked Sendable {
             && Array(probe.suffix(thinkOpen.count)) == thinkOpen
     }
 
+    /// Dependency-injected construction for deterministic session-boundary
+    /// tests. Production callers use the async model/tokenizer initializer.
+    init(
+        testingModel model: any InferenceModel,
+        modelDir: URL,
+        encodeText: @escaping (String) -> [Int],
+        decodeTokens: @escaping ([Int]) -> String,
+        renderMessages: @escaping ([[String: String]]) throws -> [Int],
+        suppressedIds: Set<Int> = [],
+        usesThinkPrompt: Bool = false,
+        generationCleanupHook: (() -> Void)? = nil
+    ) {
+        self.modelDir = modelDir
+        self.model = model
+        self.config = model.config
+        self.generator = TextGenerator(model: model)
+        self.usesGPU = model is QwenMetalModel
+        self.encodeText = encodeText
+        self.decodeTokens = decodeTokens
+        self.renderMessages = renderMessages
+        self.suppressedIds = suppressedIds
+        self.usesThinkPrompt = usesThinkPrompt
+        self.generationCleanupHook = generationCleanupHook
+    }
+
     private let suppressedIds: Set<Int>
     private let usesThinkPrompt: Bool
 
@@ -144,7 +176,16 @@ public final class SwiftletSession: @unchecked Sendable {
     private var statePrimed = false
 
     /// Drops the cached conversation (e.g. when the user starts a new chat).
+    /// A reset requested during generation is ordered after that request so
+    /// it cannot replace DecodeState while the model is using it.
     public func resetConversation() {
+        generationQueue.sync {
+            resetConversationState()
+        }
+    }
+
+    /// The queue-confined form used by streamChat itself.
+    private func resetConversationState() {
         convState = QwenCPUModel.DecodeState()
         lastMessages = []
         lastReplyText = ""
@@ -159,6 +200,11 @@ public final class SwiftletSession: @unchecked Sendable {
     private let genLock = NSLock()
     private var generationActive = false
     private var pendingShrinkGB: Double?
+    /// Conversation state and the underlying model are both mutable. This is
+    /// the session's single-flight boundary for every public streamChat call.
+    private let generationQueue = DispatchQueue(
+        label: "swiftlet.session.generation", qos: .userInitiated
+    )
 
     /// Frees most of the expert cache in response to OS memory pressure; it
     /// refills lazily as generation continues. Safe to call from any thread.
@@ -188,6 +234,34 @@ public final class SwiftletSession: @unchecked Sendable {
         }
     }
 
+    private func beginGeneration() {
+        genLock.lock()
+        generationActive = true
+        genLock.unlock()
+    }
+
+    /// Completes all shared lifecycle cleanup before the stream continuation
+    /// is finished. Otherwise a waiting consumer can enqueue the next request
+    /// while the preceding request still advertises stale active/shrink state.
+    private func endGeneration() {
+        // Keep advertising an active generation until every deferred shrink
+        // has drained. A warning racing one shrink therefore queues another
+        // pass instead of invoking shrinkCache concurrently.
+        while true {
+            genLock.lock()
+            guard let gb = pendingShrinkGB else {
+                generationActive = false
+                genLock.unlock()
+                break
+            }
+            pendingShrinkGB = nil
+            genLock.unlock()
+            (model as? QwenMetalModel)?.shrinkCache(toGB: gb)
+            print("[SwiftletSession] deferred cache shrink applied")
+        }
+        generationCleanupHook?()
+    }
+
     /// Full prompt for a fresh conversation, with reasoning disabled: the
     /// Qwen3.6 template ends the generation prompt with "<think>\n", which
     /// makes the model reason in the open — and since the literal <think>
@@ -195,13 +269,13 @@ public final class SwiftletSession: @unchecked Sendable {
     /// Appending the rest of an empty think block reproduces the template's
     /// own enable_thinking=false rendering byte for byte.
     private func freshPromptIds(_ messages: [[String: String]]) throws -> [Int] {
-        var ids = try tokenizer.applyChatTemplate(messages: messages)
+        var ids = try renderMessages(messages)
         // Compare token ids, not decoded text — decode can normalize or skip
         // special tokens and silently defeat a string comparison.
         if usesThinkPrompt {
-            let thinkOpen = tokenizer.encode(text: "<think>\n")
+            let thinkOpen = encodeText("<think>\n")
             if ids.count >= thinkOpen.count, Array(ids.suffix(thinkOpen.count)) == thinkOpen {
-                ids += tokenizer.encode(text: "\n</think>\n\n")
+                ids += encodeText("\n</think>\n\n")
             }
         }
         return ids
@@ -229,7 +303,7 @@ public final class SwiftletSession: @unchecked Sendable {
         let turn = "<|im_end|>\n<|im_start|>user\n" + (newUser["content"] ?? "")
             + "<|im_end|>\n<|im_start|>assistant\n"
             + (usesThinkPrompt ? "<think>\n\n</think>\n\n" : "")
-        return tokenizer.encode(text: turn)
+        return encodeText(turn)
     }
 
     /// Drops the replacement characters an incomplete trailing multi-byte
@@ -339,15 +413,16 @@ public final class SwiftletSession: @unchecked Sendable {
             continuation.onTermination = { termination in
                 if case .cancelled = termination { control.cancel() }
             }
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.genLock.lock()
-                self.generationActive = true
-                self.genLock.unlock()
+            self.generationQueue.async {
+                self.beginGeneration()
+                var terminalError: Swift.Error?
                 defer {
-                    self.genLock.lock()
-                    self.generationActive = false
-                    self.genLock.unlock()
-                    self.applyPendingShrink()
+                    self.endGeneration()
+                    if let terminalError {
+                        continuation.finish(throwing: terminalError)
+                    } else {
+                        continuation.finish()
+                    }
                 }
                 do {
                     // A server request can be cancelled while waiting behind
@@ -357,7 +432,6 @@ public final class SwiftletSession: @unchecked Sendable {
                     // the preceding request.
                     if control.isCancelled {
                         self.storeMetrics(Metrics(finishReason: .cancelled))
-                        continuation.finish()
                         return
                     }
 
@@ -365,7 +439,7 @@ public final class SwiftletSession: @unchecked Sendable {
                     if let delta = self.continuationIds(messages) {
                         suffix = delta
                     } else {
-                        self.resetConversation()
+                        self.resetConversationState()
                         suffix = try self.freshPromptIds(messages)
                     }
 
@@ -426,7 +500,7 @@ public final class SwiftletSession: @unchecked Sendable {
                             // token boundaries. The filter also owns the UTF-8
                             // and potential-stop-prefix hold-back.
                             let update = stopFilter.consume(
-                                decoded: self.tokenizer.decode(tokens: generated)
+                                decoded: self.decodeTokens(generated)
                             )
                             guard update.isConsistent else {
                                 throw GenerationInterruption.invalidTextStream
@@ -465,7 +539,7 @@ public final class SwiftletSession: @unchecked Sendable {
                     // not release anything further.
                     if finishReason != .cancelled, !matchedTextStop {
                         let finalUpdate = stopFilter.finishUpdate(
-                            decoded: self.tokenizer.decode(tokens: generated)
+                            decoded: self.decodeTokens(generated)
                         )
                         guard finalUpdate.isConsistent else {
                             throw GenerationInterruption.invalidTextStream
@@ -499,7 +573,7 @@ public final class SwiftletSession: @unchecked Sendable {
                         self.lastReplyText = stopFilter.output
                         self.statePrimed = true
                     } else {
-                        self.resetConversation()
+                        self.resetConversationState()
                     }
 
                     self.storeMetrics(Metrics(
@@ -509,10 +583,9 @@ public final class SwiftletSession: @unchecked Sendable {
                         tokensPerSecond: decodeSeconds > 0 ? Double(generated.count) / decodeSeconds : 0,
                         finishReason: finishReason
                     ))
-                    continuation.finish()
                 } catch {
-                    self.resetConversation()
-                    continuation.finish(throwing: error)
+                    self.resetConversationState()
+                    terminalError = error
                 }
             }
         }

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -10,6 +10,7 @@ public final class SwiftletSession: @unchecked Sendable {
         public var generatedTokens = 0
         public var timeToFirstToken: TimeInterval = 0
         public var tokensPerSecond: Double = 0
+        public var finishReason: GenerationFinishReason?
     }
 
     /// Sampling settings. Defaults follow Qwen's recommendation for
@@ -37,6 +38,10 @@ public final class SwiftletSession: @unchecked Sendable {
         /// a "be concise" system prompt put real probability on stopping after
         /// 1-2 tokens ("I can" <eos>); a minimum length makes that impossible.
         public var minNew: Int = 8
+        /// Text sequences that end generation without being emitted. Potential
+        /// prefixes are held across token boundaries, so split stop strings do
+        /// not leak into a streamed response.
+        public var stopSequences: [String] = []
         public init() {}
         public static var greedy: GenerationOptions {
             var o = GenerationOptions()
@@ -321,13 +326,19 @@ public final class SwiftletSession: @unchecked Sendable {
     /// Applies the model's chat template to `messages` (role/content pairs,
     /// e.g. [["role": "user", "content": "hi"]]) and streams generated text
     /// deltas. Reasoning is disabled; the reply is the answer directly.
-    /// Cancelling the consuming task stops generation.
+    /// Cancelling the consuming task, or the optional cancellation owner,
+    /// stops generation at the next model-safe boundary.
     public func streamChat(
         messages: [[String: String]],
         maxNew: Int = 1024,
-        options: GenerationOptions = GenerationOptions()
+        options: GenerationOptions = GenerationOptions(),
+        cancellation: GenerationCancellation? = nil
     ) -> AsyncThrowingStream<String, Swift.Error> {
         AsyncThrowingStream { continuation in
+            let control = cancellation ?? GenerationCancellation()
+            continuation.onTermination = { termination in
+                if case .cancelled = termination { control.cancel() }
+            }
             DispatchQueue.global(qos: .userInitiated).async {
                 self.genLock.lock()
                 self.generationActive = true
@@ -339,6 +350,17 @@ public final class SwiftletSession: @unchecked Sendable {
                     self.applyPendingShrink()
                 }
                 do {
+                    // A server request can be cancelled while waiting behind
+                    // another request on the serial generation queue. Observe
+                    // that before consulting or mutating conversation state,
+                    // and report a fresh result instead of stale metrics from
+                    // the preceding request.
+                    if control.isCancelled {
+                        self.storeMetrics(Metrics(finishReason: .cancelled))
+                        continuation.finish()
+                        return
+                    }
+
                     let suffix: [Int]
                     if let delta = self.continuationIds(messages) {
                         suffix = delta
@@ -351,94 +373,130 @@ public final class SwiftletSession: @unchecked Sendable {
                     var firstTokenAt: Date?
                     var generated: [Int] = []
                     var generatedCounts: [Int: Int] = [:]
-                    var printed = ""
-                    var cleanEnd = false
-
-                    var logits = try self.model.step(suffix, state: self.convState)
-                    let prefillDone = Date()
-
+                    var stopFilter = StopSequenceFilter(stopSequences: options.stopSequences)
+                    var matchedTextStop = false
+                    var prefillDone = start
                     var decodeSeconds = 0.0
-                    var stopReason = "maxNew"
-                    for _ in 0..<maxNew {
-                        self.applyPendingShrink()
-                        // EOS is legal when the reply reads finished (ends at
-                        // a sentence or line break; a stop after "are:"
-                        // mid-list is never valid) OR when EOS is the model's
-                        // top choice outright: a model that strongly wants to
-                        // stop knows the reply is done even after ")" or a
-                        // quote, and forcing it past its stop just makes it
-                        // emit junk. The 300-token escape keeps a
-                        // punctuation-averse reply from running to maxNew.
-                        let tail = printed.hasSuffix("\n") || {
-                            guard let last = printed.trimmingCharacters(in: .whitespacesAndNewlines).last
-                            else { return false }
-                            return ".!?。！？".contains(last)
-                        }()
-                        let eosIsTop = { () -> Bool in
-                            let vocab = min(self.config.vocabSize, logits.count)
-                            var best = 0
-                            for v in 1..<vocab where logits[v] > logits[best] { best = v }
-                            return self.generator.eosTokens.contains(best)
-                        }()
-                        let eosAllowed = generated.count >= options.minNew
-                            && (tail || eosIsTop || generated.count >= 300)
-                        let best = self.sample(logits, options: options, generated: generated,
-                                               seen: generatedCounts, banEOS: !eosAllowed)
-                        if self.generator.eosTokens.contains(best) {
-                            cleanEnd = true
-                            stopReason = "eos"
-                            break
+                    var finishReason = GenerationFinishReason.length
+
+                    do {
+                        var logits = try self.model.step(
+                            suffix, state: self.convState,
+                            shouldCancel: { control.isCancelled }
+                        )
+                        prefillDone = Date()
+
+                        for _ in 0..<max(0, maxNew) {
+                            try checkGenerationCancellation { control.isCancelled }
+                            self.applyPendingShrink()
+                            try checkGenerationCancellation { control.isCancelled }
+                            // EOS is legal when the reply reads finished (ends
+                            // at a sentence or line break) OR EOS is the model's
+                            // top choice outright. `stopFilter.output` is only
+                            // text already safe to expose; a possible stop
+                            // prefix must not influence this punctuation gate.
+                            let visible = stopFilter.output
+                            let tail = visible.hasSuffix("\n") || {
+                                guard let last = visible.trimmingCharacters(in: .whitespacesAndNewlines).last
+                                else { return false }
+                                return ".!?。！？".contains(last)
+                            }()
+                            let eosIsTop = { () -> Bool in
+                                let vocab = min(self.config.vocabSize, logits.count)
+                                var best = 0
+                                for v in 1..<vocab where logits[v] > logits[best] { best = v }
+                                return self.generator.eosTokens.contains(best)
+                            }()
+                            let eosAllowed = generated.count >= options.minNew
+                                && (tail || eosIsTop || generated.count >= 300)
+                            let best = self.sample(
+                                logits, options: options, generated: generated,
+                                seen: generatedCounts, banEOS: !eosAllowed
+                            )
+                            if self.generator.eosTokens.contains(best) {
+                                finishReason = .stop
+                                break
+                            }
+
+                            if firstTokenAt == nil { firstTokenAt = Date() }
+                            generated.append(best)
+                            generatedCounts[best, default: 0] += 1
+
+                            // Decode cumulatively so a stop can cross arbitrary
+                            // token boundaries. The filter also owns the UTF-8
+                            // and potential-stop-prefix hold-back.
+                            let update = stopFilter.consume(
+                                decoded: self.tokenizer.decode(tokens: generated)
+                            )
+                            guard update.isConsistent else {
+                                throw GenerationInterruption.invalidTextStream
+                            }
+                            try checkGenerationCancellation { control.isCancelled }
+                            if let delta = update.delta,
+                               case .terminated = continuation.yield(delta) {
+                                control.cancel()
+                            }
+                            if control.isCancelled {
+                                finishReason = .cancelled
+                                break
+                            }
+                            if update.didStop {
+                                matchedTextStop = true
+                                finishReason = .stop
+                                break
+                            }
+
+                            let t0 = Date()
+                            logits = try self.model.step(
+                                [best], state: self.convState,
+                                shouldCancel: { control.isCancelled }
+                            )
+                            decodeSeconds += -t0.timeIntervalSinceNow
                         }
-                        if firstTokenAt == nil { firstTokenAt = Date() }
-                        generated.append(best)
-                        generatedCounts[best, default: 0] += 1
-                        // StreamingText.delta owns the hold-back: a byte-split
-                        // multi-byte character decodes with a trailing U+FFFD,
-                        // and a later token can extend an already-decoded
-                        // character with a variation selector or ZWJ. Either
-                        // one desyncs a naive prefix check and silences the
-                        // rest of the turn (issues #9 and #15). Pass the raw
-                        // decode so the trim and the scalar-level prefix run
-                        // once, in one place, not stacked with a second trim.
-                        let text = self.tokenizer.decode(tokens: generated)
-                        var terminated = false
-                        if let (delta, newPrinted) = StreamingText.delta(printed: printed, decoded: text) {
-                            if case .terminated = continuation.yield(delta) { terminated = true }
-                            printed = newPrinted
-                        }
-                        let t0 = Date()
-                        logits = try self.model.step([best], state: self.convState)
-                        decodeSeconds += -t0.timeIntervalSinceNow
-                        if terminated { cleanEnd = true; stopReason = "consumer-cancelled"; break }
-                    }
-                    // Flush whatever the hold-back logic still owes (a
-                    // character completed by the last token, or a genuinely
-                    // unfinishable U+FFFD when EOS cut an emoji short).
-                    if let rest = StreamingText.finalDelta(
-                        printed: printed, decoded: self.tokenizer.decode(tokens: generated)
-                    ) {
-                        continuation.yield(rest)
-                    }
-                    print("[SwiftletSession] stop: \(stopReason) after \(generated.count) tokens")
-                    if !cleanEnd {
-                        // Hit maxNew: state still matches the generated text,
-                        // so the conversation remains continuable.
-                        cleanEnd = true
+                    } catch GenerationInterruption.cancelled {
+                        finishReason = .cancelled
                     }
 
-                    self.lastMessages = messages
-                    self.lastReplyText = Self.trimIncompleteUTF8(
-                        self.tokenizer.decode(tokens: generated))
-                    self.statePrimed = cleanEnd && !generated.isEmpty
+                    if control.isCancelled { finishReason = .cancelled }
+                    // On EOS/length, release a non-matching potential stop
+                    // prefix and any final U+FFFD. A matched stop and a
+                    // cancelled turn deliberately release nothing further.
+                    if finishReason != .cancelled, !matchedTextStop,
+                       let rest = stopFilter.finish(
+                            decoded: self.tokenizer.decode(tokens: generated)
+                       ), case .terminated = continuation.yield(rest) {
+                        finishReason = .cancelled
+                    }
+                    // Cancellation can race the final EOS/length flush. Make
+                    // the reuse decision only after one last observation so a
+                    // turn cancelled during delivery cannot prime mismatched
+                    // conversation state. Cancellation after this check is
+                    // linearized as occurring after generation completed.
+                    if control.isCancelled { finishReason = .cancelled }
+                    print("[SwiftletSession] stop: \(finishReason.rawValue) after \(generated.count) tokens")
 
-                    self.metricsLock.lock()
-                    self._lastMetrics = Metrics(
+                    // EOS and length end with state exactly matching the text
+                    // exposed to the caller. An arbitrary text stop may span
+                    // already-fed token pieces, and cancellation can interrupt
+                    // a prompt/token partway through, so neither is reusable
+                    // without a real DecodeState snapshot/rollback facility.
+                    let reusable = finishReason != .cancelled
+                        && !matchedTextStop && !generated.isEmpty
+                    if reusable {
+                        self.lastMessages = messages
+                        self.lastReplyText = stopFilter.output
+                        self.statePrimed = true
+                    } else {
+                        self.resetConversation()
+                    }
+
+                    self.storeMetrics(Metrics(
                         promptTokens: suffix.count,
                         generatedTokens: generated.count,
                         timeToFirstToken: (firstTokenAt ?? prefillDone).timeIntervalSince(start),
-                        tokensPerSecond: decodeSeconds > 0 ? Double(generated.count) / decodeSeconds : 0
-                    )
-                    self.metricsLock.unlock()
+                        tokensPerSecond: decodeSeconds > 0 ? Double(generated.count) / decodeSeconds : 0,
+                        finishReason: finishReason
+                    ))
                     continuation.finish()
                 } catch {
                     self.resetConversation()
@@ -446,5 +504,11 @@ public final class SwiftletSession: @unchecked Sendable {
                 }
             }
         }
+    }
+
+    private func storeMetrics(_ metrics: Metrics) {
+        metricsLock.lock()
+        _lastMetrics = metrics
+        metricsLock.unlock()
     }
 }

--- a/Sources/SwiftletCore/TextGenerator.swift
+++ b/Sources/SwiftletCore/TextGenerator.swift
@@ -68,26 +68,48 @@ public final class TextGenerator {
     /// Token-id stream over `generate`, in the `AsyncStream` shape iOS chat
     /// UIs consume (Priv AI's engines all expose `-> AsyncStream`). Runs the
     /// blocking decode loop on a utility queue; cancelling the consuming task
-    /// stops generation at the next token.
+    /// stops prefill/decode at the next model-safe boundary.
     public func tokenStream(promptIds: [Int], maxNew: Int) -> AsyncThrowingStream<Int, Swift.Error> {
+        tokenStream(
+            promptIds: promptIds,
+            maxNew: maxNew,
+            cancellation: GenerationCancellation()
+        )
+    }
+
+    /// Token stream with an explicit cancellation owner for embedding clients
+    /// that need to cancel independently of the consuming Task.
+    public func tokenStream(
+        promptIds: [Int],
+        maxNew: Int,
+        cancellation: GenerationCancellation
+    ) -> AsyncThrowingStream<Int, Swift.Error> {
         AsyncThrowingStream { continuation in
             let work = DispatchWorkItem {
                 do {
-                    var cancelled = false
-                    try self.generate(promptIds: promptIds, maxNew: maxNew) { token in
+                    try self.generate(
+                        promptIds: promptIds,
+                        maxNew: maxNew,
+                        cancellation: cancellation
+                    ) { token in
                         if case .terminated = continuation.yield(token) {
-                            cancelled = true
+                            cancellation.cancel()
                             return false
                         }
                         return true
                     }
-                    _ = cancelled
+                    continuation.finish()
+                } catch GenerationInterruption.cancelled {
+                    // Task/owner cancellation is normal stream termination;
+                    // the local DecodeState dies with this work item.
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { _ in }
+            continuation.onTermination = { termination in
+                if case .cancelled = termination { cancellation.cancel() }
+            }
             DispatchQueue.global(qos: .userInitiated).async(execute: work)
         }
     }
@@ -97,22 +119,48 @@ public final class TextGenerator {
     /// consumed as a stop signal and not reported.
     @discardableResult
     public func generate(promptIds: [Int], maxNew: Int, onToken: (Int) -> Bool) throws -> Stats {
+        try generate(
+            promptIds: promptIds,
+            maxNew: maxNew,
+            cancellation: GenerationCancellation(),
+            onToken: onToken
+        )
+    }
+
+    /// Cancellable form of `generate`. Any cancellation error invalidates the
+    /// method-local DecodeState, which is discarded while unwinding.
+    @discardableResult
+    public func generate(
+        promptIds: [Int],
+        maxNew: Int,
+        cancellation: GenerationCancellation,
+        onToken: (Int) -> Bool
+    ) throws -> Stats {
         var stats = Stats()
         stats.promptTokens = promptIds.count
         let state = QwenCPUModel.DecodeState()
 
         let prefillStart = Date()
-        var logits = try model.step(promptIds, state: state)
+        var logits = try model.step(
+            promptIds,
+            state: state,
+            shouldCancel: { cancellation.isCancelled }
+        )
         stats.prefillSeconds = -prefillStart.timeIntervalSinceNow
 
         let decodeStart = Date()
-        for _ in 0..<maxNew {
+        for _ in 0..<max(0, maxNew) {
+            try checkGenerationCancellation { cancellation.isCancelled }
             var best = 0
             for v in 1..<model.config.vocabSize where logits[v] > logits[best] { best = v }
             if eosTokens.contains(best) { break }
             stats.generatedTokens += 1
             if !onToken(best) { break }
-            logits = try model.step([best], state: state)
+            logits = try model.step(
+                [best],
+                state: state,
+                shouldCancel: { cancellation.isCancelled }
+            )
         }
         stats.decodeSeconds = -decodeStart.timeIntervalSinceNow
         return stats

--- a/Sources/SwiftletCore/TextGenerator.swift
+++ b/Sources/SwiftletCore/TextGenerator.swift
@@ -5,6 +5,27 @@ public protocol InferenceModel: AnyObject {
     var config: QwenConfig { get }
     var modelDir: URL { get }
     func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float]
+    func step(
+        _ tokens: [Int],
+        state: QwenCPUModel.DecodeState,
+        shouldCancel: () -> Bool
+    ) throws -> [Float]
+}
+
+public extension InferenceModel {
+    /// CPU/reference fallback: the batched step is atomic from the caller's
+    /// perspective, so cancellation is checked immediately before and after.
+    /// Metal supplies a finer-grained implementation between command buffers.
+    func step(
+        _ tokens: [Int],
+        state: QwenCPUModel.DecodeState,
+        shouldCancel: () -> Bool
+    ) throws -> [Float] {
+        try checkGenerationCancellation(shouldCancel)
+        let logits = try step(tokens, state: state)
+        try checkGenerationCancellation(shouldCancel)
+        return logits
+    }
 }
 
 extension QwenCPUModel: InferenceModel {

--- a/Sources/SwiftletCore/TextGenerator.swift
+++ b/Sources/SwiftletCore/TextGenerator.swift
@@ -37,9 +37,13 @@ extension QwenMetalModel: InferenceModel {
 }
 
 /// Engine-agnostic greedy generation loop shared by the CLI and server.
-public final class TextGenerator {
+public final class TextGenerator: @unchecked Sendable {
     public let model: any InferenceModel
     public let eosTokens: Set<Int>
+    /// Inference models own mutable decode/GPU scratch state. Keep every
+    /// public generation entry point single-flight even when callers create
+    /// several token streams from the same generator concurrently.
+    private let generationLock = NSLock()
 
     public init(model: any InferenceModel) {
         self.model = model
@@ -136,6 +140,14 @@ public final class TextGenerator {
         cancellation: GenerationCancellation,
         onToken: (Int) -> Bool
     ) throws -> Stats {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+
+        // A stream can be cancelled while it waits behind another generation.
+        // Observe that before allocating or passing any DecodeState to the
+        // shared model.
+        try checkGenerationCancellation { cancellation.isCancelled }
+
         var stats = Stats()
         stats.promptTokens = promptIds.count
         let state = QwenCPUModel.DecodeState()

--- a/Sources/SwiftletCore/TextGenerator.swift
+++ b/Sources/SwiftletCore/TextGenerator.swift
@@ -38,12 +38,21 @@ extension QwenMetalModel: InferenceModel {
 
 /// Engine-agnostic greedy generation loop shared by the CLI and server.
 public final class TextGenerator: @unchecked Sendable {
+    public enum Error: Swift.Error, Equatable, Sendable {
+        /// `generate` was called again from a synchronous callback made by an
+        /// active generation on this same generator.
+        case reentrantGeneration
+    }
+
     public let model: any InferenceModel
     public let eosTokens: Set<Int>
     /// Inference models own mutable decode/GPU scratch state. Keep every
     /// public generation entry point single-flight even when callers create
-    /// several token streams from the same generator concurrently.
-    private let generationLock = NSLock()
+    /// several token streams from the same generator concurrently. A recursive
+    /// call can reacquire this lock only long enough to reject the call instead
+    /// of deadlocking inside a public token callback.
+    private let generationLock = NSRecursiveLock()
+    private var generationInProgress = false
 
     public init(model: any InferenceModel) {
         self.model = model
@@ -132,7 +141,9 @@ public final class TextGenerator: @unchecked Sendable {
     }
 
     /// Cancellable form of `generate`. Any cancellation error invalidates the
-    /// method-local DecodeState, which is discarded while unwinding.
+    /// method-local DecodeState, which is discarded while unwinding. Concurrent
+    /// callers are serialized; a call made recursively from `onToken` throws
+    /// `Error.reentrantGeneration`.
     @discardableResult
     public func generate(
         promptIds: [Int],
@@ -141,7 +152,15 @@ public final class TextGenerator: @unchecked Sendable {
         onToken: (Int) -> Bool
     ) throws -> Stats {
         generationLock.lock()
-        defer { generationLock.unlock() }
+        if generationInProgress {
+            generationLock.unlock()
+            throw Error.reentrantGeneration
+        }
+        generationInProgress = true
+        defer {
+            generationInProgress = false
+            generationLock.unlock()
+        }
 
         // A stream can be cancelled while it waits behind another generation.
         // Observe that before allocating or passing any DecodeState to the

--- a/Sources/SwiftletServer/main.swift
+++ b/Sources/SwiftletServer/main.swift
@@ -165,9 +165,14 @@ final class ConnectionGenerationOwner: @unchecked Sendable {
     (try? JSONSerialization.data(withJSONObject: obj)) ?? Data("{}".utf8)
 }
 
+/// `model` defaults to the served model's name. Tests pass it explicitly:
+/// top-level `main.swift` globals are not initialised when the executable
+/// module is imported by a test target, so reading `modelName` there yields a
+/// null object that `JSONSerialization` rejects.
 @Sendable func completionPayload(
     id: String, text: String?, delta: String?, finish: String?,
-    usage: (prompt: Int, completion: Int)? = nil
+    usage: (prompt: Int, completion: Int)? = nil,
+    model: String = modelName
 ) -> [String: Any] {
     var choice: [String: Any] = ["index": 0]
     if let text { choice["message"] = ["role": "assistant", "content": text] }
@@ -187,7 +192,7 @@ final class ConnectionGenerationOwner: @unchecked Sendable {
         "id": id,
         "object": delta != nil ? "chat.completion.chunk" : "chat.completion",
         "created": Int(Date().timeIntervalSince1970),
-        "model": modelName,
+        "model": model,
         "choices": [choice],
     ]
     if let usage {

--- a/Sources/SwiftletServer/main.swift
+++ b/Sources/SwiftletServer/main.swift
@@ -89,7 +89,7 @@ let generationQueue = DispatchQueue(label: "swiftlet.generation")
 final class ConnectionGenerationOwner: @unchecked Sendable {
     private struct Job {
         let cancellation: GenerationCancellation
-        let heartbeat: RepeatedTask?
+        var heartbeat: RepeatedTask?
     }
 
     private let lock = NSLock()
@@ -105,11 +105,48 @@ final class ConnectionGenerationOwner: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Attaches a heartbeat after the initial SSE head is submitted. If that
+    /// head has already failed and removed the job, cancel the newly-created
+    /// task instead of orphaning it.
+    func attachHeartbeat(id: String, heartbeat: RepeatedTask) {
+        lock.lock()
+        if var job = jobs[id] {
+            job.heartbeat = heartbeat
+            jobs[id] = job
+            lock.unlock()
+        } else {
+            lock.unlock()
+            heartbeat.cancel()
+        }
+    }
+
+    func stopHeartbeat(id: String) {
+        lock.lock()
+        let heartbeat = jobs[id]?.heartbeat
+        if var job = jobs[id] {
+            job.heartbeat = nil
+            jobs[id] = job
+        }
+        lock.unlock()
+        heartbeat?.cancel()
+    }
+
     func finish(id: String) {
         lock.lock()
         let job = jobs.removeValue(forKey: id)
         lock.unlock()
         job?.heartbeat?.cancel()
+    }
+
+    /// Cancels and removes only the request whose write failed.
+    @discardableResult
+    func failWrite(id: String) -> Bool {
+        lock.lock()
+        let job = jobs.removeValue(forKey: id)
+        lock.unlock()
+        job?.cancellation.cancel()
+        job?.heartbeat?.cancel()
+        return job != nil
     }
 
     func cancelAll() {
@@ -135,7 +172,17 @@ final class ConnectionGenerationOwner: @unchecked Sendable {
     var choice: [String: Any] = ["index": 0]
     if let text { choice["message"] = ["role": "assistant", "content": text] }
     if let delta { choice["delta"] = ["content": delta] }
-    if let finish { choice["finish_reason"] = finish }
+    if delta != nil {
+        // OpenAI streaming choices carry the key on every chunk; it is null
+        // until the terminal chunk supplies "stop" or "length".
+        if let finish {
+            choice["finish_reason"] = finish
+        } else {
+            choice["finish_reason"] = NSNull()
+        }
+    } else if let finish {
+        choice["finish_reason"] = finish
+    }
     var payload: [String: Any] = [
         "id": id,
         "object": delta != nil ? "chat.completion.chunk" : "chat.completion",
@@ -225,6 +272,27 @@ final class HTTPHandler: ChannelInboundHandler {
         let channel = context.channel
         let cancellation = GenerationCancellation()
         let owner = generationOwner
+        owner.register(id: id, cancellation: cancellation)
+
+        /// Every chat write is observed. A failed outbound future cancels this
+        /// request's token (never a neighboring connection/request), tears down
+        /// its heartbeat ownership, and closes the failed channel. The final
+        /// successful write is what releases normal ownership.
+        @Sendable func observeWrite(
+            _ future: EventLoopFuture<Void>,
+            terminal: Bool = false
+        ) {
+            future.whenComplete { result in
+                switch result {
+                case .success:
+                    if terminal { owner.finish(id: id) }
+                case .failure:
+                    cancellation.cancel()
+                    owner.failWrite(id: id)
+                    if channel.isActive { channel.close(promise: nil) }
+                }
+            }
+        }
 
         let options: SwiftletSession.GenerationOptions = {
             var o = SwiftletSession.GenerationOptions()
@@ -239,31 +307,42 @@ final class HTTPHandler: ChannelInboundHandler {
         // Agent clients (OpenCode etc.) send multi-thousand-token prompts, so
         // prefill can run minutes with no output. SSE comment heartbeats keep
         // the idle connection from being dropped; parsers ignore them.
-        var heartbeat: RepeatedTask? = nil
         if streaming {
             var head = HTTPResponseHead(version: .http1_1, status: .ok)
             head.headers.add(name: "Content-Type", value: "text/event-stream")
             head.headers.add(name: "Cache-Control", value: "no-cache")
             head.headers.add(name: "Transfer-Encoding", value: "chunked")
-            context.writeAndFlush(wrapOutboundOut(.head(head)), promise: nil)
-            heartbeat = eventLoop.scheduleRepeatedTask(
+            let headPromise = eventLoop.makePromise(of: Void.self)
+            observeWrite(headPromise.futureResult)
+            context.writeAndFlush(wrapOutboundOut(.head(head)), promise: headPromise)
+            let heartbeat = eventLoop.scheduleRepeatedTask(
                 initialDelay: .seconds(15), delay: .seconds(15)
             ) { _ in
-                guard channel.isActive else { return }
+                guard channel.isActive, !cancellation.isCancelled else { return }
                 var buf = channel.allocator.buffer(capacity: 16)
                 buf.writeString(": ping\n\n")
-                _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buf)))
+                observeWrite(channel.writeAndFlush(
+                    HTTPServerResponsePart.body(.byteBuffer(buf))
+                ))
             }
+            owner.attachHeartbeat(id: id, heartbeat: heartbeat)
         }
-        owner.register(id: id, cancellation: cancellation, heartbeat: heartbeat)
 
         @Sendable func writeSSE(_ obj: [String: Any]) {
             let payload = "data: " + (String(data: jsonData(obj), encoding: .utf8) ?? "{}") + "\n\n"
             eventLoop.execute {
-                guard channel.isActive else { return }
+                guard channel.isActive, !cancellation.isCancelled else {
+                    if !channel.isActive {
+                        cancellation.cancel()
+                        owner.failWrite(id: id)
+                    }
+                    return
+                }
                 var buf = channel.allocator.buffer(capacity: payload.utf8.count)
                 buf.writeString(payload)
-                _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buf)))
+                observeWrite(channel.writeAndFlush(
+                    HTTPServerResponsePart.body(.byteBuffer(buf))
+                ))
             }
         }
 
@@ -297,8 +376,12 @@ final class HTTPHandler: ChannelInboundHandler {
                     ).utf8))
 
                     eventLoop.execute {
-                        owner.finish(id: id)
-                        guard channel.isActive, m.finishReason != .cancelled else { return }
+                        guard channel.isActive, m.finishReason != .cancelled else {
+                            cancellation.cancel()
+                            owner.failWrite(id: id)
+                            return
+                        }
+                        owner.stopHeartbeat(id: id)
                         let finishReason = openAIFinishReason(m.finishReason)
                         if streaming {
                             // The finish chunk, [DONE], and the HTTP end must
@@ -314,8 +397,13 @@ final class HTTPHandler: ChannelInboundHandler {
                                 + "\n\ndata: [DONE]\n\n"
                             var buf = channel.allocator.buffer(capacity: tail.utf8.count)
                             buf.writeString(tail)
-                            _ = channel.write(HTTPServerResponsePart.body(.byteBuffer(buf)))
-                            _ = channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+                            observeWrite(channel.write(
+                                HTTPServerResponsePart.body(.byteBuffer(buf))
+                            ))
+                            observeWrite(
+                                channel.writeAndFlush(HTTPServerResponsePart.end(nil)),
+                                terminal: true
+                            )
                         } else {
                             let data = jsonData(completionPayload(
                                 id: id, text: fullText, delta: nil, finish: finishReason,
@@ -325,15 +413,24 @@ final class HTTPHandler: ChannelInboundHandler {
                             head.headers.add(name: "Content-Length", value: String(data.count))
                             var buf = channel.allocator.buffer(capacity: data.count)
                             buf.writeBytes(data)
-                            _ = channel.write(HTTPServerResponsePart.head(head))
-                            _ = channel.write(HTTPServerResponsePart.body(.byteBuffer(buf)))
-                            _ = channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+                            observeWrite(channel.write(HTTPServerResponsePart.head(head)))
+                            observeWrite(channel.write(
+                                HTTPServerResponsePart.body(.byteBuffer(buf))
+                            ))
+                            observeWrite(
+                                channel.writeAndFlush(HTTPServerResponsePart.end(nil)),
+                                terminal: true
+                            )
                         }
                     }
                 } catch {
                     eventLoop.execute {
-                        owner.finish(id: id)
-                        guard channel.isActive else { return }
+                        guard channel.isActive else {
+                            cancellation.cancel()
+                            owner.failWrite(id: id)
+                            return
+                        }
+                        owner.stopHeartbeat(id: id)
                         if streaming {
                             // The 200 + SSE head is already on the wire; a
                             // second head would be a protocol error. Report
@@ -343,17 +440,27 @@ final class HTTPHandler: ChannelInboundHandler {
                             ) ?? "{}") + "\n\ndata: [DONE]\n\n"
                             var buf = channel.allocator.buffer(capacity: payload.utf8.count)
                             buf.writeString(payload)
-                            _ = channel.write(HTTPServerResponsePart.body(.byteBuffer(buf)))
-                            _ = channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+                            observeWrite(channel.write(
+                                HTTPServerResponsePart.body(.byteBuffer(buf))
+                            ))
+                            observeWrite(
+                                channel.writeAndFlush(HTTPServerResponsePart.end(nil)),
+                                terminal: true
+                            )
                         } else {
                             let data = jsonData(["error": "\(error)"])
                             var head = HTTPResponseHead(version: .http1_1, status: .internalServerError)
                             head.headers.add(name: "Content-Length", value: String(data.count))
                             var buf = channel.allocator.buffer(capacity: data.count)
                             buf.writeBytes(data)
-                            _ = channel.write(HTTPServerResponsePart.head(head))
-                            _ = channel.write(HTTPServerResponsePart.body(.byteBuffer(buf)))
-                            _ = channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+                            observeWrite(channel.write(HTTPServerResponsePart.head(head)))
+                            observeWrite(channel.write(
+                                HTTPServerResponsePart.body(.byteBuffer(buf))
+                            ))
+                            observeWrite(
+                                channel.writeAndFlush(HTTPServerResponsePart.end(nil)),
+                                terminal: true
+                            )
                         }
                     }
                 }

--- a/Sources/SwiftletServer/main.swift
+++ b/Sources/SwiftletServer/main.swift
@@ -28,6 +28,20 @@ struct ChatContent: Decodable {
     }
 }
 
+/// OpenAI accepts `stop` as either one string or an array of strings.
+struct StopSequences: Decodable {
+    let values: [String]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            values = [value]
+        } else {
+            values = try container.decode([String].self)
+        }
+    }
+}
+
 /// OpenAI-compatible Chat Completions request body.
 struct ChatRequest: Decodable {
     struct Message: Decodable { let role: String; let content: ChatContent }
@@ -37,6 +51,7 @@ struct ChatRequest: Decodable {
     let max_completion_tokens: Int?
     let temperature: Float?
     let top_p: Float?
+    let stop: StopSequences?
 }
 
 let cliArgs = CommandLine.arguments
@@ -67,6 +82,48 @@ let modelName: String = {
 // One request at a time: the session mutates shared conversation state.
 let generationQueue = DispatchQueue(label: "swiftlet.generation")
 
+/// Owns every generation associated with one HTTP/1 connection. NIO invokes
+/// `channelInactive` as soon as a peer disconnects, even while its request is
+/// still queued behind another generation, so cancellation reaches both
+/// queued and active work instead of waiting for another attempted write.
+final class ConnectionGenerationOwner: @unchecked Sendable {
+    private struct Job {
+        let cancellation: GenerationCancellation
+        let heartbeat: RepeatedTask?
+    }
+
+    private let lock = NSLock()
+    private var jobs: [String: Job] = [:]
+
+    func register(
+        id: String,
+        cancellation: GenerationCancellation,
+        heartbeat: RepeatedTask? = nil
+    ) {
+        lock.lock()
+        jobs[id] = Job(cancellation: cancellation, heartbeat: heartbeat)
+        lock.unlock()
+    }
+
+    func finish(id: String) {
+        lock.lock()
+        let job = jobs.removeValue(forKey: id)
+        lock.unlock()
+        job?.heartbeat?.cancel()
+    }
+
+    func cancelAll() {
+        lock.lock()
+        let pending = Array(jobs.values)
+        jobs.removeAll()
+        lock.unlock()
+        for job in pending {
+            job.cancellation.cancel()
+            job.heartbeat?.cancel()
+        }
+    }
+}
+
 @Sendable func jsonData(_ obj: [String: Any]) -> Data {
     (try? JSONSerialization.data(withJSONObject: obj)) ?? Data("{}".utf8)
 }
@@ -96,12 +153,34 @@ let generationQueue = DispatchQueue(label: "swiftlet.generation")
     return payload
 }
 
+@Sendable func openAIFinishReason(_ reason: GenerationFinishReason?) -> String? {
+    switch reason {
+    case .length: return "length"
+    case .stop: return "stop"
+    // Cancellation normally coincides with an inactive channel and therefore
+    // writes no terminal chunk. If it is observed on an active channel, omit
+    // the field instead of inventing a non-standard OpenAI finish reason.
+    case .cancelled, nil: return nil
+    }
+}
+
 final class HTTPHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
     private var requestHead: HTTPRequestHead?
     private var body = ByteBuffer()
+    private let generationOwner = ConnectionGenerationOwner()
+
+    func channelInactive(context: ChannelHandlerContext) {
+        generationOwner.cancelAll()
+        context.fireChannelInactive()
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Swift.Error) {
+        generationOwner.cancelAll()
+        context.close(promise: nil)
+    }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         switch unwrapInboundIn(data) {
@@ -144,6 +223,8 @@ final class HTTPHandler: ChannelInboundHandler {
         let id = "chatcmpl-\(UUID().uuidString.prefix(8))"
         let eventLoop = context.eventLoop
         let channel = context.channel
+        let cancellation = GenerationCancellation()
+        let owner = generationOwner
 
         let options: SwiftletSession.GenerationOptions = {
             var o = SwiftletSession.GenerationOptions()
@@ -151,6 +232,7 @@ final class HTTPHandler: ChannelInboundHandler {
                 if t <= 0 { o = .greedy } else { o.temperature = t }
             }
             if let p = request.top_p { o.topP = p }
+            o.stopSequences = request.stop?.values ?? []
             return o
         }()
 
@@ -167,16 +249,18 @@ final class HTTPHandler: ChannelInboundHandler {
             heartbeat = eventLoop.scheduleRepeatedTask(
                 initialDelay: .seconds(15), delay: .seconds(15)
             ) { _ in
+                guard channel.isActive else { return }
                 var buf = channel.allocator.buffer(capacity: 16)
                 buf.writeString(": ping\n\n")
                 _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buf)))
             }
         }
-        let stopHeartbeat = heartbeat
+        owner.register(id: id, cancellation: cancellation, heartbeat: heartbeat)
 
         @Sendable func writeSSE(_ obj: [String: Any]) {
             let payload = "data: " + (String(data: jsonData(obj), encoding: .utf8) ?? "{}") + "\n\n"
             eventLoop.execute {
+                guard channel.isActive else { return }
                 var buf = channel.allocator.buffer(capacity: payload.utf8.count)
                 buf.writeString(payload)
                 _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buf)))
@@ -184,13 +268,21 @@ final class HTTPHandler: ChannelInboundHandler {
         }
 
         generationQueue.async {
+            // The channel may have disappeared while this request waited
+            // behind another generation. Do not even construct a stream in
+            // that case: prompt preparation and prefill must never start.
+            guard !cancellation.isCancelled else {
+                eventLoop.execute { owner.finish(id: id) }
+                return
+            }
             let done = DispatchSemaphore(value: 0)
             Task {
                 defer { done.signal() }
                 do {
                     var fullText = ""
                     for try await delta in session.streamChat(
-                        messages: messages, maxNew: maxNew, options: options
+                        messages: messages, maxNew: maxNew, options: options,
+                        cancellation: cancellation
                     ) {
                         fullText += delta
                         if streaming {
@@ -205,7 +297,9 @@ final class HTTPHandler: ChannelInboundHandler {
                     ).utf8))
 
                     eventLoop.execute {
-                        stopHeartbeat?.cancel()
+                        owner.finish(id: id)
+                        guard channel.isActive, m.finishReason != .cancelled else { return }
+                        let finishReason = openAIFinishReason(m.finishReason)
                         if streaming {
                             // The finish chunk, [DONE], and the HTTP end must
                             // land in this order on the wire. Write them here
@@ -214,7 +308,7 @@ final class HTTPHandler: ChannelInboundHandler {
                             // and it would land after .end and be dropped
                             // (strict clients then wait for it forever).
                             let finish = jsonData(completionPayload(
-                                id: id, text: nil, delta: "", finish: "stop",
+                                id: id, text: nil, delta: "", finish: finishReason,
                                 usage: (m.promptTokens, m.generatedTokens)))
                             let tail = "data: " + (String(data: finish, encoding: .utf8) ?? "{}")
                                 + "\n\ndata: [DONE]\n\n"
@@ -224,7 +318,7 @@ final class HTTPHandler: ChannelInboundHandler {
                             _ = channel.writeAndFlush(HTTPServerResponsePart.end(nil))
                         } else {
                             let data = jsonData(completionPayload(
-                                id: id, text: fullText, delta: nil, finish: "stop",
+                                id: id, text: fullText, delta: nil, finish: finishReason,
                                 usage: (m.promptTokens, m.generatedTokens)))
                             var head = HTTPResponseHead(version: .http1_1, status: .ok)
                             head.headers.add(name: "Content-Type", value: "application/json")
@@ -238,7 +332,8 @@ final class HTTPHandler: ChannelInboundHandler {
                     }
                 } catch {
                     eventLoop.execute {
-                        stopHeartbeat?.cancel()
+                        owner.finish(id: id)
+                        guard channel.isActive else { return }
                         if streaming {
                             // The 200 + SSE head is already on the wire; a
                             // second head would be a protocol error. Report

--- a/Tests/SwiftletCoreTests/GenerationControlTests.swift
+++ b/Tests/SwiftletCoreTests/GenerationControlTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+@Suite struct GenerationControlTests {
+    private static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    private final class LegacyInferenceModel: InferenceModel {
+        let config: QwenConfig
+        let modelDir: URL
+        var stepCalls = 0
+
+        init(modelDir: URL) throws {
+            self.modelDir = modelDir
+            config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
+        }
+
+        func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+            stepCalls += 1
+            return [0, 1, 2, 3]
+        }
+    }
+
+    @Test func cancellationIsOneWayAndObservableAcrossReferences() {
+        let cancellation = GenerationCancellation()
+        let shared = cancellation
+        #expect(!shared.isCancelled)
+        cancellation.cancel()
+        #expect(shared.isCancelled)
+        cancellation.cancel()
+        #expect(shared.isCancelled)
+    }
+
+    @Test func finishReasonsHaveStableWireValues() {
+        #expect(GenerationFinishReason.stop.rawValue == "stop")
+        #expect(GenerationFinishReason.length.rawValue == "length")
+        #expect(GenerationFinishReason.cancelled.rawValue == "cancelled")
+    }
+
+    @Test func legacyInferenceConformerGetsCancellableDefault() throws {
+        let model = try LegacyInferenceModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model")
+        )
+        let state = QwenCPUModel.DecodeState()
+        let erased: any InferenceModel = model
+
+        let logits = try erased.step([1], state: state, shouldCancel: { false })
+
+        #expect(logits == [0, 1, 2, 3])
+        #expect(model.stepCalls == 1)
+    }
+
+    @Test func cancellableDefaultChecksBeforeAndAfterLegacyStep() throws {
+        let model = try LegacyInferenceModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model")
+        )
+        let state = QwenCPUModel.DecodeState()
+        let erased: any InferenceModel = model
+
+        #expect(throws: GenerationInterruption.self) {
+            _ = try erased.step([1], state: state, shouldCancel: { true })
+        }
+        #expect(model.stepCalls == 0)
+
+        var checks = 0
+        #expect(throws: GenerationInterruption.self) {
+            _ = try erased.step([1], state: state, shouldCancel: {
+                checks += 1
+                return checks == 2
+            })
+        }
+        #expect(model.stepCalls == 1)
+        #expect(checks == 2)
+    }
+
+    @Test func cpuReferenceCancelsOnlyBetweenCompleteLayers() throws {
+        let model = try QwenCPUModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model")
+        )
+        let interruptedState = QwenCPUModel.DecodeState()
+        var checks = 0
+
+        #expect(throws: GenerationInterruption.self) {
+            _ = try model.step([1, 5, 9], state: interruptedState, shouldCancel: {
+                checks += 1
+                // Entry, before layer 0, then between layers 0 and 1.
+                return checks == 3
+            })
+        }
+        #expect(checks == 3)
+        #expect(interruptedState.position == 0)
+
+        // A caller recovers by discarding the partial state, not by trying to
+        // continue it. A fresh state still completes normally.
+        let freshState = QwenCPUModel.DecodeState()
+        let logits = try model.step(
+            [1, 5, 9], state: freshState, shouldCancel: { false }
+        )
+        #expect(freshState.position == 3)
+        #expect(logits.count == model.config.vocabSize)
+    }
+}

--- a/Tests/SwiftletCoreTests/StopSequenceFilterTests.swift
+++ b/Tests/SwiftletCoreTests/StopSequenceFilterTests.swift
@@ -93,6 +93,20 @@ import Testing
         #expect(!update.didStop)
     }
 
+    @Test func canonicallyEquivalentStopsRemainScalarDistinct() {
+        let precomposed = "\u{00E9}"
+        let decomposed = "e\u{0301}"
+        #expect(precomposed == decomposed) // Swift String canonical equality.
+
+        var filter = StopSequenceFilter(stopSequences: [precomposed, decomposed])
+        let update = filter.consume(decoded: "before \(decomposed) after")
+
+        #expect(update.didStop)
+        #expect(update.delta == "before ")
+        #expect(update.matchedStop?.unicodeScalars.count == 2)
+        #expect(filter.output == "before ")
+    }
+
     @Test func utf8ReplacementTailRemainsProvisional() {
         var filter = StopSequenceFilter(stopSequences: ["END"])
         #expect(filter.consume(decoded: "ok \u{FFFD}").delta == "ok ")
@@ -108,6 +122,20 @@ import Testing
         var cancelledFilter = StopSequenceFilter(stopSequences: ["END"])
         #expect(cancelledFilter.consume(decoded: "ok \u{FFFD}").delta == "ok ")
         #expect(cancelledFilter.output == "ok ")
+    }
+
+    @Test func finalRawReplacementCanCompleteStopWithoutLeaking() {
+        let stop = "X\u{FFFD}"
+        var filter = StopSequenceFilter(stopSequences: [stop])
+
+        // Model a terminal replacement at the end of the cumulative decode;
+        // stablePrefix withholds it, leaving X as a possible stop prefix.
+        #expect(filter.consume(decoded: "answer \(stop)").delta == "answer ")
+        let final = filter.finishUpdate(decoded: "answer \(stop)")
+
+        #expect(final.didStop)
+        #expect(final.delta == nil)
+        #expect(filter.output == "answer ")
     }
 
     @Test func divergentCumulativeDecodeFailsClosed() {

--- a/Tests/SwiftletCoreTests/StopSequenceFilterTests.swift
+++ b/Tests/SwiftletCoreTests/StopSequenceFilterTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import SwiftletCore
+
+@Suite struct StopSequenceFilterTests {
+    @Test func splitStopPrefixIsHeldAcrossTokens() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+
+        let first = filter.consume(decoded: "hello E")
+        #expect(first.delta == "hello ")
+        #expect(!first.didStop)
+
+        let second = filter.consume(decoded: "hello EN")
+        #expect(second.delta == nil)
+        #expect(!second.didStop)
+
+        let third = filter.consume(decoded: "hello END ignored")
+        #expect(third.delta == nil)
+        #expect(third.matchedStop == "END")
+        #expect(filter.output == "hello ")
+    }
+
+    @Test func textBeforeAndAfterStopInOneTokenIsFiltered() {
+        var filter = StopSequenceFilter(stopSequences: ["<stop>"])
+        let update = filter.consume(decoded: "answer<stop>not part of the answer")
+        #expect(update.delta == "answer")
+        #expect(update.matchedStop == "<stop>")
+        #expect(filter.output == "answer")
+        #expect(filter.finish(decoded: "answer<stop>not part of the answer") == nil)
+    }
+
+    @Test func earliestOfSeveralStopsWins() {
+        var filter = StopSequenceFilter(stopSequences: ["SECOND", "FIRST"])
+        let update = filter.consume(decoded: "a FIRST b SECOND")
+        #expect(update.delta == "a ")
+        #expect(update.matchedStop == "FIRST")
+    }
+
+    @Test func overlappingStopsDoNotLeakTheirSharedPrefix() {
+        var filter = StopSequenceFilter(stopSequences: ["ABC", "AB"])
+        #expect(filter.consume(decoded: "xA").delta == "x")
+        let update = filter.consume(decoded: "xAB")
+        #expect(update.matchedStop == "AB")
+        #expect(filter.output == "x")
+    }
+
+    @Test func falsePrefixIsReleasedWhenItCanNoLongerMatch() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(filter.consume(decoded: "hello E").delta == "hello ")
+
+        let update = filter.consume(decoded: "hello EX then")
+        #expect(update.delta == "EX then")
+        #expect(!update.didStop)
+        #expect(filter.output == "hello EX then")
+    }
+
+    @Test func longestViablePrefixIsHeldAcrossOverlappingStops() {
+        var filter = StopSequenceFilter(stopSequences: ["ABCD", "BCD"])
+        #expect(filter.consume(decoded: "xABC").delta == "x")
+
+        let update = filter.consume(decoded: "xABCE")
+        #expect(update.delta == "ABCE")
+        #expect(!update.didStop)
+    }
+
+    @Test func unicodeStopCanCrossScalarFragments() {
+        var filter = StopSequenceFilter(stopSequences: ["🌲!"])
+        #expect(filter.consume(decoded: "woods 🌲").delta == "woods ")
+        let update = filter.consume(decoded: "woods 🌲! trailing")
+        #expect(update.matchedStop == "🌲!")
+        #expect(filter.output == "woods ")
+    }
+
+    @Test func lengthOrEOSFlushesNonMatchingPartialStop() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(filter.consume(decoded: "hello E").delta == "hello ")
+        #expect(filter.finish(decoded: "hello E") == "E")
+        #expect(filter.output == "hello E")
+    }
+
+    @Test func cancellationCanDropHeldTextWithoutFlushing() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(filter.consume(decoded: "visible E").delta == "visible ")
+
+        // Cancellation deliberately does not call finish(decoded:). The only
+        // text exposed to the consumer is therefore the committed prefix.
+        #expect(filter.output == "visible ")
+    }
+
+    @Test func emptyAndDuplicateStopsAreHarmless() {
+        var filter = StopSequenceFilter(stopSequences: ["", "END", "END"])
+        let update = filter.consume(decoded: "plain text")
+        #expect(update.delta == "plain text")
+        #expect(!update.didStop)
+    }
+
+    @Test func utf8ReplacementTailRemainsProvisional() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(filter.consume(decoded: "ok \u{FFFD}").delta == "ok ")
+        #expect(filter.consume(decoded: "ok 😊").delta == "😊")
+        #expect(filter.finish(decoded: "ok 😊") == nil)
+    }
+
+    @Test func lengthFlushesFinalReplacementButCancellationNeedNot() {
+        var lengthFilter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(lengthFilter.consume(decoded: "ok \u{FFFD}").delta == "ok ")
+        #expect(lengthFilter.finish(decoded: "ok \u{FFFD}") == "\u{FFFD}")
+
+        var cancelledFilter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(cancelledFilter.consume(decoded: "ok \u{FFFD}").delta == "ok ")
+        #expect(cancelledFilter.output == "ok ")
+    }
+
+    @Test func divergentCumulativeDecodeFailsClosed() {
+        var filter = StopSequenceFilter(stopSequences: ["END"])
+        #expect(filter.consume(decoded: "already visible").delta == "already visible")
+
+        let update = filter.consume(decoded: "a rewritten decode")
+        #expect(!update.isConsistent)
+        #expect(update.delta == nil)
+        #expect(filter.output == "already visible")
+    }
+}

--- a/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
+++ b/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
@@ -3,6 +3,169 @@ import Testing
 @testable import SwiftletCore
 
 @Suite struct SwiftletSessionTests {
+    private final class CleanupGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private let releaseSemaphore = DispatchSemaphore(value: 0)
+        private var _entered = false
+        private var _completed = false
+        private var calls = 0
+
+        var entered: Bool { locked { _entered } }
+        var completed: Bool { locked { _completed } }
+
+        func run() {
+            let shouldBlock = locked { () -> Bool in
+                calls += 1
+                if calls == 1 {
+                    _entered = true
+                    return true
+                }
+                return false
+            }
+            guard shouldBlock else { return }
+            _ = releaseSemaphore.wait(timeout: .now() + .seconds(2))
+            locked { _completed = true }
+        }
+
+        func release() {
+            releaseSemaphore.signal()
+        }
+
+        private func locked<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
+    private final class LockedFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func set() {
+            lock.lock()
+            value = true
+            lock.unlock()
+        }
+    }
+
+    private final class SessionProbeModel: InferenceModel, @unchecked Sendable {
+        enum ProbeError: Swift.Error { case timedOutWaitingForRelease }
+        struct Call {
+            let tokens: [Int]
+            let stateID: ObjectIdentifier
+        }
+
+        let config: QwenConfig
+        let modelDir: URL
+        private let blockFirstCall: Bool
+        private let cleanupGate: CleanupGate?
+        private let lock = NSLock()
+        private let releaseFirstCall = DispatchSemaphore(value: 0)
+        private var _calls: [Call] = []
+        private var _activeCalls = 0
+        private var _maxActiveCalls = 0
+        private var _firstCallEntered = false
+        private var _secondStartedBeforeCleanup = false
+
+        init(modelDir: URL, blockFirstCall: Bool, cleanupGate: CleanupGate? = nil) throws {
+            self.modelDir = modelDir
+            self.blockFirstCall = blockFirstCall
+            self.cleanupGate = cleanupGate
+            config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
+        }
+
+        var calls: [Call] { locked { _calls } }
+        var maxActiveCalls: Int { locked { _maxActiveCalls } }
+        var firstCallEntered: Bool { locked { _firstCallEntered } }
+        var secondStartedBeforeCleanup: Bool { locked { _secondStartedBeforeCleanup } }
+
+        func releaseFirst() {
+            releaseFirstCall.signal()
+        }
+
+        func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+            try runStep(tokens: tokens, state: state, shouldCancel: { false })
+        }
+
+        func step(
+            _ tokens: [Int],
+            state: QwenCPUModel.DecodeState,
+            shouldCancel: () -> Bool
+        ) throws -> [Float] {
+            try runStep(tokens: tokens, state: state, shouldCancel: shouldCancel)
+        }
+
+        private func runStep(
+            tokens: [Int],
+            state: QwenCPUModel.DecodeState,
+            shouldCancel: () -> Bool
+        ) throws -> [Float] {
+            let ordinal = locked { () -> Int in
+                _calls.append(Call(tokens: tokens, stateID: ObjectIdentifier(state)))
+                _activeCalls += 1
+                _maxActiveCalls = max(_maxActiveCalls, _activeCalls)
+                if _calls.count == 1 { _firstCallEntered = true }
+                return _calls.count
+            }
+            defer { locked { _activeCalls -= 1 } }
+
+            if ordinal == 2, let cleanupGate, !cleanupGate.completed {
+                locked { _secondStartedBeforeCleanup = true }
+            }
+            if blockFirstCall, ordinal == 1,
+               releaseFirstCall.wait(timeout: .now() + .seconds(2)) == .timedOut {
+                throw ProbeError.timedOutWaitingForRelease
+            }
+            if shouldCancel() { throw GenerationInterruption.cancelled }
+            state.position += tokens.count
+
+            var logits = [Float](repeating: -.infinity, count: config.vocabSize)
+            logits[65] = 1
+            return logits
+        }
+
+        private func locked<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
+    private static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    private func makeSession(
+        model: SessionProbeModel,
+        cleanupGate: CleanupGate? = nil
+    ) -> SwiftletSession {
+        SwiftletSession(
+            testingModel: model,
+            modelDir: model.modelDir,
+            encodeText: { _ in [30] },
+            decodeTokens: { tokens in
+                String(String.UnicodeScalarView(tokens.compactMap { Unicode.Scalar($0) }))
+            },
+            renderMessages: { messages in
+                switch messages.last?["content"] {
+                case "one": return [10]
+                case "other": return [20]
+                default: return [40]
+                }
+            },
+            generationCleanupHook: cleanupGate.map { gate in { gate.run() } }
+        )
+    }
+
     /// Issue #9: a token boundary that splits a multi-byte character decodes
     /// to a trailing U+FFFD, which must be held back, never emitted or stored
     /// as printed text (it poisons the prefix check and the EOS gate).
@@ -17,5 +180,175 @@ import Testing
         #expect(SwiftletSession.trimIncompleteUTF8("a\u{FFFD}b\u{FFFD}") == "a\u{FFFD}b")
         // Completed characters pass through untouched.
         #expect(SwiftletSession.trimIncompleteUTF8("~10⁵⁰⁰ vacua") == "~10⁵⁰⁰ vacua")
+    }
+
+    @Test func queuedCancellationCannotStepOrResetActiveConversation() async throws {
+        let model = try SessionProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            blockFirstCall: true
+        )
+        let session = makeSession(model: model)
+        var options = SwiftletSession.GenerationOptions.greedy
+        options.minNew = 0
+
+        let firstStream = session.streamChat(
+            messages: [["role": "user", "content": "one"]],
+            maxNew: 1,
+            options: options
+        )
+        let first = Task {
+            var output = ""
+            for try await delta in firstStream { output += delta }
+            return output
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while !model.firstCallEntered, Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(model.firstCallEntered)
+
+        let queuedCancellation = GenerationCancellation()
+        let queuedStream = session.streamChat(
+            messages: [["role": "user", "content": "other"]],
+            maxNew: 1,
+            options: options,
+            cancellation: queuedCancellation
+        )
+        let queued = Task {
+            var output = ""
+            for try await delta in queuedStream { output += delta }
+            return output
+        }
+        queuedCancellation.cancel()
+        model.releaseFirst()
+
+        let firstOutput = try await first.value
+        let queuedOutput = try await queued.value
+        #expect(firstOutput == "A")
+        #expect(queuedOutput == "")
+        #expect(model.calls.map(\.tokens) == [[10], [65]])
+        #expect(model.maxActiveCalls == 1)
+
+        // The cancelled request was queued, so it must not reset the state
+        // committed by the first request. This exact message shape exercises
+        // continuationIds and should reuse the same DecodeState identity.
+        let continuationStream = session.streamChat(
+            messages: [
+                ["role": "user", "content": "one"],
+                ["role": "assistant", "content": "A"],
+                ["role": "user", "content": "next"],
+            ],
+            maxNew: 0,
+            options: options
+        )
+        for try await _ in continuationStream {}
+
+        let calls = model.calls
+        #expect(calls.map(\.tokens) == [[10], [65], [30]])
+        #expect(Set(calls.map(\.stateID)).count == 1)
+        #expect(model.maxActiveCalls == 1)
+    }
+
+    @Test func concurrentStreamChatsCannotOverlapOrReplaceActiveState() async throws {
+        let model = try SessionProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            blockFirstCall: true
+        )
+        let session = makeSession(model: model)
+        var options = SwiftletSession.GenerationOptions.greedy
+        options.minNew = 0
+
+        let firstStream = session.streamChat(
+            messages: [["role": "user", "content": "one"]],
+            maxNew: 1,
+            options: options
+        )
+        let first = Task {
+            var output = ""
+            for try await delta in firstStream { output += delta }
+            return output
+        }
+        let firstDeadline = Date().addingTimeInterval(1)
+        while !model.firstCallEntered, Date() < firstDeadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(model.firstCallEntered)
+
+        // This prompt is deliberately unrelated, so it must reset state —
+        // but only after the first request has fully finished using its own
+        // state. The blocked first step makes any overlap observable.
+        let secondStream = session.streamChat(
+            messages: [["role": "user", "content": "other"]],
+            maxNew: 1,
+            options: options
+        )
+        let second = Task {
+            var output = ""
+            for try await delta in secondStream { output += delta }
+            return output
+        }
+        try await Task<Never, Never>.sleep(nanoseconds: 20_000_000)
+        #expect(model.calls.count == 1)
+
+        model.releaseFirst()
+        let firstOutput = try await first.value
+        let secondOutput = try await second.value
+        #expect(firstOutput == "A")
+        #expect(secondOutput == "A")
+
+        let calls = model.calls
+        #expect(calls.map(\.tokens) == [[10], [65], [20], [65]])
+        try #require(calls.count == 4)
+        #expect(calls[0].stateID == calls[1].stateID)
+        #expect(calls[2].stateID == calls[3].stateID)
+        #expect(calls[0].stateID != calls[2].stateID)
+        #expect(model.maxActiveCalls == 1)
+    }
+
+    @Test func cleanupCompletesBeforeContinuationOrNextRequestStarts() async throws {
+        let cleanupGate = CleanupGate()
+        let model = try SessionProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            blockFirstCall: false,
+            cleanupGate: cleanupGate
+        )
+        let session = makeSession(model: model, cleanupGate: cleanupGate)
+        let firstStarted = LockedFlag()
+        let firstFinished = LockedFlag()
+
+        let firstStream = session.streamChat(
+            messages: [["role": "user", "content": "one"]], maxNew: 0
+        )
+        let first = Task {
+            firstStarted.set()
+            for try await _ in firstStream {}
+            firstFinished.set()
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while (!firstStarted.isSet || !cleanupGate.entered), Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(firstStarted.isSet)
+        #expect(cleanupGate.entered)
+
+        let secondStream = session.streamChat(
+            messages: [["role": "user", "content": "other"]], maxNew: 0
+        )
+        let second = Task {
+            for try await _ in secondStream {}
+        }
+        try await Task<Never, Never>.sleep(nanoseconds: 20_000_000)
+
+        #expect(!firstFinished.isSet)
+        #expect(model.calls.count == 1)
+        cleanupGate.release()
+        try await first.value
+        try await second.value
+
+        #expect(firstFinished.isSet)
+        #expect(cleanupGate.completed)
+        #expect(model.calls.count == 2)
+        #expect(!model.secondStartedBeforeCleanup)
+        #expect(model.maxActiveCalls == 1)
     }
 }

--- a/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
+++ b/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
@@ -119,9 +119,16 @@ import Testing
             if ordinal == 2, let cleanupGate, !cleanupGate.completed {
                 locked { _secondStartedBeforeCleanup = true }
             }
-            if blockFirstCall, ordinal == 1,
-               releaseFirstCall.wait(timeout: .now() + .seconds(2)) == .timedOut {
-                throw ProbeError.timedOutWaitingForRelease
+            if blockFirstCall, ordinal == 1 {
+                // Block like a long Metal/CPU step would, but observe
+                // cancellation at the same cadence a real step does.
+                let deadline = DispatchTime.now() + .seconds(2)
+                while releaseFirstCall.wait(timeout: .now() + .milliseconds(5)) == .timedOut {
+                    if shouldCancel() { throw GenerationInterruption.cancelled }
+                    if DispatchTime.now() >= deadline {
+                        throw ProbeError.timedOutWaitingForRelease
+                    }
+                }
             }
             if shouldCancel() { throw GenerationInterruption.cancelled }
             state.position += tokens.count
@@ -246,6 +253,65 @@ import Testing
         let calls = model.calls
         #expect(calls.map(\.tokens) == [[10], [65], [30]])
         #expect(Set(calls.map(\.stateID)).count == 1)
+        #expect(model.maxActiveCalls == 1)
+    }
+
+    /// A "new chat" issued mid-reply must interrupt the reply, not wait for it.
+    /// The probe blocks its first step for 2 s unless cancelled; the reset must
+    /// return well inside that window, and the following request must be a
+    /// fresh prompt rather than a continuation of the interrupted one.
+    @Test func resetConversationCancelsActiveGenerationInsteadOfWaiting() async throws {
+        let model = try SessionProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            blockFirstCall: true
+        )
+        let session = makeSession(model: model)
+        var options = SwiftletSession.GenerationOptions.greedy
+        options.minNew = 0
+
+        let stream = session.streamChat(
+            messages: [["role": "user", "content": "one"]],
+            maxNew: 4,
+            options: options
+        )
+        let consumer = Task { () -> Swift.Error? in
+            do {
+                for try await _ in stream {}
+                return nil
+            } catch {
+                return error
+            }
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while !model.firstCallEntered, Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(model.firstCallEntered)
+
+        let resetStarted = Date()
+        await withCheckedContinuation { (done: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                session.resetConversation()
+                done.resume()
+            }
+        }
+        let resetSeconds = Date().timeIntervalSince(resetStarted)
+        #expect(resetSeconds < 1.0, "reset waited \(resetSeconds)s for the interrupted reply")
+
+        let failure = await consumer.value
+        #expect(failure is GenerationInterruption)
+        #expect(model.calls.map(\.tokens) == [[10]])
+
+        // The reset landed: the same first message renders as a fresh prompt.
+        let next = session.streamChat(
+            messages: [["role": "user", "content": "one"]],
+            maxNew: 1,
+            options: options
+        )
+        var nextOutput = ""
+        for try await delta in next { nextOutput += delta }
+        #expect(nextOutput == "A")
+        #expect(model.calls.map(\.tokens) == [[10], [10], [65]])
         #expect(model.maxActiveCalls == 1)
     }
 

--- a/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
+++ b/Tests/SwiftletCoreTests/SwiftletSessionTests.swift
@@ -298,8 +298,11 @@ import Testing
         let resetSeconds = Date().timeIntervalSince(resetStarted)
         #expect(resetSeconds < 1.0, "reset waited \(resetSeconds)s for the interrupted reply")
 
+        // A cooperative cancellation ends the stream cleanly; the session reports
+        // it through metrics rather than by throwing to the consumer.
         let failure = await consumer.value
-        #expect(failure is GenerationInterruption)
+        #expect(failure == nil)
+        #expect(session.lastMetrics.finishReason == .cancelled)
         #expect(model.calls.map(\.tokens) == [[10]])
 
         // The reset landed: the same first message renders as a fresh prompt.

--- a/Tests/SwiftletCoreTests/TextGeneratorTests.swift
+++ b/Tests/SwiftletCoreTests/TextGeneratorTests.swift
@@ -3,6 +3,61 @@ import Testing
 @testable import SwiftletCore
 
 @Suite struct TextGeneratorTests {
+    private final class CancellationProbeModel: InferenceModel, @unchecked Sendable {
+        enum ProbeError: Swift.Error { case timedOutWaitingForCancellation }
+
+        let config: QwenConfig
+        let modelDir: URL
+        let waitForCancellation: Bool
+        private let lock = NSLock()
+        private var _legacyCalls = 0
+        private var _cancellableCalls = 0
+        private var _observedCancellation = false
+
+        init(modelDir: URL, waitForCancellation: Bool) throws {
+            self.modelDir = modelDir
+            self.waitForCancellation = waitForCancellation
+            config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
+        }
+
+        var legacyCalls: Int { locked { _legacyCalls } }
+        var cancellableCalls: Int { locked { _cancellableCalls } }
+        var observedCancellation: Bool { locked { _observedCancellation } }
+
+        func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+            locked { _legacyCalls += 1 }
+            return [Float](repeating: 0, count: config.vocabSize)
+        }
+
+        func step(
+            _ tokens: [Int],
+            state: QwenCPUModel.DecodeState,
+            shouldCancel: () -> Bool
+        ) throws -> [Float] {
+            locked { _cancellableCalls += 1 }
+            if waitForCancellation {
+                let deadline = Date().addingTimeInterval(2)
+                while !shouldCancel() {
+                    guard Date() < deadline else {
+                        throw ProbeError.timedOutWaitingForCancellation
+                    }
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+            }
+            if shouldCancel() {
+                locked { _observedCancellation = true }
+                throw GenerationInterruption.cancelled
+            }
+            return [Float](repeating: 0, count: config.vocabSize)
+        }
+
+        private func locked<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
     static let fixturesDir = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
@@ -23,5 +78,76 @@ import Testing
         }
         #expect(streamed == direct)
         #expect(streamed.count == 6)
+    }
+
+    @Test func generateRoutesCancellationThroughCancellableModelStep() throws {
+        let model = try CancellationProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            waitForCancellation: false
+        )
+        let generator = TextGenerator(model: model)
+        let cancellation = GenerationCancellation()
+        cancellation.cancel()
+
+        #expect(throws: GenerationInterruption.self) {
+            _ = try generator.generate(
+                promptIds: [1, 5, 9], maxNew: 2, cancellation: cancellation
+            ) { _ in true }
+        }
+        #expect(model.cancellableCalls == 1)
+        #expect(model.legacyCalls == 0)
+        #expect(model.observedCancellation)
+    }
+
+    @Test func tokenStreamOwnerCancelsBlockedPrefill() async throws {
+        let model = try CancellationProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            waitForCancellation: true
+        )
+        let generator = TextGenerator(model: model)
+        let cancellation = GenerationCancellation()
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(20)) {
+            cancellation.cancel()
+        }
+
+        var streamed: [Int] = []
+        for try await token in generator.tokenStream(
+            promptIds: [1, 5, 9], maxNew: 2, cancellation: cancellation
+        ) {
+            streamed.append(token)
+        }
+
+        #expect(streamed.isEmpty)
+        #expect(model.cancellableCalls == 1)
+        #expect(model.legacyCalls == 0)
+        #expect(model.observedCancellation)
+    }
+
+    @Test func cancellingConsumerTaskCancelsBlockedPrefill() async throws {
+        let model = try CancellationProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            waitForCancellation: true
+        )
+        let generator = TextGenerator(model: model)
+        let stream = generator.tokenStream(promptIds: [1, 5, 9], maxNew: 2)
+        let consumer = Task {
+            do {
+                for try await _ in stream {}
+            } catch {
+                // Cancellation is normal termination for this API.
+            }
+        }
+
+        try await Task<Never, Never>.sleep(nanoseconds: 20_000_000)
+        consumer.cancel()
+        await consumer.value
+        let deadline = Date().addingTimeInterval(1)
+        while !model.observedCancellation, Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(model.cancellableCalls == 1)
+        #expect(model.legacyCalls == 0)
+        #expect(model.observedCancellation)
     }
 }

--- a/Tests/SwiftletCoreTests/TextGeneratorTests.swift
+++ b/Tests/SwiftletCoreTests/TextGeneratorTests.swift
@@ -58,6 +58,71 @@ import Testing
         }
     }
 
+    private final class SingleFlightProbeModel: InferenceModel, @unchecked Sendable {
+        enum ProbeError: Swift.Error { case timedOutWaitingForRelease }
+
+        let config: QwenConfig
+        let modelDir: URL
+        private let lock = NSLock()
+        private let releaseFirstCall = DispatchSemaphore(value: 0)
+        private var _callCount = 0
+        private var _activeCalls = 0
+        private var _maxActiveCalls = 0
+        private var _firstCallEntered = false
+
+        init(modelDir: URL) throws {
+            self.modelDir = modelDir
+            config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
+        }
+
+        var callCount: Int { locked { _callCount } }
+        var maxActiveCalls: Int { locked { _maxActiveCalls } }
+        var firstCallEntered: Bool { locked { _firstCallEntered } }
+
+        func releaseFirst() {
+            releaseFirstCall.signal()
+        }
+
+        func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+            try runStep(shouldCancel: { false })
+        }
+
+        func step(
+            _ tokens: [Int],
+            state: QwenCPUModel.DecodeState,
+            shouldCancel: () -> Bool
+        ) throws -> [Float] {
+            try runStep(shouldCancel: shouldCancel)
+        }
+
+        private func runStep(shouldCancel: () -> Bool) throws -> [Float] {
+            let blocks = locked { () -> Bool in
+                _callCount += 1
+                _activeCalls += 1
+                _maxActiveCalls = max(_maxActiveCalls, _activeCalls)
+                if _callCount == 1 {
+                    _firstCallEntered = true
+                    return true
+                }
+                return false
+            }
+            defer { locked { _activeCalls -= 1 } }
+
+            if blocks,
+               releaseFirstCall.wait(timeout: .now() + .seconds(2)) == .timedOut {
+                throw ProbeError.timedOutWaitingForRelease
+            }
+            if shouldCancel() { throw GenerationInterruption.cancelled }
+            return [Float](repeating: 0, count: config.vocabSize)
+        }
+
+        private func locked<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
     static let fixturesDir = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
@@ -80,7 +145,7 @@ import Testing
         #expect(streamed.count == 6)
     }
 
-    @Test func generateRoutesCancellationThroughCancellableModelStep() throws {
+    @Test func generateRejectsPreCancelledWorkBeforeModelStep() throws {
         let model = try CancellationProbeModel(
             modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
             waitForCancellation: false
@@ -94,9 +159,73 @@ import Testing
                 promptIds: [1, 5, 9], maxNew: 2, cancellation: cancellation
             ) { _ in true }
         }
-        #expect(model.cancellableCalls == 1)
+        #expect(model.cancellableCalls == 0)
         #expect(model.legacyCalls == 0)
-        #expect(model.observedCancellation)
+        #expect(!model.observedCancellation)
+    }
+
+    @Test func concurrentTokenStreamsNeverOverlapModelCalls() async throws {
+        let model = try SingleFlightProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model")
+        )
+        let generator = TextGenerator(model: model)
+
+        let firstStream = generator.tokenStream(promptIds: [1], maxNew: 0)
+        let first = Task {
+            for try await _ in firstStream {}
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while !model.firstCallEntered, Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(model.firstCallEntered)
+
+        let secondStream = generator.tokenStream(promptIds: [2], maxNew: 0)
+        let second = Task {
+            for try await _ in secondStream {}
+        }
+        try await Task<Never, Never>.sleep(nanoseconds: 20_000_000)
+
+        #expect(model.callCount == 1)
+        #expect(model.maxActiveCalls == 1)
+        model.releaseFirst()
+        try await first.value
+        try await second.value
+
+        #expect(model.callCount == 2)
+        #expect(model.maxActiveCalls == 1)
+    }
+
+    @Test func queuedCancelledTokenStreamNeverTouchesModel() async throws {
+        let model = try SingleFlightProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model")
+        )
+        let generator = TextGenerator(model: model)
+
+        let firstStream = generator.tokenStream(promptIds: [1], maxNew: 0)
+        let first = Task {
+            for try await _ in firstStream {}
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while !model.firstCallEntered, Date() < deadline {
+            try await Task<Never, Never>.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(model.firstCallEntered)
+
+        let cancellation = GenerationCancellation()
+        let secondStream = generator.tokenStream(
+            promptIds: [2], maxNew: 0, cancellation: cancellation
+        )
+        let second = Task {
+            for try await _ in secondStream {}
+        }
+        cancellation.cancel()
+        model.releaseFirst()
+
+        try await first.value
+        try await second.value
+        #expect(model.callCount == 1)
+        #expect(model.maxActiveCalls == 1)
     }
 
     @Test func tokenStreamOwnerCancelsBlockedPrefill() async throws {

--- a/Tests/SwiftletCoreTests/TextGeneratorTests.swift
+++ b/Tests/SwiftletCoreTests/TextGeneratorTests.swift
@@ -3,6 +3,31 @@ import Testing
 @testable import SwiftletCore
 
 @Suite struct TextGeneratorTests {
+    private enum RecursiveGenerateOutcome: Equatable, Sendable {
+        case pending
+        case rejected(TextGenerator.Error)
+        case innerSucceeded
+        case unexpectedInnerError
+        case outerFailed
+    }
+
+    private final class RecursiveGenerateResult: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _outcome = RecursiveGenerateOutcome.pending
+
+        var outcome: RecursiveGenerateOutcome {
+            lock.lock()
+            defer { lock.unlock() }
+            return _outcome
+        }
+
+        func record(_ outcome: RecursiveGenerateOutcome) {
+            lock.lock()
+            _outcome = outcome
+            lock.unlock()
+        }
+    }
+
     private final class CancellationProbeModel: InferenceModel, @unchecked Sendable {
         enum ProbeError: Swift.Error { case timedOutWaitingForCancellation }
 
@@ -162,6 +187,39 @@ import Testing
         #expect(model.cancellableCalls == 0)
         #expect(model.legacyCalls == 0)
         #expect(!model.observedCancellation)
+    }
+
+    @Test func recursiveGenerateFromTokenCallbackIsRejectedWithoutDeadlock() throws {
+        let model = try CancellationProbeModel(
+            modelDir: Self.fixturesDir.appendingPathComponent("tiny-model"),
+            waitForCancellation: false
+        )
+        let generator = TextGenerator(model: model)
+        let result = RecursiveGenerateResult()
+        let completed = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            defer { completed.signal() }
+            do {
+                _ = try generator.generate(promptIds: [1], maxNew: 1) { _ in
+                    do {
+                        _ = try generator.generate(promptIds: [2], maxNew: 0) { _ in true }
+                        result.record(.innerSucceeded)
+                    } catch let error as TextGenerator.Error {
+                        result.record(.rejected(error))
+                    } catch {
+                        result.record(.unexpectedInnerError)
+                    }
+                    return false
+                }
+            } catch {
+                result.record(.outerFailed)
+            }
+        }
+
+        #expect(completed.wait(timeout: .now() + .seconds(2)) == .success)
+        #expect(result.outcome == .rejected(.reentrantGeneration))
+        #expect(model.cancellableCalls == 1)
     }
 
     @Test func concurrentTokenStreamsNeverOverlapModelCalls() async throws {

--- a/Tests/SwiftletServerTests/ChatRequestTests.swift
+++ b/Tests/SwiftletServerTests/ChatRequestTests.swift
@@ -85,7 +85,8 @@ import SwiftletCore
 
     @Test func nonterminalStreamingPayloadCarriesNullFinishReason() throws {
         let payload = completionPayload(
-            id: "chatcmpl-test", text: nil, delta: "piece", finish: nil
+            id: "chatcmpl-test", text: nil, delta: "piece", finish: nil,
+            model: "swiftlet-test"
         )
         let choices = try #require(payload["choices"] as? [[String: Any]])
         let choice = try #require(choices.first)

--- a/Tests/SwiftletServerTests/ChatRequestTests.swift
+++ b/Tests/SwiftletServerTests/ChatRequestTests.swift
@@ -83,6 +83,28 @@ import SwiftletCore
         #expect(openAIFinishReason(nil) == nil)
     }
 
+    @Test func nonterminalStreamingPayloadCarriesNullFinishReason() throws {
+        let payload = completionPayload(
+            id: "chatcmpl-test", text: nil, delta: "piece", finish: nil
+        )
+        let choices = try #require(payload["choices"] as? [[String: Any]])
+        let choice = try #require(choices.first)
+        #expect(choice["finish_reason"] is NSNull)
+
+        let encoded = try JSONSerialization.data(withJSONObject: payload)
+        let json = try #require(String(data: encoded, encoding: .utf8))
+        #expect(json.contains(#""finish_reason":null"#))
+    }
+
+    @Test func terminalStreamingPayloadCarriesConcreteFinishReason() throws {
+        let payload = completionPayload(
+            id: "chatcmpl-test", text: nil, delta: "", finish: "length"
+        )
+        let choices = try #require(payload["choices"] as? [[String: Any]])
+        let choice = try #require(choices.first)
+        #expect(choice["finish_reason"] as? String == "length")
+    }
+
     @Test func connectionOwnerCancelsQueuedAndActiveWork() {
         let owner = ConnectionGenerationOwner()
         let first = GenerationCancellation()
@@ -119,6 +141,22 @@ import SwiftletCore
 
         #expect(disconnectedRequest.isCancelled)
         #expect(!liveRequest.isCancelled)
+    }
+
+    @Test func writeFailureCancelsOnlyItsOwnedRequest() {
+        let owner = ConnectionGenerationOwner()
+        let failedRequest = GenerationCancellation()
+        let neighboringRequest = GenerationCancellation()
+        owner.register(id: "failed", cancellation: failedRequest)
+        owner.register(id: "neighbor", cancellation: neighboringRequest)
+
+        #expect(owner.failWrite(id: "failed"))
+        #expect(failedRequest.isCancelled)
+        #expect(!neighboringRequest.isCancelled)
+        #expect(!owner.failWrite(id: "unknown"))
+
+        owner.cancelAll()
+        #expect(neighboringRequest.isCancelled)
     }
 
     @Test func malformedInputThrows() {

--- a/Tests/SwiftletServerTests/ChatRequestTests.swift
+++ b/Tests/SwiftletServerTests/ChatRequestTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import SwiftletCore
 @testable import SwiftletServer
 
 @Suite struct ChatRequestTests {
@@ -53,6 +54,71 @@ import Testing
         #expect(r.messages.count == 1)
         #expect(r.max_tokens == nil)
         #expect(r.max_completion_tokens == 256)
+    }
+
+    @Test func stopAcceptsStringOrArray() throws {
+        let one = try decode(
+            #"{"messages":[{"role":"user","content":"hi"}],"stop":"END"}"#
+        )
+        #expect(one.stop?.values == ["END"])
+
+        let many = try decode(
+            #"{"messages":[{"role":"user","content":"hi"}],"stop":["END","USER:"]}"#
+        )
+        #expect(many.stop?.values == ["END", "USER:"])
+    }
+
+    @Test func nonStringStopThrows() {
+        #expect(throws: DecodingError.self) {
+            _ = try decode(
+                #"{"messages":[{"role":"user","content":"hi"}],"stop":42}"#
+            )
+        }
+    }
+
+    @Test func finishReasonMappingIsTruthful() {
+        #expect(openAIFinishReason(.stop) == "stop")
+        #expect(openAIFinishReason(.length) == "length")
+        #expect(openAIFinishReason(.cancelled) == nil)
+        #expect(openAIFinishReason(nil) == nil)
+    }
+
+    @Test func connectionOwnerCancelsQueuedAndActiveWork() {
+        let owner = ConnectionGenerationOwner()
+        let first = GenerationCancellation()
+        let second = GenerationCancellation()
+        owner.register(id: "first", cancellation: first)
+        owner.register(id: "second", cancellation: second)
+
+        owner.cancelAll()
+
+        #expect(first.isCancelled)
+        #expect(second.isCancelled)
+    }
+
+    @Test func completedWorkIsNoLongerOwnedByConnection() {
+        let owner = ConnectionGenerationOwner()
+        let completed = GenerationCancellation()
+        owner.register(id: "done", cancellation: completed)
+        owner.finish(id: "done")
+
+        owner.cancelAll()
+
+        #expect(!completed.isCancelled)
+    }
+
+    @Test func disconnectCancellationIsScopedToItsConnection() {
+        let disconnectedOwner = ConnectionGenerationOwner()
+        let liveOwner = ConnectionGenerationOwner()
+        let disconnectedRequest = GenerationCancellation()
+        let liveRequest = GenerationCancellation()
+        disconnectedOwner.register(id: "queued", cancellation: disconnectedRequest)
+        liveOwner.register(id: "active", cancellation: liveRequest)
+
+        disconnectedOwner.cancelAll()
+
+        #expect(disconnectedRequest.isCancelled)
+        #expect(!liveRequest.isCancelled)
     }
 
     @Test func malformedInputThrows() {


### PR DESCRIPTION
## What this fixes

Streamed requests could leak text past a `stop` string, report `length` when the stop had already matched, keep generating after the client went away, and let one connection's disconnect or a `resetConversation()` race the model while another request was mid-step. This series closes those gaps without changing what the model generates (see the A/B below).

Commits, in order:

1. **Fix streamed stop and cancellation semantics** — `StopSequenceFilter` holds back the longest suffix that could still become a stop string, across token boundaries and Unicode scalars, so nothing at or after a stop reaches the client; `finish_reason` is `stop` vs `length` truthfully. Cooperative `GenerationCancellation` is checked before/after each CPU step and between Metal command buffers (never while one is in flight).
2. **Close streamed request correctness gaps** — per-connection request ownership (`ConnectionGenerationOwner`): a disconnect or outbound write failure cancels only that connection's queued and active work; conversation state is committed transactionally and cleaned up before a continuation or the next request can start; SSE terminates with exactly one concrete-finish chunk, then `data: [DONE]`, then the HTTP end.
3. **Serialize public generation boundaries** — `SwiftletSession` and `TextGenerator` serialize their public entry points so concurrent callers cannot overlap or replace active `DecodeState`.
4. **Reject recursive text generation** — a same-generator callback that re-enters `generate` is rejected deterministically instead of deadlocking.
5. **Cancel an in-flight reply before resetting the conversation** — found by a fresh review of the rebased series: `resetConversation()` had become ordered behind the whole active reply; it now cancels it first and waits for at most one model-safe boundary. Also makes `GenerationInterruption` public so API callers can distinguish a cooperative cancellation from a failure.
6. **Make `completionPayload`'s model name a parameter** — found by running the suite on macOS: the test target crashed in `JSONSerialization` because `main.swift`'s script-mode `modelName` global is uninitialised when imported by tests.

Rebased onto `aaa910a` (#19/#20). In `QwenMetalModel.swift` the cancellation checks sit after each `commitAndWait(...)` and never inside it, so #20's timing counters stay intact and a cancelled step publishes `StepMetrics` with `completedWithoutThrow == false`. This series touches the same file as the open #21–#24 stack; whichever lands second rebases (one extra line per command-buffer boundary).

## Validation

macbook — MacBookPro18,2, Apple M1 Max, 64 GB, macOS 26.6.2, Command Line Tools with Swift 6.3.3 (no Xcode; `swift test` run with the README's Swift Testing framework flags):

- `swift build`, `swift build -c release`: clean.
- `swift test`: **89 tests in 15 suites passed**, including on real Metal — GenerationControlTests 5, StopSequenceFilterTests 15, TextGeneratorTests 7, SwiftletSessionTests 5, ChatRequestTests 17, MetalModelTests 3.

Live loopback exercise against `swiftlet-server --model Qwen3.6-35B-A3B-qpack --port 18080` (container downloaded from the R2 mirror and verified clean against the Hugging Face hashes with `scripts/verify_container.py`; 127.0.0.1 only; raw SSE captured with a socket client, greedy sampling): **9/9 checks passed** —

| check | result |
|---|---|
| terminal ordering | 12 chunks with `finish_reason: null`, one `stop` chunk, `data: [DONE]`, chunked terminator; 0 bytes after `[DONE]`, 0 bytes after HTTP end |
| ASCII stop `gamma` on "alpha beta gamma delta epsilon" | text `alpha beta `, `finish_reason: stop` |
| Unicode stop `résumé` on "café — résumé — naïve — piñata" | text `café — `, `finish_reason: stop` |
| `max_tokens: 5` | `finish_reason: length` |
| disconnect during a 4023-token prefill | request abandoned with 0 tokens generated; next request healthy |
| queued request closed before it started | never stepped (no server entry); active request finished with one terminal chunk |
| one of two live streams disconnected mid-stream | aborted stream stopped after 5 tokens; the other finished cleanly (`stop`, 78 chunks) |
| RST mid-stream (write failure) | aborted after 3 tokens; next request healthy |
| non-streaming | concrete `finish_reason`, `usage` populated |

Behavioural A/B, same greedy prompts to this branch and to `aaa910a` on the same box: identical text, chunk counts and finish reasons on all three prompts (including the case where the model emits `</s>\n<|user|>` after a one-word answer — that is the model/template on `main` too, untouched here).

One property to know about: while a response is outstanding, NIO's pipelining handler suppresses reads, so a client disconnect during a silent phase (prefill, or queued behind another request) is detected when the next write fails — the 15-second SSE heartbeat or the first token — rather than at the FIN itself. Mid-stream disconnects are caught at the next token. I've kept the heartbeat as is rather than change NIO read handling in this series.

Not run: Thread Sanitizer; a memory-pressure shrink during generation (covered by unit tests only).

Prepared with AI assistance; I reviewed the change and ran the validation above.
