### PR TITLE
Account for physical Metal allocations in the expert cache

### DIFF
--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -237,8 +237,11 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
     if let metal = model as? QwenMetalModel, let cache = metal.expertCache {
         let total = cache.hits + cache.misses
         FileHandle.standardError.write(Data(String(
-            format: "expert cache: %d slots (%.1f GB), %d hits / %d misses (%.0f%% hit rate)\n",
-            cache.slotCount, Double(cache.slotCount * cache.stride) / 1_073_741_824,
+            format: "expert cache: %d/%d slots (%.1f GB logical, %.1f GB allocated / %.1f GB budget), %d hits / %d misses (%.0f%% hit rate)\n",
+            cache.allocatedSlots, cache.slotCount,
+            Double(cache.logicalBytes) / 1_073_741_824,
+            Double(cache.allocatedBytes) / 1_073_741_824,
+            Double(cache.budgetBytes) / 1_073_741_824,
             cache.hits, cache.misses, total > 0 ? 100 * Double(cache.hits) / Double(total) : 0
         ).utf8))
     }

--- a/Sources/SwiftletCore/ExpertCache.swift
+++ b/Sources/SwiftletCore/ExpertCache.swift
@@ -1,11 +1,35 @@
 import Foundation
 import Metal
 
-/// Bounded expert-blob cache over a .qpack container: fixed slot pool of
-/// GPU-shared buffers, filled by single preads, LFU eviction with recency
-/// tie-break (TurboFieldfare's benchmarked policy). This replaces OS paging so
-/// the working set can never thrash the machine: memory use is exactly
-/// `slots * expertStride`, no more.
+/// Physical-allocation budget used by ``ExpertCache``. Metal may round a
+/// buffer's logical length up to a larger allocation, so the cache charges the
+/// resource's actual `allocatedSize` before retaining it.
+struct ExpertCacheBudget {
+    let limitBytes: Int
+    private(set) var allocatedBytes = 0
+
+    static func slotCapacity(
+        limitBytes: Int, stride: Int, totalSlots: Int, minimumSlots: Int = 16
+    ) -> Int? {
+        guard limitBytes >= 0, stride > 0, totalSlots > 0, minimumSlots >= 0 else {
+            return nil
+        }
+        let capacity = min(limitBytes / stride, totalSlots)
+        return capacity >= min(minimumSlots, totalSlots) ? capacity : nil
+    }
+
+    mutating func reserve(_ bytes: Int) -> Bool {
+        guard bytes > 0, allocatedBytes <= limitBytes,
+              bytes <= limitBytes - allocatedBytes else { return false }
+        allocatedBytes += bytes
+        return true
+    }
+}
+
+/// Bounded expert-blob cache over a .qpack container: a lazily allocated pool
+/// of GPU-shared buffers, filled by single preads, with LFU eviction and a
+/// recency tie-break (TurboFieldfare's benchmarked policy). Both logical slot
+/// capacity and Metal's physical allocation size are bounded by `budgetBytes`.
 public final class ExpertCache {
     let reader: QpackExpertReader
     public let stride: Int
@@ -21,7 +45,8 @@ public final class ExpertCache {
     public private(set) var hits = 0
     public private(set) var misses = 0
 
-    private let maxSlots: Int
+    private var maxSlots: Int
+    private var physicalBudget: ExpertCacheBudget
 
     init(containerDir: URL, device: MTLDevice, budgetBytes: Int) throws {
         self.device = device
@@ -30,8 +55,23 @@ public final class ExpertCache {
         guard stride > 0, !reader.layout.sections.isEmpty else {
             throw Checkpoint.Error.badShape("corrupt container: empty expert layout (re-download the model)")
         }
-        let total = reader.layout.expertCount * reader.layout.layerCount
-        maxSlots = min(max(budgetBytes / stride, 16), total)
+        let (total, overflow) = reader.layout.expertCount.multipliedReportingOverflow(
+            by: reader.layout.layerCount
+        )
+        guard !overflow, total > 0 else {
+            throw Checkpoint.Error.badShape("corrupt container: invalid expert count")
+        }
+        guard let capacity = ExpertCacheBudget.slotCapacity(
+            limitBytes: budgetBytes, stride: stride, totalSlots: total
+        ) else {
+            let availableSlots = budgetBytes >= 0 ? budgetBytes / stride : 0
+            throw Checkpoint.Error.badShape(
+                "expert cache budget fits \(availableSlots) logical slots; "
+                    + "at least \(min(16, total)) required"
+            )
+        }
+        maxSlots = capacity
+        physicalBudget = ExpertCacheBudget(limitBytes: budgetBytes)
         // Slots allocate lazily on demand (memory grows with use, never past
         // the budget) — important on iOS where an up-front multi-GB allocation
         // invites jetsam before the model even runs.
@@ -39,6 +79,9 @@ public final class ExpertCache {
 
     public var slotCount: Int { maxSlots }
     public var allocatedSlots: Int { slots.count }
+    public var logicalBytes: Int { slots.count * stride }
+    public var allocatedBytes: Int { physicalBudget.allocatedBytes }
+    public var budgetBytes: Int { physicalBudget.limitBytes }
 
     private func key(_ layer: Int, _ expert: Int) -> Int64 {
         Int64(layer) << 32 | Int64(expert)
@@ -79,12 +122,30 @@ public final class ExpertCache {
     /// LFU victim with recency tie-break; grow-on-demand, then free slots,
     /// then eviction.
     private func slotForFill(excluding: Set<Int>) throws -> Int {
-        if slots.count < maxSlots,
-           let b = device.makeBuffer(length: stride, options: .storageModeShared) {
-            slots.append(b)
-            slotKey.append(-1)
-            return slots.count - 1
+        if slots.count < maxSlots {
+            guard let b = device.makeBuffer(length: stride, options: .storageModeShared) else {
+                // Treat an allocator refusal as the discovered physical cap;
+                // repeated retries on every cache miss only make pressure worse.
+                maxSlots = slots.count
+                return try existingSlot(excluding: excluding)
+            }
+            // Never undercharge a resource even if a Metal implementation
+            // reports an unexpected value smaller than the requested length.
+            let charge = max(stride, b.allocatedSize)
+            if physicalBudget.reserve(charge) {
+                slots.append(b)
+                slotKey.append(-1)
+                return slots.count - 1
+            }
+            // Resource rounding made the physical capacity smaller than the
+            // logical estimate. Remember the discovered cap so every miss
+            // does not allocate and immediately discard another buffer.
+            maxSlots = slots.count
         }
+        return try existingSlot(excluding: excluding)
+    }
+
+    private func existingSlot(excluding: Set<Int>) throws -> Int {
         if let free = slotKey.firstIndex(of: -1) { return free }
         var victim = -1
         var victimScore = (Int.max, Int.max)
@@ -96,7 +157,12 @@ public final class ExpertCache {
                 victim = s
             }
         }
-        guard victim >= 0 else { throw Checkpoint.Error.badShape("expert cache too small for batch") }
+        guard victim >= 0 else {
+            throw Checkpoint.Error.badShape(
+                "expert cache budget fits \(slots.count) physical slots; "
+                    + "batch requires at least \(excluding.count + 1)"
+            )
+        }
         return victim
     }
 }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -373,9 +373,12 @@ public final class QwenMetalModel {
     /// immediately; the new cache refills lazily). Memory-pressure valve.
     public func shrinkCache(toGB gb: Double) {
         guard expertCache != nil else { return }
+        // Int(Double) traps on NaN, infinity, and out-of-range values; a
+        // pressure valve must refuse such a request, not crash on it.
+        let bytes = gb * 1_073_741_824
+        guard bytes >= 0, let budget = Int(exactly: bytes.rounded(.down)) else { return }
         guard let replacement = try? ExpertCache(
-            containerDir: ckpt.dir, device: engine.device,
-            budgetBytes: Int(gb * 1_073_741_824)
+            containerDir: ckpt.dir, device: engine.device, budgetBytes: budget
         ) else { return }
         expertCache = replacement
     }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -373,10 +373,11 @@ public final class QwenMetalModel {
     /// immediately; the new cache refills lazily). Memory-pressure valve.
     public func shrinkCache(toGB gb: Double) {
         guard expertCache != nil else { return }
-        expertCache = try? ExpertCache(
+        guard let replacement = try? ExpertCache(
             containerDir: ckpt.dir, device: engine.device,
             budgetBytes: Int(gb * 1_073_741_824)
-        )
+        ) else { return }
+        expertCache = replacement
     }
 
     // MARK: - GPU phase helper

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -79,12 +79,21 @@ public final class SwiftletSession: @unchecked Sendable {
         print("[SwiftletSession] loading tokenizer...")
         tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
         print("[SwiftletSession] tokenizer ok; building Metal model...")
-        if let gpu = try? QwenMetalModel(modelDir: modelDir, cacheBudgetGB: cacheBudgetGB) {
+        do {
+            let gpu = try QwenMetalModel(modelDir: modelDir, cacheBudgetGB: cacheBudgetGB)
             model = gpu
             usesGPU = true
             print("[SwiftletSession] Metal model ready")
-        } else {
-            print("[SwiftletSession] Metal init FAILED, falling back to CPU (heavy)")
+        } catch {
+            // A .qpack container streams its experts through the Metal cache
+            // and the CPU reader cannot serve it, so an impossible cache
+            // budget (or any other Metal failure) must surface here instead
+            // of producing a model that fails on its first step.
+            let isContainer = FileManager.default.fileExists(
+                atPath: modelDir.appendingPathComponent("packed_experts/layout.json").path
+            )
+            if isContainer { throw error }
+            print("[SwiftletSession] Metal init FAILED (\(error)), falling back to CPU (heavy)")
             let cpu = try QwenCPUModel(modelDir: modelDir)
             cpu.retainAllLayers = retainAllLayers
             model = cpu

--- a/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
+++ b/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
@@ -19,22 +19,30 @@ import Testing
     @Test func chargesPhysicalAllocationWithoutCrossingLimit() {
         var budget = ExpertCacheBudget(limitBytes: 100)
 
-        #expect(budget.reserve(64))
+        let first = budget.reserve(64)
+        #expect(first)
         #expect(budget.allocatedBytes == 64)
-        #expect(!budget.reserve(37))
+        let over = budget.reserve(37)
+        #expect(!over)
         #expect(budget.allocatedBytes == 64)
-        #expect(budget.reserve(36))
+        let exact = budget.reserve(36)
+        #expect(exact)
         #expect(budget.allocatedBytes == 100)
-        #expect(!budget.reserve(1))
+        let full = budget.reserve(1)
+        #expect(!full)
     }
 
     @Test func reservationIsOverflowSafe() {
         var budget = ExpertCacheBudget(limitBytes: .max)
 
-        #expect(!budget.reserve(0))
-        #expect(!budget.reserve(-1))
-        #expect(budget.reserve(Int.max - 1))
-        #expect(!budget.reserve(2))
+        let zero = budget.reserve(0)
+        let negative = budget.reserve(-1)
+        let nearlyFull = budget.reserve(Int.max - 1)
+        let overflow = budget.reserve(2)
+        #expect(!zero)
+        #expect(!negative)
+        #expect(nearlyFull)
+        #expect(!overflow)
         #expect(budget.allocatedBytes == Int.max - 1)
     }
 }

--- a/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
+++ b/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import SwiftletCore
+
+@Suite struct ExpertCacheBudgetTests {
+    @Test func requiresMinimumLogicalWorkingSet() {
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 15_999, stride: 1_000, totalSlots: 100
+        ) == nil)
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 16_000, stride: 1_000, totalSlots: 100
+        ) == 16)
+
+        // Small models need all of their slots, not an arbitrary minimum of 16.
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 8_000, stride: 1_000, totalSlots: 8
+        ) == 8)
+    }
+
+    @Test func chargesPhysicalAllocationWithoutCrossingLimit() {
+        var budget = ExpertCacheBudget(limitBytes: 100)
+
+        #expect(budget.reserve(64))
+        #expect(budget.allocatedBytes == 64)
+        #expect(!budget.reserve(37))
+        #expect(budget.allocatedBytes == 64)
+        #expect(budget.reserve(36))
+        #expect(budget.allocatedBytes == 100)
+        #expect(!budget.reserve(1))
+    }
+
+    @Test func reservationIsOverflowSafe() {
+        var budget = ExpertCacheBudget(limitBytes: .max)
+
+        #expect(!budget.reserve(0))
+        #expect(!budget.reserve(-1))
+        #expect(budget.reserve(Int.max - 1))
+        #expect(!budget.reserve(2))
+        #expect(budget.allocatedBytes == Int.max - 1)
+    }
+}

--- a/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
+++ b/Tests/SwiftletCoreTests/ExpertCacheBudgetTests.swift
@@ -16,6 +16,28 @@ import Testing
         ) == 8)
     }
 
+    @Test func rejectsInvalidCapacityInputs() {
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: -1, stride: 1_000, totalSlots: 100
+        ) == nil)
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 16_000, stride: 0, totalSlots: 100
+        ) == nil)
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 16_000, stride: 1_000, totalSlots: 0
+        ) == nil)
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 16_000, stride: 1_000, totalSlots: 100, minimumSlots: -1
+        ) == nil)
+        // Zero budget is well-formed input; it is the minimum that rejects it.
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 0, stride: 1_000, totalSlots: 100
+        ) == nil)
+        #expect(ExpertCacheBudget.slotCapacity(
+            limitBytes: 0, stride: 1_000, totalSlots: 100, minimumSlots: 0
+        ) == 0)
+    }
+
     @Test func chargesPhysicalAllocationWithoutCrossingLimit() {
         var budget = ExpertCacheBudget(limitBytes: 100)
 

--- a/Tests/SwiftletCoreTests/ExpertCacheMetalTests.swift
+++ b/Tests/SwiftletCoreTests/ExpertCacheMetalTests.swift
@@ -43,6 +43,43 @@ import Testing
         return root
     }
 
+    /// A stride the device cannot allocate at all: `makeBuffer` returns nil
+    /// on the very first miss, before any blob is read. The cache must turn
+    /// that into an error naming the zero-slot pool, remember the cap so no
+    /// further allocation is attempted, and leave the accounting at zero.
+    @Test func allocatorRefusalWithNoSlotsIsAnError() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let stride = Qpack.align(device.maxBufferLength + 1, to: Qpack.pageAlignment)
+        #expect(device.makeBuffer(length: stride, options: .storageModeShared) == nil)
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("expert-cache-refusal-\(UUID().uuidString)")
+        let dir = root.appendingPathComponent("packed_experts")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = Qpack.Layout(
+            expertCount: 1, layerCount: 1, expertStride: stride,
+            sections: [Qpack.Section(
+                name: "gate_proj.weight", dtype: "uint8", shape: [stride], offset: 0, size: stride
+            )],
+            linearLayers: [true]
+        )
+        try JSONEncoder().encode(layout).write(to: dir.appendingPathComponent("layout.json"))
+
+        let cache = try ExpertCache(containerDir: root, device: device, budgetBytes: 16 * stride)
+        #expect(cache.slotCount == 1)
+        for _ in 0..<2 {
+            #expect(throws: Checkpoint.Error.self) {
+                _ = try cache.buffers(layer: 0, experts: [0])
+            }
+        }
+        #expect(cache.allocatedSlots == 0)
+        #expect(cache.slotCount == 0)
+        #expect(cache.allocatedBytes == 0)
+        #expect(cache.logicalBytes == 0)
+        #expect(cache.misses == 2)
+    }
+
     @Test func physicalCapFollowsAllocatorRounding() throws {
         let device = try #require(MTLCreateSystemDefaultDevice())
         let container = try Self.makeContainer()

--- a/Tests/SwiftletCoreTests/ExpertCacheMetalTests.swift
+++ b/Tests/SwiftletCoreTests/ExpertCacheMetalTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Metal
+import Testing
+@testable import SwiftletCore
+
+/// Live-Metal accounting on a synthetic container whose expert stride is one
+/// byte over a 16 KiB page. The repacker page-aligns real strides, so this is
+/// the only way to make `MTLBuffer.allocatedSize` exceed the stride and drive
+/// the cache into its physical-cap path on current Apple devices.
+@Suite struct ExpertCacheMetalTests {
+    static let stride = 16_385
+    static let expertCount = 16
+    static let layerCount = 4
+
+    /// Writes `packed_experts/layout.json` plus one blob file per layer whose
+    /// every expert is filled with its own index, so a read-back can be
+    /// checked byte for byte.
+    static func makeContainer() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("expert-cache-metal-\(UUID().uuidString)")
+        let dir = root.appendingPathComponent("packed_experts")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let layout = Qpack.Layout(
+            expertCount: expertCount,
+            layerCount: layerCount,
+            expertStride: stride,
+            sections: [Qpack.Section(
+                name: "gate_proj.weight", dtype: "uint8", shape: [stride], offset: 0, size: stride
+            )],
+            linearLayers: Array(repeating: true, count: layerCount)
+        )
+        try JSONEncoder().encode(layout).write(to: dir.appendingPathComponent("layout.json"))
+        for layer in 0..<layerCount {
+            var blob = Data(count: stride * expertCount)
+            for expert in 0..<expertCount {
+                blob.replaceSubrange(
+                    expert * stride..<(expert + 1) * stride,
+                    with: Data(repeating: UInt8(expert), count: stride)
+                )
+            }
+            try blob.write(to: dir.appendingPathComponent(String(format: "layer_%02d.bin", layer)))
+        }
+        return root
+    }
+
+    @Test func physicalCapFollowsAllocatorRounding() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let container = try Self.makeContainer()
+        defer { try? FileManager.default.removeItem(at: container) }
+
+        // What this device actually allocates for one slot decides the
+        // expected shape: a rounding device caps below the logical ceiling, a
+        // non-rounding device reaches it. Both are asserted exactly.
+        let sample = try #require(device.makeBuffer(length: Self.stride, options: .storageModeShared))
+        let slotBytes = max(Self.stride, sample.allocatedSize)
+        let logicalSlots = 20
+        let budget = logicalSlots * Self.stride
+        let expectedSlots = min(logicalSlots, budget / slotBytes)
+
+        let cache = try ExpertCache(containerDir: container, device: device, budgetBytes: budget)
+        #expect(cache.slotCount == logicalSlots)
+        #expect(cache.allocatedSlots == 0)
+
+        // Fill past the physical ceiling one miss at a time. Every request is
+        // a fresh (layer, expert) pair, so each one is a miss.
+        var served = 0
+        for layer in 0..<Self.layerCount {
+            for expert in 0..<Self.expertCount where served < logicalSlots + 3 {
+                let bufs = try cache.buffers(layer: layer, experts: [expert])
+                #expect(bufs.count == 1)
+                #expect(bufs[0].length == Self.stride)
+                #expect(bufs[0].allocatedSize == sample.allocatedSize)
+                #expect(bufs[0].contents().load(as: UInt8.self) == UInt8(expert))
+                served += 1
+            }
+        }
+        #expect(cache.misses == served)
+        #expect(cache.hits == 0)
+        #expect(cache.allocatedSlots == expectedSlots)
+        #expect(cache.slotCount == expectedSlots)
+        #expect(cache.logicalBytes == expectedSlots * Self.stride)
+        #expect(cache.allocatedBytes == expectedSlots * slotBytes)
+        #expect(cache.allocatedBytes <= cache.budgetBytes)
+        if slotBytes > Self.stride {
+            #expect(cache.allocatedBytes > cache.logicalBytes)
+            #expect(expectedSlots < logicalSlots)
+        } else {
+            #expect(cache.allocatedBytes == cache.logicalBytes)
+            #expect(expectedSlots == logicalSlots)
+        }
+
+        // Once capped, a whole batch that fits stays resident together and
+        // does not grow the pool; one that does not fit is refused, not
+        // silently over-allocated.
+        let fits = Array(0..<min(expectedSlots, Self.expertCount))
+        let batch = try cache.buffers(layer: Self.layerCount - 1, experts: fits)
+        for (expert, buf) in zip(fits, batch) {
+            #expect(buf.contents().load(as: UInt8.self) == UInt8(expert))
+        }
+        #expect(cache.allocatedSlots == expectedSlots)
+        #expect(cache.allocatedBytes == expectedSlots * slotBytes)
+        if expectedSlots < Self.expertCount {
+            #expect(throws: Checkpoint.Error.self) {
+                _ = try cache.buffers(layer: 0, experts: Array(0..<(expectedSlots + 1)))
+            }
+            #expect(cache.allocatedSlots == expectedSlots)
+        }
+    }
+}

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -234,7 +234,16 @@ import Testing
 
         for cache in [sequentialGPU.expertCache!, elidingGPU.expertCache!] {
             #expect(cache.hits + cache.misses > 0)
+            #expect(cache.allocatedSlots > 0)
+            #expect(cache.allocatedBytes >= cache.logicalBytes)
+            #expect(cache.allocatedBytes <= cache.budgetBytes)
         }
+
+        // A pressure request below the minimum working set must not replace a
+        // functioning qpack cache with nil.
+        let cacheBeforeImpossibleShrink = sequentialGPU.expertCache!
+        sequentialGPU.shrinkCache(toGB: 0)
+        #expect(sequentialGPU.expertCache === cacheBeforeImpossibleShrink)
     }
 
     @Test func gpuMatchesCPUOnQwen35Tiny() throws {


### PR DESCRIPTION
## What this fixes

The qpack expert cache budgeted `slots × expertStride` and its doc comment promised memory use is "exactly `slots * expertStride`, no more". Each slot is its own `MTLBuffer`, and Metal may allocate more than the requested length (on an M1 Max a shared buffer above one 16 KiB page is rounded up to the next page: 16385 → 32768, 1048577 → 1064960). On iOS, where jetsam acts on physical allocation, that is the wrong number to be sure about. This series makes the cache account for what Metal actually allocated, and stops it from silently exceeding the budget it was given.

Commits, in order:

1. **Enforce physical expert cache budget** — `ExpertCacheBudget` derives the logical slot ceiling without ever rounding it above the requested budget, and refuses a budget that cannot hold `min(16, totalExperts)` slots instead of quietly allocating 16 anyway. Each retained slot is charged `max(expertStride, MTLBuffer.allocatedSize)` (never undercharged, even if a Metal implementation reports a smaller value); a reservation that would cross the budget, or an allocator refusal, becomes the remembered effective slot cap so later misses stop allocating-and-discarding. `logicalBytes`, `allocatedBytes` and `budgetBytes` are exposed separately and the CLI prints all three. `shrinkCache(toGB:)` keeps the live cache when a replacement cannot be built (previously it became `nil`, which the qpack path cannot serve). Expert-count multiplication is overflow-checked.
2. **Fix mutating cache budget assertions** — Swift Testing rejects a mutating call inside `#expect`; the reservation results are bound first.
3. **Assert live Metal cache accounting** — the real qpack Metal test asserts lazily allocated slots > 0, `allocatedBytes >= logicalBytes`, `allocatedBytes <= budgetBytes`, and that an impossible pressure shrink preserves the working cache.
4. **Surface Metal init failures for qpack containers** — found in review: `SwiftletSession` swallowed the Metal error with `try?` and fell back to the CPU reader, which cannot serve a container, so a too-small `--cache-gb` made `swiftlet-server` start and then fail every request with a missing-tensor error. For a container the error now propagates; for raw checkpoints the fallback stays and logs the error.
5. **Refuse non-finite cache shrink budgets and cover rejected inputs** — `Int(gb * 2^30)` traps on NaN/±inf/out-of-range; the pressure valve now refuses such input instead. Unit tests for negative/zero budget, stride and slot counts.
6. **Exercise the physical cap on a synthetic non-aligned stride** — the repacker page-aligns every real expert stride (`Qpack.align(offset, to: 16_384)`), so on a 16 KiB-page device a real container can never make `allocatedSize` exceed the stride and the cap path was reachable only by reading. This test builds a container by hand with stride 16385, fills it through `ExpertCache` on the live device, and asserts the exact shape either way: on a rounding device the pool stops at `budget / allocatedSize` slots below the logical ceiling with `allocatedBytes > logicalBytes` and a too-large batch refused; on a non-rounding device it reaches the logical ceiling with the two byte counts equal.
7. **Exercise allocator refusal on a stride the device cannot allocate** — a container whose stride exceeds `device.maxBufferLength` makes the very first `makeBuffer` return nil on real hardware, before any blob is read; the cache throws the zero-slot error, remembers the cap (no allocation is retried on the next miss), and the accounting stays at zero.

Scope, stated plainly: the budget bounds the **retained expert-cache buffers**. It is not a whole-process or whole-model ceiling, and one candidate buffer exists briefly before its `allocatedSize` can be charged (Metal only reports it after `makeBuffer`). Budgets below the minimum working set now fail at construction; for the supported models that minimum is under 30 MiB, and the 0.4 GB memory-pressure shrink still admits well over 200 slots.

Touches `ExpertCache.swift`, five lines of `QwenMetalModel.shrinkCache`, `SwiftletSession.init`, and the CLI's cache summary line; merges cleanly with the open #21–#25 stack (checked with `git merge-tree`).

Idea credit: Colibri [#1244](https://github.com/JustVugg/colibri/pull/1244) showed that logical tensor bytes can understate allocator footprint. This is a Metal-native implementation (`MTLBuffer.allocatedSize`); it does not probe free memory.

## Validation

MacBookPro18,2, Apple M1 Max, 64 GB, macOS 26.6.2, Command Line Tools with Swift 6.3.3 (no Xcode; `swift test` run with the README's Swift Testing framework flags), fresh clone, clean scratch path per ref:

- `swift build --build-tests`, `swift build -c release`: clean. Full-rebuild warning capture: the same 13 pre-existing diagnostics as `main` at `aaa910a`, none added.
- `swift test`: **56 tests in 15 suites passed** (base: 50 in 13). Focused: ExpertCacheMetalTests 2/2 (live device: synthetic stride cap, allocator refusal), ExpertCacheBudgetTests 4/4, MetalModelTests 3/3 on real Metal with a qpack repacked from the tiny fixture.
- `MTLBuffer.allocatedSize` probe on the same device: exact for sub-page lengths, rounded to 16 KiB pages above one page (16385 → 32768). Real containers cannot hit that: the repacker page-aligns the stride, so the qpack Metal test observes `allocatedBytes == logicalBytes`. The synthetic-stride test (commit 6) is what drives the cap path on this hardware: with stride 16385 and a 20-slot logical budget the pool stopped at 10 physically charged slots, `allocatedBytes` 327,680 > `logicalBytes` 163,850 and ≤ the 327,700 budget, and an 11-expert batch was refused.
- What that means for the claim: today the accounting changes nothing for a real container on a 16 KiB-page device beyond honest metrics and the allocator-refusal cap; it matters when Metal's allocation granularity exceeds the stride's alignment (another device, a future stride policy), and the test proves the cache does the right thing on both kinds of device.

Production weights (Qwen3.6-35B-A3B, 4-bit DWQ experts, repacked locally from an mlx-lm checkpoint; M1 Max): `swiftlet generate --gpu --cache-gb 0.5 --max-new 8` reports `expert cache: 303/303 slots (0.5 GB logical, 0.5 GB allocated / 0.5 GB budget), 83 hits / 2797 misses` — allocated equals logical because the repacker page-aligns the ~1.77 MB stride; `--cache-gb 0.01` now fails up front with `expert cache budget fits 6 logical slots; at least 16 required` from both the CLI and `swiftlet-server` (which exits at start-up instead of printing `listening` and failing every request).

iOS: `xcodebuild -scheme SwiftletCore -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` → `** BUILD SUCCEEDED **` on a GitHub-hosted `macos-26` runner (Xcode 26.6 17F113, Swift 6.3.3) at `569d6cc`; the only later commit is the test-only `5bb94d8`.

Not run: production 35B/80B weights.

Prepared with AI assistance; I reviewed the change and ran the validation above.



