### PR TITLE
Model-owned inference context and versioned conversation-state snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ swift build -c release
 .build/release/swiftlet generate ~/models/qwen3.6-35b.qpack \
   --gpu --chat --prompt "Explain expert streaming in one paragraph."
 
+# Save the conversation state (KV, DeltaNet recurrence, position) and resume
+# it later in a new process, continuing exactly from the saved state
+# (docs/STATE_FORMAT.md):
+.build/release/swiftlet generate ~/models/qwen3.6-35b.qpack \
+  --gpu --prompt "The fieldfare is a bird that" --save-state /tmp/s.swlstate
+.build/release/swiftlet generate ~/models/qwen3.6-35b.qpack \
+  --gpu --prompt " It" --load-state /tmp/s.swlstate
+
 # OpenAI-compatible server (loopback only):
 .build/release/swiftlet-server --model ~/models/qwen3.6-35b.qpack --port 8080
 ```

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -242,7 +242,22 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         if let vs = obj["eos_token_id"] as? [Int] { eos.formUnion(vs) }
     }
 
-    let context = model.makeContext()
+    // S6: --load-state resumes a saved context; the prompt/ids are then the
+    // continuation of that sequence (raw tokens, no template). The snapshot
+    // holds state, not the pending logits, so at least one token is needed.
+    let context: any InferenceContext
+    if let loadPath = flagValue(CommandLine.arguments, "--load-state") {
+        guard let persistable = model as? any PersistableInferenceModel else {
+            throw CLIError.statePersistenceUnavailable
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: loadPath))
+        context = try persistable.restoreContext(from: data)
+        FileHandle.standardError.write(Data(
+            "loaded state: \(loadPath) (\(data.count) bytes, position \(context.position))\n".utf8))
+    } else {
+        context = model.makeContext()
+    }
+    guard !ids.isEmpty else { throw CLIError.emptyPrompt }
     let prefillStart = Date()
     var logits = try model.step(ids, context: context)
     let prefillSecs = -prefillStart.timeIntervalSinceNow
@@ -308,6 +323,10 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         format: "decode: %d tokens in %.1fs (%.2f tok/s)\n",
         generated.count, decodeSecs, Double(generated.count) / max(decodeSecs, 0.001)
     ).utf8))
+    // Raw ids, so a resumed run (--load-state --ids ...) can be compared
+    // token for token against an uninterrupted one.
+    FileHandle.standardError.write(Data(
+        "generated ids: \(generated.map(String.init).joined(separator: ","))\n".utf8))
     if model is QwenMetalModel {
         let gpu = gpuTimingSummary(
             seconds: decodeMetal.gpuExecutionSeconds,
@@ -332,6 +351,29 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             cache.slotCount, Double(cache.slotCount * cache.stride) / 1_073_741_824,
             cache.hits, cache.misses, total > 0 ? 100 * Double(cache.hits) / Double(total) : 0
         ).utf8))
+    }
+    // S6: --save-state writes the context as it stands after the last
+    // generated token was fed (prompt + every generated token).
+    if let savePath = flagValue(CommandLine.arguments, "--save-state") {
+        guard let persistable = model as? any PersistableInferenceModel else {
+            throw CLIError.statePersistenceUnavailable
+        }
+        let data = try persistable.snapshot(of: context)
+        try data.write(to: URL(fileURLWithPath: savePath), options: .atomic)
+        FileHandle.standardError.write(Data(
+            "saved state: \(savePath) (\(data.count) bytes, position \(context.position))\n".utf8))
+    }
+}
+
+enum CLIError: Swift.Error, CustomStringConvertible {
+    case statePersistenceUnavailable
+    case emptyPrompt
+
+    var description: String {
+        switch self {
+        case .statePersistenceUnavailable: return "this model cannot save or load state"
+        case .emptyPrompt: return "nothing to feed: give --prompt or --ids (a loaded state needs at least one new token)"
+        }
     }
 }
 
@@ -443,9 +485,12 @@ default:
     print("  swiftlet verify <model-dir> <fixtures.safetensors>   compare CPU forward vs mlx fixture")
     print("  swiftlet dump-tensor <model-dir> <module-path> <out.safetensors>   dequantized f32 weights of one module")
     print("  swiftlet generate <model-dir> --prompt \"...\" [--max-new 32] [--chat] [--gpu] [--cache-gb 8] [--prefill-chunk 32] [--lazy]")
+    print("                                [--save-state <file>] [--load-state <file>]")
     print("  swiftlet chat <model-dir> [\"turn\" ...] [--max-new 256] [--cache-gb 8] [--greedy] [--system \"...\"]")
     print("")
     print("  --gpu       Metal runtime; on a .qpack container experts stream through a bounded cache")
     print("  --cache-gb  expert cache budget, default 8 (note: swiftlet-server defaults to 2)")
     print("  --lazy      CPU path only: ~3 GB peak instead of ~10-14 GB, slower per step")
+    print("  --save-state  after generating, write the context (KV, DeltaNet state, position) to <file>")
+    print("  --load-state  resume from <file>; --prompt/--ids are then fed as the continuation (docs/STATE_FORMAT.md)")
 }

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -242,9 +242,9 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         if let vs = obj["eos_token_id"] as? [Int] { eos.formUnion(vs) }
     }
 
-    let state = QwenCPUModel.DecodeState()
+    let context = model.makeContext()
     let prefillStart = Date()
-    var logits = try model.step(ids, state: state)
+    var logits = try model.step(ids, context: context)
     let prefillSecs = -prefillStart.timeIntervalSinceNow
     if let metal = model as? QwenMetalModel {
         let m = metal.lastStepMetrics
@@ -277,7 +277,7 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
     let decodeStart = Date()
     for _ in 0..<maxNew {
         var best = 0
-        for v in 1..<model.config.vocabSize where logits[v] > logits[best] { best = v }
+        for v in 1..<model.vocabSize where logits[v] > logits[best] { best = v }
         if eos.contains(best) { break }
         generated.append(best)
         if let tokenizer {
@@ -293,7 +293,7 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             print(best, terminator: " ")
             fflush(stdout)
         }
-        logits = try model.step([best], state: state)
+        logits = try model.step([best], context: context)
         if let metal = model as? QwenMetalModel {
             decodeMetal.add(metal.lastStepMetrics)
         }

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -20,6 +20,9 @@ private struct MetalStepAggregate {
     var gpuUntimedCommandBuffers = 0
     var phaseDispatches: [QwenMetalModel.StepPhase: Int] = [:]
     var phaseEncodeSeconds: [QwenMetalModel.StepPhase: Double] = [:]
+    /// Per-phase GPU seconds; non-nil only when the device measured them
+    /// (dispatch-boundary counters — see QwenMetalModel.PhaseGpuSplitSupport).
+    var phaseGpuSeconds: [QwenMetalModel.StepPhase: Double]?
     var bufferCounts: [String: Int] = [:]
     var bufferWaitSeconds: [String: Double] = [:]
     var bufferGpuSeconds: [String: Double] = [:]
@@ -41,6 +44,11 @@ private struct MetalStepAggregate {
         for (phase, s) in metrics.phaseEncodeSeconds {
             phaseEncodeSeconds[phase, default: 0] += s
         }
+        if let measured = metrics.phaseGpuSeconds {
+            var merged = phaseGpuSeconds ?? [:]
+            for (phase, s) in measured { merged[phase, default: 0] += s }
+            phaseGpuSeconds = merged
+        }
         for sample in metrics.commandBufferTimeline {
             let label = sample.phases.map(\.rawValue).joined(separator: "+")
             bufferCounts[label, default: 0] += 1
@@ -61,9 +69,14 @@ private func phaseSummaryLines(_ prefix: String, _ agg: MetalStepAggregate) -> [
         agg.phaseDispatches[$0, default: 0] > 0 || agg.phaseEncodeSeconds[$0, default: 0] > 0
     }
     if !phases.isEmpty {
-        let cells = phases.map {
-            "\($0.rawValue) enc=" + String(format: "%.3fs", agg.phaseEncodeSeconds[$0, default: 0])
-                + " disp=\(agg.phaseDispatches[$0, default: 0])"
+        let cells = phases.map { phase -> String in
+            var cell = "\(phase.rawValue) enc="
+                + String(format: "%.3fs", agg.phaseEncodeSeconds[phase, default: 0])
+                + " disp=\(agg.phaseDispatches[phase, default: 0])"
+            if let gpu = agg.phaseGpuSeconds {
+                cell += String(format: " gpu=%.3fs", gpu[phase, default: 0])
+            }
+            return cell
         }
         lines.append("\(prefix) S3b encode phases: " + cells.joined(separator: " | "))
     }
@@ -183,7 +196,19 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         // Metal runtime: weights stay quantized; experts stream via the
         // bounded cache (--cache-gb) when the model is a .qpack container.
         let cacheGB = Double(flagValue(CommandLine.arguments, "--cache-gb") ?? "8") ?? 8
-        model = try QwenMetalModel(modelDir: url, cacheBudgetGB: cacheGB)
+        let metal = try QwenMetalModel(modelDir: url, cacheBudgetGB: cacheGB)
+        // S3b follow-up: what the device's counters can actually sample, and
+        // whether the per-phase GPU split is measured or honestly absent.
+        let split: String
+        switch metal.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            split = "per-phase GPU split: measured (dispatch-boundary counters)"
+        case .unsupported(let reason):
+            split = "per-phase GPU split: unsupported (\(reason))"
+        }
+        FileHandle.standardError.write(Data(
+            "S3b counters: \(metal.counterSamplingSupport.summary)\n\(split)\n".utf8))
+        model = metal
     } else {
         let cpu = try QwenCPUModel(modelDir: url)
         // --lazy: ~3 GB peak instead of ~10-14 GB, at the cost of re-dequantizing

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -197,6 +197,13 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
         // bounded cache (--cache-gb) when the model is a .qpack container.
         let cacheGB = Double(flagValue(CommandLine.arguments, "--cache-gb") ?? "8") ?? 8
         let metal = try QwenMetalModel(modelDir: url, cacheBudgetGB: cacheGB)
+        // S1b prefill schedule knob: --prefill-chunk N sets the layer-major
+        // chunk size; 0 restores the legacy token-major schedule (A/B runs).
+        // Default (flag absent) is the model's layer-major default.
+        if let chunkFlag = flagValue(CommandLine.arguments, "--prefill-chunk"),
+           let chunk = Int(chunkFlag) {
+            metal.prefillMode = chunk <= 0 ? .tokenMajor : .layerMajor(chunkTokens: chunk)
+        }
         // S3b follow-up: what the device's counters can actually sample, and
         // whether the per-phase GPU split is measured or honestly absent.
         let split: String
@@ -435,7 +442,7 @@ default:
     print("  swiftlet info <model>            model budget summary (\(ArchConfig.known.keys.sorted().joined(separator: " | ")))")
     print("  swiftlet verify <model-dir> <fixtures.safetensors>   compare CPU forward vs mlx fixture")
     print("  swiftlet dump-tensor <model-dir> <module-path> <out.safetensors>   dequantized f32 weights of one module")
-    print("  swiftlet generate <model-dir> --prompt \"...\" [--max-new 32] [--chat] [--gpu] [--cache-gb 8] [--lazy]")
+    print("  swiftlet generate <model-dir> --prompt \"...\" [--max-new 32] [--chat] [--gpu] [--cache-gb 8] [--prefill-chunk 32] [--lazy]")
     print("  swiftlet chat <model-dir> [\"turn\" ...] [--max-new 256] [--cache-gb 8] [--greedy] [--system \"...\"]")
     print("")
     print("  --gpu       Metal runtime; on a .qpack container experts stream through a bounded cache")

--- a/Sources/SwiftletCLI/main.swift
+++ b/Sources/SwiftletCLI/main.swift
@@ -5,8 +5,9 @@ import Tokenizers
 func gib(_ bytes: Int) -> String { String(format: "%.2f GiB", Double(bytes) / Double(1 << 30)) }
 func mib(_ bytes: Int) -> String { String(format: "%.1f MiB", Double(bytes) / Double(1 << 20)) }
 
-/// S3a decode totals only. They establish an aggregate baseline, not phase or
-/// command-buffer timeline diagnosis.
+/// S3a whole-run totals plus S3b phase/timeline folds. Encode-side cost is
+/// exact per phase; wait/GPU cost is only available per command-buffer label
+/// because one buffer can span several phases.
 private struct MetalStepAggregate {
     var steps = 0
     var commandBuffersCommitted = 0
@@ -17,6 +18,12 @@ private struct MetalStepAggregate {
     var gpuExecutionSeconds = 0.0
     var gpuTimedCommandBuffers = 0
     var gpuUntimedCommandBuffers = 0
+    var phaseDispatches: [QwenMetalModel.StepPhase: Int] = [:]
+    var phaseEncodeSeconds: [QwenMetalModel.StepPhase: Double] = [:]
+    var bufferCounts: [String: Int] = [:]
+    var bufferWaitSeconds: [String: Double] = [:]
+    var bufferGpuSeconds: [String: Double] = [:]
+    var bufferGpuTimed: [String: Int] = [:]
 
     mutating func add(_ metrics: QwenMetalModel.StepMetrics) {
         steps += 1
@@ -28,7 +35,51 @@ private struct MetalStepAggregate {
         gpuExecutionSeconds += metrics.gpuExecutionSeconds
         gpuTimedCommandBuffers += metrics.gpuTimedCommandBuffers
         gpuUntimedCommandBuffers += metrics.gpuUntimedCommandBuffers
+        for (phase, n) in metrics.phaseDispatchesEncoded {
+            phaseDispatches[phase, default: 0] += n
+        }
+        for (phase, s) in metrics.phaseEncodeSeconds {
+            phaseEncodeSeconds[phase, default: 0] += s
+        }
+        for sample in metrics.commandBufferTimeline {
+            let label = sample.phases.map(\.rawValue).joined(separator: "+")
+            bufferCounts[label, default: 0] += 1
+            bufferWaitSeconds[label, default: 0] += sample.waitSeconds
+            if let gpu = sample.gpuSeconds {
+                bufferGpuSeconds[label, default: 0] += gpu
+                bufferGpuTimed[label, default: 0] += 1
+            }
+        }
     }
+}
+
+/// S3b stderr lines: exact encode-side phase split, then wait/GPU folded by
+/// command-buffer label (the honest granularity for those two costs).
+private func phaseSummaryLines(_ prefix: String, _ agg: MetalStepAggregate) -> [String] {
+    var lines: [String] = []
+    let phases = QwenMetalModel.StepPhase.allCases.filter {
+        agg.phaseDispatches[$0, default: 0] > 0 || agg.phaseEncodeSeconds[$0, default: 0] > 0
+    }
+    if !phases.isEmpty {
+        let cells = phases.map {
+            "\($0.rawValue) enc=" + String(format: "%.3fs", agg.phaseEncodeSeconds[$0, default: 0])
+                + " disp=\(agg.phaseDispatches[$0, default: 0])"
+        }
+        lines.append("\(prefix) S3b encode phases: " + cells.joined(separator: " | "))
+    }
+    if !agg.bufferCounts.isEmpty {
+        let cells = agg.bufferCounts.keys.sorted().map { label -> String in
+            let timed = agg.bufferGpuTimed[label, default: 0]
+            let gpu = timed > 0
+                ? String(format: "%.3fs/%d timed", agg.bufferGpuSeconds[label, default: 0], timed)
+                : "n/a"
+            return "\(label) cb=\(agg.bufferCounts[label, default: 0])"
+                + String(format: " wait=%.3fs", agg.bufferWaitSeconds[label, default: 0])
+                + " gpu=\(gpu)"
+        }
+        lines.append("\(prefix) S3b buffers: " + cells.joined(separator: " | "))
+    }
+    return lines
 }
 
 private func gpuTimingSummary(
@@ -177,6 +228,11 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             m.logitProjections, m.avoidedLogitProjections
         ) + " gpu=\(gpu)\n"
         FileHandle.standardError.write(Data(line.utf8))
+        var prefillAgg = MetalStepAggregate()
+        prefillAgg.add(m)
+        for extra in phaseSummaryLines("prefill", prefillAgg) {
+            FileHandle.standardError.write(Data((extra + "\n").utf8))
+        }
     } else {
         FileHandle.standardError.write(Data(String(
             format: "prefill: %d tokens in %.1fs\n", ids.count, prefillSecs
@@ -233,6 +289,9 @@ func runGenerate(modelDir: String, prompt: String, maxNew: Int, chat: Bool, rawI
             decodeMetal.blockingWaits, decodeMetal.computeDispatchesEncoded
         ) + " gpu=\(gpu)\n"
         FileHandle.standardError.write(Data(line.utf8))
+        for extra in phaseSummaryLines("decode", decodeMetal) {
+            FileHandle.standardError.write(Data((extra + "\n").utf8))
+        }
     }
     if let metal = model as? QwenMetalModel, let cache = metal.expertCache {
         let total = cache.hits + cache.misses

--- a/Sources/SwiftletCore/Checkpoint.swift
+++ b/Sources/SwiftletCore/Checkpoint.swift
@@ -23,6 +23,8 @@ public final class Checkpoint {
 
     private var files: [SafetensorsFile] = []
     private var fileURLs: [URL] = []
+    /// The safetensors shards backing this checkpoint (model identity input).
+    var shardURLs: [URL] { fileURLs }
     private var tensorToFile: [String: Int] = [:]
 
     public init(dir: URL) throws {

--- a/Sources/SwiftletCore/ConversationState.swift
+++ b/Sources/SwiftletCore/ConversationState.swift
@@ -1,0 +1,350 @@
+import CryptoKit
+import Foundation
+
+/// Why a snapshot was refused. Every case is a hard stop: nothing is
+/// restored from bytes that fail any check.
+public enum ConversationStateError: Swift.Error, Equatable {
+    /// Not a Swiftlet state file (or shorter than its magic).
+    case badMagic
+    /// A format version this build does not read.
+    case unsupportedVersion(found: UInt32, supported: UInt32)
+    /// Fewer bytes than the header says the file holds.
+    case truncated
+    /// Structurally wrong bytes: digest mismatch, bad section table, extra
+    /// or missing layers, a section whose size does not fit the geometry.
+    case corrupt(String)
+    /// Written from another checkpoint (identity digests differ, hex).
+    case modelMismatch(expected: String, found: String)
+    /// Same checkpoint family but a state-shaping dimension differs.
+    case geometryMismatch(field: String, expected: Int, found: Int)
+    /// The elements are not float32.
+    case dtypeMismatch(found: UInt32)
+}
+
+/// The versioned binary snapshot of a Qwen inference context. See
+/// docs/STATE_FORMAT.md for the byte layout; the constants and offsets there
+/// are pinned by ConversationStateTests.headerLayoutIsPinned.
+///
+/// Container: fixed 128-byte little-endian header, a run of float32
+/// sections, and a trailing SHA-256 over everything before it. The header
+/// carries the format version, dtype, a model identity digest (with the
+/// scheme that produced it), the eleven geometry fields that shape the
+/// state, the position, the section count, and the total byte length, so
+/// a reader can refuse a truncated, foreign, or mis-shaped file before it
+/// interprets a single section.
+public enum ConversationState {
+    public static let formatVersion: UInt32 = 1
+    static let magic: [UInt8] = Array("SWLSTATE".utf8)
+    static let headerBytes = 128
+    static let trailerBytes = 32
+    /// Element dtype codes. Only float32 exists in v1.
+    static let dtypeFloat32: UInt32 = 1
+
+    /// What a section holds. Layouts match both engines' state:
+    /// K/V rows [pos][kvHead][headDim], conv tail [convKernel-1][convDim],
+    /// delta state [vHead][vDim][kDim].
+    enum Kind: UInt32 {
+        case k = 1
+        case v = 2
+        case convTail = 3
+        case deltaState = 4
+    }
+
+    struct Section: Equatable {
+        let layer: Int
+        let kind: Kind
+        let values: [Float]
+    }
+
+    /// The state-shaping dimensions, in header order. Anything else in the
+    /// config (experts, MoE sizes, rope) does not change what a context
+    /// holds and is covered by the identity digest instead.
+    struct Geometry: Equatable {
+        static let fieldNames = [
+            "numHiddenLayers", "fullAttentionInterval", "numKeyValueHeads", "headDim",
+            "linearNumValueHeads", "linearNumKeyHeads", "linearKeyHeadDim",
+            "linearValueHeadDim", "linearConvKernelDim", "hiddenSize", "vocabSize",
+        ]
+        let values: [Int]
+
+        init(values: [Int]) {
+            precondition(values.count == Self.fieldNames.count)
+            self.values = values
+        }
+
+        init(config c: QwenConfig) {
+            self.init(values: [
+                c.numHiddenLayers, c.fullAttentionInterval, c.numKeyValueHeads, c.headDim,
+                c.linearNumValueHeads, c.linearNumKeyHeads, c.linearKeyHeadDim,
+                c.linearValueHeadDim, c.linearConvKernelDim, c.hiddenSize, c.vocabSize,
+            ])
+        }
+
+        var numHiddenLayers: Int { values[0] }
+        var fullAttentionInterval: Int { values[1] }
+        var kvRowFloats: Int { values[2] * values[3] }
+        var convTailFloats: Int { (values[8] - 1) * convDim }
+        var deltaStateFloats: Int { values[4] * values[7] * values[6] }
+        private var convDim: Int { 2 * values[5] * values[6] + values[4] * values[7] }
+        func isLinearLayer(_ index: Int) -> Bool { (index + 1) % fullAttentionInterval != 0 }
+    }
+
+    /// A decoded file: everything the header and sections say, before it
+    /// is compared with any model.
+    struct Snapshot {
+        var identityScheme: UInt32
+        var identity: [UInt8]
+        var geometry: Geometry
+        var position: Int
+        var sections: [Section]
+
+        func section(layer: Int, kind: Kind) -> Section? {
+            sections.first { $0.layer == layer && $0.kind == kind }
+        }
+    }
+
+    // MARK: - Encoding
+
+    static func encode(_ s: Snapshot) -> Data {
+        precondition(s.identity.count == 32)
+        var sectionBytes = 0
+        for sec in s.sections { sectionBytes += 16 + 4 * sec.values.count }
+        let total = headerBytes + sectionBytes + trailerBytes
+        var body = Data(capacity: total - trailerBytes)
+        body.append(contentsOf: magic)
+        body.appendLE(formatVersion)
+        body.appendLE(UInt32(headerBytes))
+        body.appendLE(dtypeFloat32)
+        body.appendLE(s.identityScheme)
+        body.append(contentsOf: s.identity)
+        for v in s.geometry.values { body.appendLE(UInt32(v)) }
+        body.appendLE(UInt64(s.position))
+        body.appendLE(UInt32(s.sections.count))
+        body.appendLE(UInt64(total))
+        body.append(contentsOf: [UInt8](repeating: 0, count: headerBytes - body.count))
+        precondition(body.count == headerBytes)
+        for sec in s.sections {
+            body.appendLE(UInt32(sec.layer))
+            body.appendLE(sec.kind.rawValue)
+            body.appendLE(UInt64(sec.values.count))
+            sec.values.withUnsafeBufferPointer { body.append(Data(buffer: $0)) }
+        }
+        return signed(body)
+    }
+
+    /// Appends the trailing SHA-256 of `body`. Internal so tests can forge
+    /// headers and still exercise the semantic refusals.
+    static func signed(_ body: Data) -> Data {
+        var out = body
+        out.append(contentsOf: Array(SHA256.hash(data: body)))
+        return out
+    }
+
+    // MARK: - Decoding
+
+    /// Parses and structurally validates a file: magic, version, length,
+    /// digest, header fields, and a section table whose every entry fits
+    /// the header's own geometry and position. Model identity and geometry
+    /// are compared separately by `verify`.
+    static func decode(_ input: Data) throws -> Snapshot {
+        // Reader indexes from 0; a slice handed in from another Data would not.
+        let data = input.startIndex == 0 ? input : Data(input)
+        guard data.count >= magic.count, Array(data.prefix(magic.count)) == magic else {
+            throw ConversationStateError.badMagic
+        }
+        guard data.count >= headerBytes else { throw ConversationStateError.truncated }
+        var r = Reader(data: data, offset: magic.count)
+        let version = r.u32()
+        guard version == formatVersion else {
+            throw ConversationStateError.unsupportedVersion(found: version, supported: formatVersion)
+        }
+        let declaredHeader = r.u32()
+        guard declaredHeader == UInt32(headerBytes) else {
+            throw ConversationStateError.corrupt("header length \(declaredHeader)")
+        }
+        let dtype = r.u32()
+        let scheme = r.u32()
+        let identity = r.bytes(32)
+        var geometryValues: [Int] = []
+        for _ in Geometry.fieldNames { geometryValues.append(Int(r.u32())) }
+        let position = r.u64()
+        let sectionCount = r.u32()
+        let total = r.u64()
+        guard total >= UInt64(headerBytes + trailerBytes), total <= UInt64(Int.max) else {
+            throw ConversationStateError.corrupt("total length \(total)")
+        }
+        if data.count < Int(total) { throw ConversationStateError.truncated }
+        if data.count > Int(total) { throw ConversationStateError.corrupt("trailing bytes") }
+
+        let bodyEnd = data.count - trailerBytes
+        let digest = Array(SHA256.hash(data: data.subdata(in: 0..<bodyEnd)))
+        guard digest == Array(data.suffix(trailerBytes)) else {
+            throw ConversationStateError.corrupt("digest mismatch")
+        }
+        // Digest verified: the rest of the bytes are what the writer wrote,
+        // so any inconsistency below is the writer's, not transport damage.
+        guard dtype == dtypeFloat32 else { throw ConversationStateError.dtypeMismatch(found: dtype) }
+        guard geometryValues.allSatisfy({ $0 > 0 }) else {
+            throw ConversationStateError.corrupt("non-positive geometry field")
+        }
+        let geometry = Geometry(values: geometryValues)
+        guard position <= UInt64(Int.max / 4) else {
+            throw ConversationStateError.corrupt("position \(position)")
+        }
+
+        r = Reader(data: data, offset: headerBytes)
+        var sections: [Section] = []
+        for _ in 0..<sectionCount {
+            guard r.offset + 16 <= bodyEnd else { throw ConversationStateError.corrupt("section table") }
+            let layer = Int(r.u32())
+            let kindRaw = r.u32()
+            let count = r.u64()
+            guard let kind = Kind(rawValue: kindRaw) else {
+                throw ConversationStateError.corrupt("section kind \(kindRaw)")
+            }
+            guard layer < geometry.numHiddenLayers else {
+                throw ConversationStateError.corrupt("section layer \(layer)")
+            }
+            let expected: UInt64
+            switch kind {
+            case .k, .v:
+                guard !geometry.isLinearLayer(layer) else {
+                    throw ConversationStateError.corrupt("KV section on DeltaNet layer \(layer)")
+                }
+                expected = position * UInt64(geometry.kvRowFloats)
+            case .convTail:
+                guard geometry.isLinearLayer(layer) else {
+                    throw ConversationStateError.corrupt("conv tail on attention layer \(layer)")
+                }
+                expected = UInt64(geometry.convTailFloats)
+            case .deltaState:
+                guard geometry.isLinearLayer(layer) else {
+                    throw ConversationStateError.corrupt("delta state on attention layer \(layer)")
+                }
+                expected = UInt64(geometry.deltaStateFloats)
+            }
+            guard count == expected else {
+                throw ConversationStateError.corrupt(
+                    "layer \(layer) \(kind) holds \(count) floats, geometry says \(expected)")
+            }
+            let byteCount = Int(count) * 4
+            guard r.offset + byteCount <= bodyEnd else { throw ConversationStateError.corrupt("section data") }
+            guard !sections.contains(where: { $0.layer == layer && $0.kind == kind }) else {
+                throw ConversationStateError.corrupt("duplicate section layer \(layer) \(kind)")
+            }
+            sections.append(Section(layer: layer, kind: kind, values: r.floats(Int(count))))
+        }
+        guard r.offset == bodyEnd else { throw ConversationStateError.corrupt("unread section bytes") }
+
+        // Every layer must be fully present once the sequence has started.
+        if position > 0 {
+            for li in 0..<geometry.numHiddenLayers {
+                let kinds: [Kind] = geometry.isLinearLayer(li) ? [.convTail, .deltaState] : [.k, .v]
+                for kind in kinds where !sections.contains(where: { $0.layer == li && $0.kind == kind }) {
+                    throw ConversationStateError.corrupt("layer \(li) missing \(kind)")
+                }
+            }
+        }
+        return Snapshot(identityScheme: scheme, identity: identity, geometry: geometry,
+                        position: Int(position), sections: sections)
+    }
+
+    /// The semantic refusals: same checkpoint, same state geometry.
+    static func verify(_ s: Snapshot, identity: ModelIdentity, geometry: Geometry) throws {
+        guard s.identityScheme == identity.scheme, s.identity == identity.digest else {
+            throw ConversationStateError.modelMismatch(
+                expected: identity.hex, found: s.identity.map { String(format: "%02x", $0) }.joined())
+        }
+        for (i, name) in Geometry.fieldNames.enumerated() where s.geometry.values[i] != geometry.values[i] {
+            throw ConversationStateError.geometryMismatch(
+                field: name, expected: geometry.values[i], found: s.geometry.values[i])
+        }
+    }
+
+    private struct Reader {
+        let data: Data
+        var offset: Int
+        mutating func u32() -> UInt32 {
+            defer { offset += 4 }
+            return data.subdata(in: offset..<offset + 4).withUnsafeBytes {
+                UInt32(littleEndian: $0.loadUnaligned(as: UInt32.self))
+            }
+        }
+        mutating func u64() -> UInt64 {
+            defer { offset += 8 }
+            return data.subdata(in: offset..<offset + 8).withUnsafeBytes {
+                UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
+            }
+        }
+        mutating func bytes(_ n: Int) -> [UInt8] {
+            defer { offset += n }
+            return Array(data.subdata(in: offset..<offset + n))
+        }
+        mutating func floats(_ n: Int) -> [Float] {
+            defer { offset += 4 * n }
+            return data.subdata(in: offset..<offset + 4 * n).withUnsafeBytes { raw in
+                [Float](unsafeUninitializedCapacity: n) { buf, filled in
+                    raw.copyBytes(to: buf)
+                    filled = n
+                }
+            }
+        }
+    }
+}
+
+/// What a snapshot names as its model. Cheap to compute (no weight bytes
+/// are read) and as strong as the container allows:
+///  - scheme 1, qpack container with hashes.json: SHA-256 over config.json
+///    and hashes.json, whose per-file SHA-256s pin every weight byte.
+///  - scheme 2, plain checkpoint (or a container without hashes.json):
+///    SHA-256 over config.json, manifest.json if present, and each
+///    safetensors shard's name, header JSON, and byte size. This pins the
+///    architecture, tensor layout, dtypes, and sizes, not the weight values.
+struct ModelIdentity: Equatable {
+    let scheme: UInt32
+    let digest: [UInt8]
+    var hex: String { digest.map { String(format: "%02x", $0) }.joined() }
+
+    static func compute(modelDir: URL, shards: [URL]) throws -> ModelIdentity {
+        var hasher = SHA256()
+        func feed(_ label: String, _ data: Data) {
+            hasher.update(data: Data(label.utf8))
+            var n = UInt64(data.count).littleEndian
+            withUnsafeBytes(of: &n) { hasher.update(bufferPointer: $0) }
+            hasher.update(data: data)
+        }
+        feed("config.json", try Data(contentsOf: modelDir.appendingPathComponent("config.json")))
+        let hashes = modelDir.appendingPathComponent("hashes.json")
+        if let hashBytes = try? Data(contentsOf: hashes) {
+            feed("hashes.json", hashBytes)
+            return ModelIdentity(scheme: 1, digest: Array(hasher.finalize()))
+        }
+        if let manifest = try? Data(contentsOf: modelDir.appendingPathComponent("manifest.json")) {
+            feed("manifest.json", manifest)
+        }
+        for url in shards.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            let lenBytes = try handle.read(upToCount: 8) ?? Data()
+            guard lenBytes.count == 8 else { throw Checkpoint.Error.badShape(url.lastPathComponent) }
+            let headerLen = lenBytes.withUnsafeBytes { UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self)) }
+            let header = try handle.read(upToCount: Int(headerLen)) ?? Data()
+            let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? UInt64) ?? 0
+            var sizeLE = size.littleEndian
+            feed(url.lastPathComponent, header)
+            withUnsafeBytes(of: &sizeLE) { hasher.update(bufferPointer: $0) }
+        }
+        return ModelIdentity(scheme: 2, digest: Array(hasher.finalize()))
+    }
+}
+
+private extension Data {
+    mutating func appendLE(_ v: UInt32) {
+        var le = v.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+    mutating func appendLE(_ v: UInt64) {
+        var le = v.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+}

--- a/Sources/SwiftletCore/InferenceModel.swift
+++ b/Sources/SwiftletCore/InferenceModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Opaque, model-owned inference state: whatever a backend needs to continue
+/// a sequence (attention KV, recurrent state, position...). Callers hold the
+/// handle and pass it back to the model that created it; they never look
+/// inside. This is the S7 seam: a new backend supplies its own context type
+/// and nothing above the model protocol has to know what it holds.
+public protocol InferenceContext: AnyObject {
+    /// Tokens the context has consumed so far.
+    var position: Int { get }
+    /// Discards everything the context holds; the next step starts a fresh
+    /// sequence. The handle stays valid.
+    func reset()
+}
+
+/// Thrown when a context is handed to a model that did not create it (a
+/// different backend, or a different instance of the same backend), or when
+/// a context's contents cannot belong to the model's geometry.
+public enum InferenceContextError: Swift.Error, Equatable {
+    /// The context was created by another model instance or backend.
+    case foreignContext
+    /// The context's stored state does not match the model's geometry
+    /// (e.g. a KV layer with the wrong row count for its position).
+    case inconsistentContext(String)
+}
+
+/// A model that can decode incrementally: CPU reference or Metal runtime.
+/// Contexts are created by the model, advanced by `step`, reset through
+/// the context itself, and refused by any other model instance.
+public protocol InferenceModel: AnyObject {
+    /// Number of logits `step` returns.
+    var vocabSize: Int { get }
+    var modelDir: URL { get }
+    /// A fresh context at position 0, owned by this model instance.
+    func makeContext() -> any InferenceContext
+    /// Processes `tokens` continuing from `context`, returning the last
+    /// position's logits. Used for prefill (many tokens) and decode (one).
+    func step(_ tokens: [Int], context: any InferenceContext) throws -> [Float]
+}

--- a/Sources/SwiftletCore/InferenceModel.swift
+++ b/Sources/SwiftletCore/InferenceModel.swift
@@ -37,3 +37,16 @@ public protocol InferenceModel: AnyObject {
     /// position's logits. Used for prefill (many tokens) and decode (one).
     func step(_ tokens: [Int], context: any InferenceContext) throws -> [Float]
 }
+
+/// A model whose contexts can be written out and reopened later (S6). The
+/// bytes are a versioned snapshot that names the model they came from; a
+/// restore into a different model, format version, geometry, or dtype is
+/// refused rather than continued from foreign state.
+public protocol PersistableInferenceModel: InferenceModel {
+    /// Serializes `context`, which must belong to this model instance. The
+    /// context stays live and unchanged.
+    func snapshot(of context: any InferenceContext) throws -> Data
+    /// A new context of this model holding the snapshot's state, ready to
+    /// continue from its position.
+    func restoreContext(from data: Data) throws -> any InferenceContext
+}

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -579,7 +579,7 @@ kernel void attn_kv_append(
 // into registers either way, so scratch offsets never need alignment); odd
 // head dims keep the lane-strided scalar loop. Per-lane accumulators and
 // the threadgroup tile cover headDim <= 256.
-#define ATTN_DECODE_SG 4
+#define ATTN_DECODE_SG 8
 
 inline void attn_decode_head(
     device float *data,

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -302,6 +302,174 @@ kernel void gemv_affine_fast8(
     if (lane == 0) y[p.yOff + row] = acc;
 }
 
+// ===== S1b token-batched GEMV: one dispatch applies the same linear to =====
+// many token slots. Each grid slice reads its x/y float offsets from a small
+// offset table (buffer 6, or 4 for the plain variant); the per-row arithmetic
+// is copied verbatim from the single-token kernels above, so every output row
+// is bitwise the value the equivalent unbatched dispatch writes.
+
+kernel void gemv_affine_batch(
+    device const float *x       [[buffer(0)]],
+    device const uchar *w       [[buffer(1)]],
+    device const uchar *scales  [[buffer(2)]],
+    device const uchar *biases  [[buffer(3)]],
+    device float       *y       [[buffer(4)]],
+    constant GemvParams &p      [[buffer(5)]],
+    constant uint2     *offs    [[buffer(6)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint row = tpg.x;
+    if (row >= p.outDim) return;
+    const uint xOff = offs[tpg.y].x;
+    const uint yOff = offs[tpg.y].y;
+    const uint perWord = 32 / p.bits;
+    const uint mask = (1u << p.bits) - 1u;
+    const uint packedCols = p.inDim / perWord;   // in uint32 words
+    const uint groups = p.inDim / p.groupSize;
+    const uint wordsPerGroup = p.groupSize / perWord;
+    const ulong rowBase = p.wOff + ulong(row) * packedCols * 4;
+
+    float acc = 0;
+    for (uint g = 0; g < groups; ++g) {
+        float qdot = 0;
+        float xsum = 0;
+        uint base = g * wordsPerGroup;
+        uint xbase = g * p.groupSize;
+        for (uint wi = 0; wi < wordsPerGroup; ++wi) {
+            uint word = load_u32(w, rowBase + ulong(base + wi) * 4);
+            uint xoff = xOff + xbase + wi * perWord;
+            for (uint j = 0; j < perWord; ++j) {
+                float xv = x[xoff + j];
+                qdot += float(word & mask) * xv;
+                xsum += xv;
+                word >>= p.bits;
+            }
+        }
+        uint gi = row * groups + g;
+        acc += load_scale(scales, p.sOff, gi, p.scalesType) * qdot
+             + load_scale(biases, p.bOff, gi, p.scalesType) * xsum;
+    }
+    y[yOff + row] = acc;
+}
+
+kernel void gemv_plain_batch(
+    device const float *x        [[buffer(0)]],
+    device const uchar *w        [[buffer(1)]],
+    device float       *y        [[buffer(2)]],
+    constant GemvPlainParams &p  [[buffer(3)]],
+    constant uint2     *offs     [[buffer(4)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint row = tpg.x;
+    if (row >= p.outDim) return;
+    const uint xOff = offs[tpg.y].x;
+    const uint yOff = offs[tpg.y].y;
+    float acc = 0;
+    if (p.dtype == 0) {
+        ulong base = p.wOff + ulong(row) * p.inDim * 4;
+        for (uint i = 0; i < p.inDim; ++i)
+            acc += as_type<float>(load_u32(w, base + ulong(i) * 4)) * x[xOff + i];
+    } else {
+        ulong base = p.wOff + ulong(row) * p.inDim * 2;
+        for (uint i = 0; i < p.inDim; ++i) {
+            ushort u = ushort(w[base + ulong(i) * 2]) | (ushort(w[base + ulong(i) * 2 + 1]) << 8);
+            float wv = (p.dtype == 1) ? float(as_type<half>(u)) : as_type<float>(uint(u) << 16);
+            acc += wv * x[xOff + i];
+        }
+    }
+    y[yOff + row] = acc;
+}
+
+kernel void gemv_affine_fast_batch(
+    device const float *x       [[buffer(0)]],
+    device const uchar *w       [[buffer(1)]],
+    device const uchar *scales  [[buffer(2)]],
+    device const uchar *biases  [[buffer(3)]],
+    device float       *y       [[buffer(4)]],
+    constant GemvParams &p      [[buffer(5)]],
+    constant uint2     *offs    [[buffer(6)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint row = tpg.y;
+    if (row >= p.outDim) return;
+    const uint xOff = offs[tpg.z].x;
+    const uint yOff = offs[tpg.z].y;
+    const uint packedCols = p.inDim / 8;           // uint32 words per row
+    const uint groups = p.inDim / p.groupSize;
+    const uint wordsPerGroup = p.groupSize / 8;
+    device const uint *wr = (device const uint *)(w + p.wOff + ulong(row) * packedCols * 4);
+
+    float acc = 0;
+    for (uint g = lane; g < groups; g += 32) {
+        float qdot = 0;
+        float xsum = 0;
+        uint base = g * wordsPerGroup;
+        uint xbase = xOff + g * p.groupSize;
+        for (uint wi = 0; wi < wordsPerGroup; ++wi) {
+            uint word = wr[base + wi];
+            uint xo = xbase + wi * 8;
+            qdot += float(word & 0xF) * x[xo]
+                  + float((word >> 4) & 0xF) * x[xo + 1]
+                  + float((word >> 8) & 0xF) * x[xo + 2]
+                  + float((word >> 12) & 0xF) * x[xo + 3]
+                  + float((word >> 16) & 0xF) * x[xo + 4]
+                  + float((word >> 20) & 0xF) * x[xo + 5]
+                  + float((word >> 24) & 0xF) * x[xo + 6]
+                  + float((word >> 28) & 0xF) * x[xo + 7];
+            xsum += x[xo] + x[xo+1] + x[xo+2] + x[xo+3] + x[xo+4] + x[xo+5] + x[xo+6] + x[xo+7];
+        }
+        uint gi = row * groups + g;
+        acc += load_scale(scales, p.sOff, gi, p.scalesType) * qdot
+             + load_scale(biases, p.bOff, gi, p.scalesType) * xsum;
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) y[yOff + row] = acc;
+}
+
+kernel void gemv_affine_fast8_batch(
+    device const float *x       [[buffer(0)]],
+    device const uchar *w       [[buffer(1)]],
+    device const uchar *scales  [[buffer(2)]],
+    device const uchar *biases  [[buffer(3)]],
+    device float       *y       [[buffer(4)]],
+    constant GemvParams &p      [[buffer(5)]],
+    constant uint2     *offs    [[buffer(6)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint row = tpg.y;
+    if (row >= p.outDim) return;
+    const uint xOff = offs[tpg.z].x;
+    const uint yOff = offs[tpg.z].y;
+    const uint packedCols = p.inDim / 4;           // uint32 words per row
+    const uint groups = p.inDim / p.groupSize;
+    const uint wordsPerGroup = p.groupSize / 4;
+    device const uint *wr = (device const uint *)(w + p.wOff + ulong(row) * packedCols * 4);
+
+    float acc = 0;
+    for (uint g = lane; g < groups; g += 32) {
+        float qdot = 0;
+        float xsum = 0;
+        uint base = g * wordsPerGroup;
+        uint xbase = xOff + g * p.groupSize;
+        for (uint wi = 0; wi < wordsPerGroup; ++wi) {
+            uint word = wr[base + wi];
+            uint xo = xbase + wi * 4;
+            qdot += float(word & 0xFF) * x[xo]
+                  + float((word >> 8) & 0xFF) * x[xo + 1]
+                  + float((word >> 16) & 0xFF) * x[xo + 2]
+                  + float((word >> 24) & 0xFF) * x[xo + 3];
+            xsum += x[xo] + x[xo+1] + x[xo+2] + x[xo+3];
+        }
+        uint gi = row * groups + g;
+        acc += load_scale(scales, p.sOff, gi, p.scalesType) * qdot
+             + load_scale(biases, p.bOff, gi, p.scalesType) * xsum;
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) y[yOff + row] = acc;
+}
+
 // ===== S2 full attention: q prep, KV append, gated causal GQA softmax. =====
 // Replaces the fast path's CPU attention core. RoPE trig uses precise::
 // variants so angles match the CPU's libm within float rounding.

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -799,6 +799,183 @@ kernel void weighted_accum(
     h[i] += acc;
 }
 
+// ===== S1b batch twins for the per-token glue kernels above. The chunked
+// prefill's per-token destinations are slot-regular (token t's rows sit
+// exactly `stride` floats after token t-1's), so instead of an offset table
+// each twin gains a token grid dimension plus stride parameters. Bodies are
+// the single-token kernels' verbatim, so every token's rows are bitwise the
+// values the equivalent per-token dispatch writes.
+
+// norm_copy over n hidden rows: row t reads h[t*hStride...] and writes
+// dst[dstOff + t*dstStride...]. One simdgroup per row.
+struct NormCopyBatchParams {
+    uint dim;
+    float eps;
+    uint dstOff;
+    uint dstStride;
+    uint hStride;
+};
+
+kernel void norm_copy_batch(
+    device const float *h    [[buffer(0)]],
+    device float       *dst  [[buffer(1)]],
+    device const float *wgt  [[buffer(2)]],
+    constant NormCopyBatchParams &p [[buffer(3)]],
+    uint2 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    device const float *hr = h + tpg.y * p.hStride;
+    device float *dr = dst + p.dstOff + tpg.y * p.dstStride;
+    float ss = 0;
+    for (uint i = lane; i < p.dim; i += 32) ss += hr[i] * hr[i];
+    ss = simd_sum(ss);
+    float inv = metal::rsqrt(ss / float(p.dim) + p.eps);
+    for (uint i = lane; i < p.dim; i += 32) {
+        dr[i] = hr[i] * inv * wgt[i];
+    }
+}
+
+// silu_mul over n token slots: slot t adds t*stride to every offset.
+kernel void silu_mul_batch(
+    device const float *g  [[buffer(0)]],
+    device const float *u  [[buffer(1)]],
+    device float       *h  [[buffer(2)]],
+    constant uint4     &po [[buffer(3)]],   // (count, gOff, uOff, dstOff)
+    constant uint      &stride [[buffer(4)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint i = tpg.x;
+    if (i >= po.x) return;
+    const uint b = tpg.y * stride;
+    float gv = g[po.y + b + i];
+    h[po.w + b + i] = (gv / (1.0f + metal::exp(-gv))) * u[po.z + b + i];
+}
+
+// add_inplace over n hidden rows: h[t*hStride + i] += r[rOff + t*rStride + i].
+kernel void add_inplace_batch(
+    device float       *h  [[buffer(0)]],
+    device const float *r  [[buffer(1)]],
+    constant uint4     &po [[buffer(2)]],   // (count, rOff, hStride, rStride)
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint i = tpg.x;
+    if (i >= po.x) return;
+    h[tpg.y * po.z + i] += r[po.y + tpg.y * po.w + i];
+}
+
+// weighted_accum over n tokens: token t reads its expert/shared rows at
+// t*stride, its own K weights at wk[t*K...], and accumulates into hidden row
+// t*hStride. The per-token K-expert accumulation order stays inside the
+// kernel, exactly the single-token loop.
+struct AccumBatchParams {
+    uint D;
+    uint K;
+    uint dBase;
+    uint shOff;
+    uint gateOff;
+    uint stride;    // scratch slot stride, floats
+    uint hStride;   // hidden row stride, floats
+};
+
+kernel void weighted_accum_batch(
+    device float       *h    [[buffer(0)]],
+    device const float *data [[buffer(1)]],
+    constant AccumBatchParams &p [[buffer(2)]],
+    constant float     *wk   [[buffer(3)]],   // n*K weights, token-major
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint i = tpg.x;
+    if (i >= p.D) return;
+    const uint t = tpg.y;
+    const uint b = t * p.stride;
+    float acc = 0;
+    for (uint k = 0; k < p.K; ++k) {
+        acc += wk[t * p.K + k] * data[p.dBase + b + k * p.D + i];
+    }
+    float gl = data[p.gateOff + b];
+    acc += (1.0f / (1.0f + metal::exp(-gl))) * data[p.shOff + b + i];
+    h[t * p.hStride + i] += acc;
+}
+
+// attn_q_prep over n tokens: token t works inside its own slot stride at
+// position p.position + t. One simdgroup per (head, token).
+struct AttnPrepBatchParams {
+    uint heads;
+    uint headDim;
+    uint rot;
+    float eps;
+    float theta;
+    uint position;   // base; token t uses position + t
+    uint srcOff;
+    uint dstOff;
+    uint stride;
+};
+
+kernel void attn_q_prep_batch(
+    device float       *data [[buffer(0)]],
+    device const float *wgt  [[buffer(1)]],
+    constant AttnPrepBatchParams &p [[buffer(2)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.heads) return;
+    const uint t = tpg.z;
+    device const float *src = data + p.srcOff + t * p.stride + head * 2 * p.headDim;
+    device float *dst = data + p.dstOff + t * p.stride + head * p.headDim;
+    float ss = 0;
+    for (uint i = lane; i < p.headDim; i += 32) ss += src[i] * src[i];
+    ss = simd_sum(ss);
+    const float inv = metal::rsqrt(ss / float(p.headDim) + p.eps);
+    for (uint i = lane; i < p.headDim; i += 32) dst[i] = src[i] * inv * wgt[i];
+    simdgroup_barrier(metal::mem_flags::mem_device);
+    rope_row(dst, p.rot, p.position + t, p.theta, lane);
+}
+
+// attn_kv_append over n tokens: token t appends at cache row index
+// p.position + t — rows are disjoint per token, so batching cannot reorder
+// any write. One simdgroup per (kv head, token).
+struct AttnKVBatchParams {
+    uint kvHeads;
+    uint headDim;
+    uint rot;
+    float eps;
+    float theta;
+    uint position;   // base; token t appends at position + t
+    uint kSrcOff;
+    uint vSrcOff;
+    uint stride;
+};
+
+kernel void attn_kv_append_batch(
+    device float       *data   [[buffer(0)]],
+    device const float *wgt    [[buffer(1)]],
+    device float       *kCache [[buffer(2)]],
+    device float       *vCache [[buffer(3)]],
+    constant AttnKVBatchParams &p [[buffer(4)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.kvHeads) return;
+    const uint t = tpg.z;
+    device const float *kSrc = data + p.kSrcOff + t * p.stride + head * p.headDim;
+    device const float *vSrc = data + p.vSrcOff + t * p.stride + head * p.headDim;
+    const ulong row = (ulong(p.position + t) * p.kvHeads + head) * p.headDim;
+    device float *kDst = kCache + row;
+    device float *vDst = vCache + row;
+    float ss = 0;
+    for (uint i = lane; i < p.headDim; i += 32) ss += kSrc[i] * kSrc[i];
+    ss = simd_sum(ss);
+    const float inv = metal::rsqrt(ss / float(p.headDim) + p.eps);
+    for (uint i = lane; i < p.headDim; i += 32) {
+        kDst[i] = kSrc[i] * inv * wgt[i];
+        vDst[i] = vSrc[i];
+    }
+    simdgroup_barrier(metal::mem_flags::mem_device);
+    rope_row(kDst, p.rot, p.position + t, p.theta, lane);
+}
+
 // qwen3_next fused projections: de-interleave the per-k-head packed
 // [q(dk) | k(dk) | v(rep*dv) | z(rep*dv)] layout plus [b(rep) | a(rep)] into
 // flat regions [q|k|v], z, b, a (what the conv/delta pipeline consumes).
@@ -837,5 +1014,49 @@ kernel void deinterleave_qkvz(
         const uint baSrc = p.baOff + hk * 2 * p.rep;
         data[p.bOff + hk * p.rep + ri] = data[baSrc + ri];
         data[p.aOff + hk * p.rep + ri] = data[baSrc + p.rep + ri];
+    }
+}
+
+// deinterleave_qkvz over n token slots (S1b batch twin): slot t adds
+// t*stride to every source and destination offset; per-slot copies are the
+// single-token kernel's verbatim.
+struct DeintBatchParams {
+    uint nk;
+    uint dk;
+    uint rep;
+    uint dv;
+    uint keyDim;
+    uint srcOff;
+    uint baOff;
+    uint qkvOff;
+    uint zOff;
+    uint bOff;
+    uint aOff;
+    uint stride;
+};
+
+kernel void deinterleave_qkvz_batch(
+    device float        *data [[buffer(0)]],
+    constant DeintBatchParams &p [[buffer(1)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint hk = tpg.x;
+    if (hk >= p.nk) return;
+    const uint b = tpg.y * p.stride;
+    const uint chunk = 2 * p.dk + 2 * p.rep * p.dv;
+    const uint src = p.srcOff + b + hk * chunk;
+    for (uint i = 0; i < p.dk; ++i) {
+        data[p.qkvOff + b + hk * p.dk + i] = data[src + i];
+        data[p.qkvOff + b + p.keyDim + hk * p.dk + i] = data[src + p.dk + i];
+    }
+    for (uint ri = 0; ri < p.rep; ++ri) {
+        const uint hv = hk * p.rep + ri;
+        for (uint i = 0; i < p.dv; ++i) {
+            data[p.qkvOff + b + 2 * p.keyDim + hv * p.dv + i] = data[src + 2 * p.dk + ri * p.dv + i];
+            data[p.zOff + b + hv * p.dv + i] = data[src + 2 * p.dk + p.rep * p.dv + ri * p.dv + i];
+        }
+        const uint baSrc = p.baOff + b + hk * 2 * p.rep;
+        data[p.bOff + b + hk * p.rep + ri] = data[baSrc + ri];
+        data[p.aOff + b + hk * p.rep + ri] = data[baSrc + p.rep + ri];
     }
 }

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -566,9 +566,133 @@ kernel void attn_kv_append(
     rope_row(kDst, p.rot, p.position, p.theta, lane);
 }
 
-// Gated causal GQA attention for one query token over cache rows [0, kvLen):
-// out = sigmoid(gate) * softmax(q K^T / sqrt(hd)) V, online softmax in f32.
-// One simdgroup per query head; per-lane accumulators cover headDim <= 256.
+// Gated causal GQA attention core, shared by attn_decode_gqa and its
+// token-grid batch twin: out = sigmoid(gate) * softmax(q K^T / sqrt(hd)) V
+// over cache rows [0, kvLen), online softmax in f32 throughout. The KV loop
+// is tiled across ATTN_DECODE_SG simdgroups per (head, token): simdgroup g
+// scans rows g, g + SG, ... with its own running (max, sum, accumulator),
+// merged once at the end through threadgroup memory — each partial rescaled
+// by exp(m_g - M) against the global max, the same f32 correction the
+// online recurrence applies per row (a simdgroup whose row subset was empty
+// contributes exp(-inf - M) = 0). K/V rows are read as float4 when
+// headDim % 4 == 0 (cache rows are 16-byte aligned then; q is preloaded
+// into registers either way, so scratch offsets never need alignment); odd
+// head dims keep the lane-strided scalar loop. Per-lane accumulators and
+// the threadgroup tile cover headDim <= 256.
+#define ATTN_DECODE_SG 4
+
+inline void attn_decode_head(
+    device float *data,
+    device const float *kCache,
+    device const float *vCache,
+    uint kvHeads, uint headDim, uint kvLen,
+    uint qOff, uint gateOff, uint outOff, uint kvHead,
+    uint sg, uint lane,
+    threadgroup float *tgM, threadgroup float *tgS, threadgroup float4 *tgAcc)
+{
+    device const float *q = data + qOff;
+    const float scale = metal::rsqrt(float(headDim));
+    const bool vec = headDim % 4 == 0;
+    const uint hd4 = headDim / 4;
+
+    float m = -INFINITY;
+    float s = 0;
+    float4 acc4[2] = {float4(0.0f), float4(0.0f)};
+    float acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    float4 q4[2] = {float4(0.0f), float4(0.0f)};
+    float qs[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint cnt = 0;
+    if (vec) {
+        for (uint i = lane; i < hd4; i += 32) {
+            q4[cnt++] = float4(q[4 * i], q[4 * i + 1], q[4 * i + 2], q[4 * i + 3]);
+        }
+    } else {
+        for (uint i = lane; i < headDim; i += 32) qs[cnt++] = q[i];
+    }
+
+    for (uint sj = sg; sj < kvLen; sj += ATTN_DECODE_SG) {
+        const ulong row = (ulong(sj) * kvHeads + kvHead) * headDim;
+        float dot = 0;
+        if (vec) {
+            device const float4 *kr = (device const float4 *)(kCache + row);
+            cnt = 0;
+            for (uint i = lane; i < hd4; i += 32) dot += metal::dot(q4[cnt++], kr[i]);
+        } else {
+            device const float *kr = kCache + row;
+            cnt = 0;
+            for (uint i = lane; i < headDim; i += 32) dot += qs[cnt++] * kr[i];
+        }
+        dot = simd_sum(dot) * scale;
+        const float mNew = metal::max(m, dot);
+        const float corr = metal::exp(m - mNew);   // first row: exp(-inf) = 0
+        const float w = metal::exp(dot - mNew);
+        s = s * corr + w;
+        if (vec) {
+            device const float4 *vr = (device const float4 *)(vCache + row);
+            cnt = 0;
+            for (uint i = lane; i < hd4; i += 32) {
+                acc4[cnt] = acc4[cnt] * corr + w * vr[i];
+                ++cnt;
+            }
+        } else {
+            device const float *vr = vCache + row;
+            cnt = 0;
+            for (uint i = lane; i < headDim; i += 32) {
+                acc[cnt] = acc[cnt] * corr + w * vr[i];
+                ++cnt;
+            }
+        }
+        m = mNew;
+    }
+
+    if (lane == 0) {
+        tgM[sg] = m;
+        tgS[sg] = s;
+    }
+    threadgroup float *tgAccF = (threadgroup float *)tgAcc;
+    if (vec) {
+        cnt = 0;
+        for (uint i = lane; i < hd4; i += 32) tgAcc[sg * hd4 + i] = acc4[cnt++];
+    } else {
+        cnt = 0;
+        for (uint i = lane; i < headDim; i += 32) tgAccF[sg * headDim + i] = acc[cnt++];
+    }
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+    float M = tgM[0];
+    for (uint g = 1; g < ATTN_DECODE_SG; ++g) M = metal::max(M, tgM[g]);
+    float sTot = 0;
+    for (uint g = 0; g < ATTN_DECODE_SG; ++g) sTot += tgS[g] * metal::exp(tgM[g] - M);
+    const float invS = 1.0f / sTot;
+    if (sg != 0) return;
+    device const float *gate = data + gateOff;
+    device float *out = data + outOff;
+    if (vec) {
+        for (uint i = lane; i < hd4; i += 32) {
+            float4 a = float4(0.0f);
+            for (uint g = 0; g < ATTN_DECODE_SG; ++g) {
+                a += tgAcc[g * hd4 + i] * metal::exp(tgM[g] - M);
+            }
+            for (uint j = 0; j < 4; ++j) {
+                const float gv = gate[4 * i + j];
+                out[4 * i + j] = a[j] * invS * (1.0f / (1.0f + metal::exp(-gv)));
+            }
+        }
+    } else {
+        for (uint i = lane; i < headDim; i += 32) {
+            float a = 0;
+            for (uint g = 0; g < ATTN_DECODE_SG; ++g) {
+                a += tgAccF[g * headDim + i] * metal::exp(tgM[g] - M);
+            }
+            const float gv = gate[i];
+            out[i] = a * invS * (1.0f / (1.0f + metal::exp(-gv)));
+        }
+    }
+}
+
+// Gated causal GQA attention for one query token over cache rows [0, kvLen),
+// via the tiled core above. One threadgroup of ATTN_DECODE_SG simdgroups
+// per query head; headDim <= 256.
 struct AttnDecodeParams {
     uint heads;
     uint kvHeads;
@@ -585,43 +709,21 @@ kernel void attn_decode_gqa(
     device const float *vCache [[buffer(2)]],
     constant AttnDecodeParams &p [[buffer(3)]],
     uint2 tpg [[thread_position_in_grid]],
+    uint sg   [[simdgroup_index_in_threadgroup]],
     uint lane [[thread_index_in_simdgroup]])
 {
+    threadgroup float tgM[ATTN_DECODE_SG];
+    threadgroup float tgS[ATTN_DECODE_SG];
+    threadgroup float4 tgAcc[ATTN_DECODE_SG * 64];
     const uint head = tpg.y;
     if (head >= p.heads) return;
-    const uint kvHead = head / (p.heads / p.kvHeads);
-    device const float *q = data + p.qOff + head * p.headDim;
-    const float scale = metal::rsqrt(float(p.headDim));
-    float m = -INFINITY;
-    float s = 0;
-    float acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-    for (uint sj = 0; sj < p.kvLen; ++sj) {
-        const ulong row = (ulong(sj) * p.kvHeads + kvHead) * p.headDim;
-        device const float *kr = kCache + row;
-        float dot = 0;
-        for (uint i = lane; i < p.headDim; i += 32) dot += q[i] * kr[i];
-        dot = simd_sum(dot) * scale;
-        const float mNew = metal::max(m, dot);
-        const float corr = metal::exp(m - mNew);   // first row: exp(-inf) = 0
-        const float w = metal::exp(dot - mNew);
-        s = s * corr + w;
-        device const float *vr = vCache + row;
-        uint cnt = 0;
-        for (uint i = lane; i < p.headDim; i += 32) {
-            acc[cnt] = acc[cnt] * corr + w * vr[i];
-            ++cnt;
-        }
-        m = mNew;
-    }
-    const float invS = 1.0f / s;
-    device const float *gate = data + p.qoutOff + head * 2 * p.headDim + p.headDim;
-    device float *out = data + p.outOff + head * p.headDim;
-    uint cnt = 0;
-    for (uint i = lane; i < p.headDim; i += 32) {
-        float gv = gate[i];
-        out[i] = acc[cnt] * invS * (1.0f / (1.0f + metal::exp(-gv)));
-        ++cnt;
-    }
+    attn_decode_head(
+        data, kCache, vCache, p.kvHeads, p.headDim, p.kvLen,
+        p.qOff + head * p.headDim,
+        p.qoutOff + head * 2 * p.headDim + p.headDim,
+        p.outOff + head * p.headDim,
+        head / (p.heads / p.kvHeads),
+        sg, lane, tgM, tgS, tgAcc);
 }
 
 // ===== Small glue kernels so a token needs few command buffers. =====
@@ -1024,7 +1126,8 @@ kernel void attn_kv_append_batch(
 // [0, position + t + 1) — the causal kvLen derived from the token grid, so
 // one dispatch covers the whole chunk once every KV append has landed
 // (callers barrier between the appends and this). Per-token arithmetic is
-// the single-token kernel's verbatim. One simdgroup per (head, token).
+// the single-token kernel's verbatim: both run the tiled attn_decode_head
+// core. One threadgroup of ATTN_DECODE_SG simdgroups per (head, token).
 struct AttnDecodeBatchParams {
     uint heads;
     uint kvHeads;
@@ -1042,46 +1145,22 @@ kernel void attn_decode_gqa_batch(
     device const float *vCache [[buffer(2)]],
     constant AttnDecodeBatchParams &p [[buffer(3)]],
     uint3 tpg [[thread_position_in_grid]],
+    uint sg   [[simdgroup_index_in_threadgroup]],
     uint lane [[thread_index_in_simdgroup]])
 {
+    threadgroup float tgM[ATTN_DECODE_SG];
+    threadgroup float tgS[ATTN_DECODE_SG];
+    threadgroup float4 tgAcc[ATTN_DECODE_SG * 64];
     const uint head = tpg.y;
     if (head >= p.heads) return;
-    const uint t = tpg.z;
-    const uint b = t * p.stride;
-    const uint kvLen = p.position + t + 1;
-    const uint kvHead = head / (p.heads / p.kvHeads);
-    device const float *q = data + p.qOff + b + head * p.headDim;
-    const float scale = metal::rsqrt(float(p.headDim));
-    float m = -INFINITY;
-    float s = 0;
-    float acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-    for (uint sj = 0; sj < kvLen; ++sj) {
-        const ulong row = (ulong(sj) * p.kvHeads + kvHead) * p.headDim;
-        device const float *kr = kCache + row;
-        float dot = 0;
-        for (uint i = lane; i < p.headDim; i += 32) dot += q[i] * kr[i];
-        dot = simd_sum(dot) * scale;
-        const float mNew = metal::max(m, dot);
-        const float corr = metal::exp(m - mNew);   // first row: exp(-inf) = 0
-        const float w = metal::exp(dot - mNew);
-        s = s * corr + w;
-        device const float *vr = vCache + row;
-        uint cnt = 0;
-        for (uint i = lane; i < p.headDim; i += 32) {
-            acc[cnt] = acc[cnt] * corr + w * vr[i];
-            ++cnt;
-        }
-        m = mNew;
-    }
-    const float invS = 1.0f / s;
-    device const float *gate = data + p.qoutOff + b + head * 2 * p.headDim + p.headDim;
-    device float *out = data + p.outOff + b + head * p.headDim;
-    uint cnt = 0;
-    for (uint i = lane; i < p.headDim; i += 32) {
-        float gv = gate[i];
-        out[i] = acc[cnt] * invS * (1.0f / (1.0f + metal::exp(-gv)));
-        ++cnt;
-    }
+    const uint b = tpg.z * p.stride;
+    attn_decode_head(
+        data, kCache, vCache, p.kvHeads, p.headDim, p.position + tpg.z + 1,
+        p.qOff + b + head * p.headDim,
+        p.qoutOff + b + head * 2 * p.headDim + p.headDim,
+        p.outOff + b + head * p.headDim,
+        head / (p.heads / p.kvHeads),
+        sg, lane, tgM, tgS, tgAcc);
 }
 
 // delta_pre over n token slots: slot t adds t*stride to every offset;

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -302,6 +302,160 @@ kernel void gemv_affine_fast8(
     if (lane == 0) y[p.yOff + row] = acc;
 }
 
+// ===== S2 full attention: q prep, KV append, gated causal GQA softmax. =====
+// Replaces the fast path's CPU attention core. RoPE trig uses precise::
+// variants so angles match the CPU's libm within float rounding.
+
+// Extract each head's query from the interleaved q|gate projection
+// (per head [q(hd) | gate(hd)] at srcOff), RMSNorm with wgt, apply partial
+// RoPE for one position, write flat rows at dstOff. One simdgroup per head;
+// the gate half stays untouched for attn_decode_gqa.
+struct AttnPrepParams {
+    uint heads;
+    uint headDim;
+    uint rot;       // rotary dims (<= headDim)
+    float eps;
+    float theta;
+    uint position;
+    uint srcOff;
+    uint dstOff;
+};
+
+inline void rope_row(device float *row, uint rot, uint position, float theta, uint lane) {
+    const uint half_ = rot / 2;
+    for (uint j = lane; j < half_; j += 32) {
+        float invFreq = metal::precise::pow(theta, -float(2 * j) / float(rot));
+        float angle = float(position) * invFreq;
+        float c = metal::precise::cos(angle);
+        float sn = metal::precise::sin(angle);
+        float a = row[j];
+        float b = row[half_ + j];
+        row[j] = a * c - b * sn;
+        row[half_ + j] = b * c + a * sn;
+    }
+}
+
+kernel void attn_q_prep(
+    device float       *data [[buffer(0)]],
+    device const float *wgt  [[buffer(1)]],
+    constant AttnPrepParams &p [[buffer(2)]],
+    uint2 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.heads) return;
+    device const float *src = data + p.srcOff + head * 2 * p.headDim;
+    device float *dst = data + p.dstOff + head * p.headDim;
+    float ss = 0;
+    for (uint i = lane; i < p.headDim; i += 32) ss += src[i] * src[i];
+    ss = simd_sum(ss);
+    const float inv = metal::rsqrt(ss / float(p.headDim) + p.eps);
+    for (uint i = lane; i < p.headDim; i += 32) dst[i] = src[i] * inv * wgt[i];
+    // RoPE pairs (j, j+rot/2) cross lanes; make the normed writes visible.
+    simdgroup_barrier(metal::mem_flags::mem_device);
+    rope_row(dst, p.rot, p.position, p.theta, lane);
+}
+
+// Append one position's K/V rows into the caches at row index `position`
+// (layout [position][kvHead][headDim], the CPU reference layout): K is
+// RMSNormed with wgt then roped, V copies verbatim. One simdgroup per kv head.
+struct AttnKVParams {
+    uint kvHeads;
+    uint headDim;
+    uint rot;
+    float eps;
+    float theta;
+    uint position;
+    uint kSrcOff;
+    uint vSrcOff;
+};
+
+kernel void attn_kv_append(
+    device float       *data   [[buffer(0)]],
+    device const float *wgt    [[buffer(1)]],
+    device float       *kCache [[buffer(2)]],
+    device float       *vCache [[buffer(3)]],
+    constant AttnKVParams &p   [[buffer(4)]],
+    uint2 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.kvHeads) return;
+    device const float *kSrc = data + p.kSrcOff + head * p.headDim;
+    device const float *vSrc = data + p.vSrcOff + head * p.headDim;
+    const ulong row = (ulong(p.position) * p.kvHeads + head) * p.headDim;
+    device float *kDst = kCache + row;
+    device float *vDst = vCache + row;
+    float ss = 0;
+    for (uint i = lane; i < p.headDim; i += 32) ss += kSrc[i] * kSrc[i];
+    ss = simd_sum(ss);
+    const float inv = metal::rsqrt(ss / float(p.headDim) + p.eps);
+    for (uint i = lane; i < p.headDim; i += 32) {
+        kDst[i] = kSrc[i] * inv * wgt[i];
+        vDst[i] = vSrc[i];
+    }
+    simdgroup_barrier(metal::mem_flags::mem_device);
+    rope_row(kDst, p.rot, p.position, p.theta, lane);
+}
+
+// Gated causal GQA attention for one query token over cache rows [0, kvLen):
+// out = sigmoid(gate) * softmax(q K^T / sqrt(hd)) V, online softmax in f32.
+// One simdgroup per query head; per-lane accumulators cover headDim <= 256.
+struct AttnDecodeParams {
+    uint heads;
+    uint kvHeads;
+    uint headDim;
+    uint kvLen;
+    uint qOff;      // prepped q rows (head * headDim)
+    uint qoutOff;   // raw interleaved projection; gate at head*2*hd + hd
+    uint outOff;    // gated context rows (head * headDim)
+};
+
+kernel void attn_decode_gqa(
+    device float       *data   [[buffer(0)]],
+    device const float *kCache [[buffer(1)]],
+    device const float *vCache [[buffer(2)]],
+    constant AttnDecodeParams &p [[buffer(3)]],
+    uint2 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.heads) return;
+    const uint kvHead = head / (p.heads / p.kvHeads);
+    device const float *q = data + p.qOff + head * p.headDim;
+    const float scale = metal::rsqrt(float(p.headDim));
+    float m = -INFINITY;
+    float s = 0;
+    float acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    for (uint sj = 0; sj < p.kvLen; ++sj) {
+        const ulong row = (ulong(sj) * p.kvHeads + kvHead) * p.headDim;
+        device const float *kr = kCache + row;
+        float dot = 0;
+        for (uint i = lane; i < p.headDim; i += 32) dot += q[i] * kr[i];
+        dot = simd_sum(dot) * scale;
+        const float mNew = metal::max(m, dot);
+        const float corr = metal::exp(m - mNew);   // first row: exp(-inf) = 0
+        const float w = metal::exp(dot - mNew);
+        s = s * corr + w;
+        device const float *vr = vCache + row;
+        uint cnt = 0;
+        for (uint i = lane; i < p.headDim; i += 32) {
+            acc[cnt] = acc[cnt] * corr + w * vr[i];
+            ++cnt;
+        }
+        m = mNew;
+    }
+    const float invS = 1.0f / s;
+    device const float *gate = data + p.qoutOff + head * 2 * p.headDim + p.headDim;
+    device float *out = data + p.outOff + head * p.headDim;
+    uint cnt = 0;
+    for (uint i = lane; i < p.headDim; i += 32) {
+        float gv = gate[i];
+        out[i] = acc[cnt] * invS * (1.0f / (1.0f + metal::exp(-gv)));
+        ++cnt;
+    }
+}
+
 // ===== Small glue kernels so a token needs few command buffers. =====
 
 // RMSNorm over `rows` rows of `dim`, in place at data[off...]. Optional

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -976,6 +976,48 @@ kernel void attn_kv_append_batch(
     rope_row(kDst, p.rot, p.position + t, p.theta, lane);
 }
 
+// ===== S1b chunked DeltaNet staging: pack every chunk token's normed
+// q/k/v conv rows and g/beta pairs from slot-strided regions into the
+// contiguous [T, row] blocks gated_delta_step's T-step scan expects. Pure
+// element copies with no arithmetic, so staging cannot perturb numerics.
+struct DeltaGatherParams {
+    uint keyDim;
+    uint valueDim;
+    uint nv;
+    uint slotStride;
+    uint convOff;   // slot conv rows: [q(keyDim) | k(keyDim) | v(valueDim)]
+    uint gbOff;     // slot decay/beta rows: [g(nv) | beta(nv)]
+    uint qOut;
+    uint kOut;
+    uint vOut;
+    uint gOut;
+    uint bOut;
+};
+
+kernel void delta_gather(
+    device float *data [[buffer(0)]],
+    constant DeltaGatherParams &p [[buffer(1)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint i = tpg.x;
+    const uint t = tpg.y;
+    const uint slot = t * p.slotStride;
+    const uint convWidth = 2 * p.keyDim + p.valueDim;
+    if (i < p.keyDim) {
+        data[p.qOut + t * p.keyDim + i] = data[slot + p.convOff + i];
+    } else if (i < 2 * p.keyDim) {
+        data[p.kOut + t * p.keyDim + (i - p.keyDim)] = data[slot + p.convOff + i];
+    } else if (i < convWidth) {
+        data[p.vOut + t * p.valueDim + (i - 2 * p.keyDim)] = data[slot + p.convOff + i];
+    } else if (i < convWidth + p.nv) {
+        const uint j = i - convWidth;
+        data[p.gOut + t * p.nv + j] = data[slot + p.gbOff + j];
+    } else if (i < convWidth + 2 * p.nv) {
+        const uint j = i - convWidth - p.nv;
+        data[p.bOut + t * p.nv + j] = data[slot + p.gbOff + p.nv + j];
+    }
+}
+
 // qwen3_next fused projections: de-interleave the per-k-head packed
 // [q(dk) | k(dk) | v(rep*dv) | z(rep*dv)] layout plus [b(rep) | a(rep)] into
 // flat regions [q|k|v], z, b, a (what the conv/delta pipeline consumes).

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -1041,6 +1041,104 @@ kernel void attn_decode_gqa_batch(
     }
 }
 
+// delta_pre over n token slots: slot t adds t*stride to every offset;
+// per-slot arithmetic is the single-token kernel's verbatim (aLog/dtBias
+// are shared weights).
+struct DeltaPreBatchParams {
+    uint nv;
+    uint aOff;
+    uint bOff;
+    uint outOff;   // g at outOff, beta at outOff + nv
+    uint stride;
+};
+
+kernel void delta_pre_batch(
+    device float       *data   [[buffer(0)]],
+    device const float *aLog   [[buffer(1)]],
+    device const float *dtBias [[buffer(2)]],
+    constant DeltaPreBatchParams &p [[buffer(3)]],
+    uint2 tpg [[thread_position_in_grid]])
+{
+    const uint i = tpg.x;
+    if (i >= p.nv) return;
+    const uint b = tpg.y * p.stride;
+    float av = data[p.aOff + b + i] + dtBias[i];
+    float sp = av > 20.0f ? av : metal::log(1.0f + metal::exp(av));
+    data[p.outOff + b + i] = metal::exp(-metal::exp(aLog[i]) * sp);
+    float bv = data[p.bOff + b + i];
+    data[p.outOff + b + p.nv + i] = 1.0f / (1.0f + metal::exp(-bv));
+}
+
+// rmsnorm_rows over n token slots: slot t norms its `rows` rows in place at
+// off + t*stride. One simdgroup per (row, token).
+struct NormBatchParams {
+    uint rows;
+    uint dim;
+    float eps;
+    uint hasWeight;
+    float scale;
+    uint off;
+    uint stride;
+};
+
+kernel void rmsnorm_rows_batch(
+    device float       *data [[buffer(0)]],
+    device const float *wgt  [[buffer(1)]],
+    constant NormBatchParams &p [[buffer(2)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint row = tpg.y;
+    if (row >= p.rows) return;
+    device float *r = data + p.off + tpg.z * p.stride + row * p.dim;
+    float ss = 0;
+    for (uint i = lane; i < p.dim; i += 32) ss += r[i] * r[i];
+    ss = simd_sum(ss);
+    float inv = metal::rsqrt(ss / float(p.dim) + p.eps) * p.scale;
+    for (uint i = lane; i < p.dim; i += 32) {
+        r[i] = p.hasWeight ? r[i] * inv * wgt[i] : r[i] * inv;
+    }
+}
+
+// gated_norm_mul over n tokens. The chunked recurrence reads y rows from
+// the contiguous [T, row] staging block while z and the output stay in the
+// per-token slots, so each stream carries its own stride. One simdgroup per
+// (v-head, token).
+struct GatedNormBatchParams {
+    uint nv;
+    uint dv;
+    float eps;
+    uint yOff;
+    uint zOff;
+    uint outOff;
+    uint yStride;
+    uint zStride;
+    uint outStride;
+};
+
+kernel void gated_norm_mul_batch(
+    device float       *data [[buffer(0)]],
+    device const float *wgt  [[buffer(1)]],   // (dv)
+    constant GatedNormBatchParams &p [[buffer(2)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint hv = tpg.y;
+    if (hv >= p.nv) return;
+    const uint t = tpg.z;
+    device float *yr = data + p.yOff + t * p.yStride + hv * p.dv;
+    device float *zr = data + p.zOff + t * p.zStride + hv * p.dv;
+    device float *outr = data + p.outOff + t * p.outStride + hv * p.dv;
+    float ss = 0;
+    for (uint i = lane; i < p.dv; i += 32) ss += yr[i] * yr[i];
+    ss = simd_sum(ss);
+    float inv = metal::rsqrt(ss / float(p.dv) + p.eps);
+    for (uint i = lane; i < p.dv; i += 32) {
+        float zv = zr[i];
+        outr[i] = yr[i] * inv * wgt[i] * (zv / (1.0f + metal::exp(-zv)));
+    }
+}
+
 // ===== S1b chunked DeltaNet staging: pack every chunk token's normed
 // q/k/v conv rows and g/beta pairs from slot-strided regions into the
 // contiguous [T, row] blocks gated_delta_step's T-step scan expects. Pure

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -976,6 +976,71 @@ kernel void attn_kv_append_batch(
     rope_row(kDst, p.rot, p.position + t, p.theta, lane);
 }
 
+// attn_decode_gqa over n tokens: token t reads its prepped q and gate rows
+// inside its own slot stride and attends over cache rows
+// [0, position + t + 1) — the causal kvLen derived from the token grid, so
+// one dispatch covers the whole chunk once every KV append has landed
+// (callers barrier between the appends and this). Per-token arithmetic is
+// the single-token kernel's verbatim. One simdgroup per (head, token).
+struct AttnDecodeBatchParams {
+    uint heads;
+    uint kvHeads;
+    uint headDim;
+    uint position;  // base; token t attends over position + t + 1 rows
+    uint qOff;      // prepped q rows (head * headDim)
+    uint qoutOff;   // raw interleaved projection; gate at head*2*hd + hd
+    uint outOff;    // gated context rows (head * headDim)
+    uint stride;
+};
+
+kernel void attn_decode_gqa_batch(
+    device float       *data   [[buffer(0)]],
+    device const float *kCache [[buffer(1)]],
+    device const float *vCache [[buffer(2)]],
+    constant AttnDecodeBatchParams &p [[buffer(3)]],
+    uint3 tpg [[thread_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    const uint head = tpg.y;
+    if (head >= p.heads) return;
+    const uint t = tpg.z;
+    const uint b = t * p.stride;
+    const uint kvLen = p.position + t + 1;
+    const uint kvHead = head / (p.heads / p.kvHeads);
+    device const float *q = data + p.qOff + b + head * p.headDim;
+    const float scale = metal::rsqrt(float(p.headDim));
+    float m = -INFINITY;
+    float s = 0;
+    float acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    for (uint sj = 0; sj < kvLen; ++sj) {
+        const ulong row = (ulong(sj) * p.kvHeads + kvHead) * p.headDim;
+        device const float *kr = kCache + row;
+        float dot = 0;
+        for (uint i = lane; i < p.headDim; i += 32) dot += q[i] * kr[i];
+        dot = simd_sum(dot) * scale;
+        const float mNew = metal::max(m, dot);
+        const float corr = metal::exp(m - mNew);   // first row: exp(-inf) = 0
+        const float w = metal::exp(dot - mNew);
+        s = s * corr + w;
+        device const float *vr = vCache + row;
+        uint cnt = 0;
+        for (uint i = lane; i < p.headDim; i += 32) {
+            acc[cnt] = acc[cnt] * corr + w * vr[i];
+            ++cnt;
+        }
+        m = mNew;
+    }
+    const float invS = 1.0f / s;
+    device const float *gate = data + p.qoutOff + b + head * 2 * p.headDim + p.headDim;
+    device float *out = data + p.outOff + b + head * p.headDim;
+    uint cnt = 0;
+    for (uint i = lane; i < p.headDim; i += 32) {
+        float gv = gate[i];
+        out[i] = acc[cnt] * invS * (1.0f / (1.0f + metal::exp(-gv)));
+        ++cnt;
+    }
+}
+
 // ===== S1b chunked DeltaNet staging: pack every chunk token's normed
 // q/k/v conv rows and g/beta pairs from slot-strided regions into the
 // contiguous [T, row] blocks gated_delta_step's T-step scan expects. Pure

--- a/Sources/SwiftletCore/Kernels.metal.txt
+++ b/Sources/SwiftletCore/Kernels.metal.txt
@@ -688,6 +688,49 @@ kernel void conv_step(
     data[p.outOff + c] = acc / (1.0f + metal::exp(-acc));
 }
 
+// Cross-token conv scan (S1b): T conv_step iterations in one dispatch, one
+// thread per channel — token t's row read at inOff + t*stride and written
+// at outOff + t*stride. Each iteration is the single-step kernel's
+// arithmetic verbatim, with the K-1 history rows carried across tokens in
+// registers instead of a barrier-fenced device round trip per token, so
+// every output row and the final history are bitwise the chained steps'.
+// History registers cover 2 <= K <= 8 (target checkpoints use K = 4).
+struct ConvScanParams {
+    uint convDim;
+    uint K;
+    uint inOff;
+    uint outOff;
+    uint stride;
+    uint T;
+};
+
+kernel void conv_scan(
+    device float       *data [[buffer(0)]],
+    device float       *hist [[buffer(1)]],
+    device const float *wgt  [[buffer(2)]],   // (convDim, K)
+    constant ConvScanParams &p [[buffer(3)]],
+    uint c [[thread_position_in_grid]])
+{
+    if (c >= p.convDim) return;
+    float h[7];
+    for (uint j = 0; j + 1 < p.K; ++j) h[j] = hist[j * p.convDim + c];
+    uint inOff = p.inOff;
+    uint outOff = p.outOff;
+    for (uint t = 0; t < p.T; ++t) {
+        float xNew = data[inOff + c];
+        float acc = wgt[c * p.K + (p.K - 1)] * xNew;
+        for (uint j = 0; j + 1 < p.K; ++j) {
+            acc += wgt[c * p.K + j] * h[j];
+        }
+        for (uint j = 0; j + 2 < p.K; ++j) h[j] = h[j + 1];
+        h[p.K - 2] = xNew;
+        data[outOff + c] = acc / (1.0f + metal::exp(-acc));
+        inOff += p.stride;
+        outOff += p.stride;
+    }
+    for (uint j = 0; j + 1 < p.K; ++j) hist[j * p.convDim + c] = h[j];
+}
+
 // g = exp(-exp(A_log) * softplus(a + dt_bias)); beta = sigmoid(b).
 struct DeltaPreParams {
     uint nv;

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -391,6 +391,235 @@ public final class MetalEngine {
         }
     }
 
+    // MARK: - S1b non-GEMV batch twins
+    //
+    // The chunked prefill's per-token glue destinations are slot-regular
+    // (token t's rows sit exactly one stride after token t-1's), so these
+    // twins batch via a token grid dimension plus stride parameters instead
+    // of the GEMV offset table. Every kernel body is the single-token
+    // kernel's verbatim, so batched rows are bitwise the per-token values.
+    // Callers keep single-token chunks on the legacy per-token encodes so
+    // the degenerate chunk stays byte-identical to the decode stream.
+
+    struct NormCopyBatchParams {
+        var dim: UInt32
+        var eps: Float
+        var dstOff: UInt32
+        var dstStride: UInt32
+        var hStride: UInt32
+    }
+
+    /// norm_copy over `tokens` hidden rows: row t reads `h` (from
+    /// `hByteOffset`) at t*hStride floats and writes dst[dstOff + t*dstStride...].
+    func encodeNormCopyBatch(
+        _ enc: MTLComputeCommandEncoder,
+        h: MTLBuffer, hByteOffset: Int, hStride: Int,
+        dst: MTLBuffer, weight: MTLBuffer,
+        dim: Int, eps: Float, dstOff: Int, dstStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("norm_copy_batch"))
+        var p = NormCopyBatchParams(
+            dim: UInt32(dim), eps: eps, dstOff: UInt32(dstOff),
+            dstStride: UInt32(dstStride), hStride: UInt32(hStride)
+        )
+        enc.setBuffer(h, offset: hByteOffset, index: 0)
+        enc.setBuffer(dst, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<NormCopyBatchParams>.stride, index: 3)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
+    /// silu_mul over `tokens` slots: slot t adds t*stride to every offset.
+    func encodeSiluMulBatch(
+        _ enc: MTLComputeCommandEncoder,
+        buf: MTLBuffer, count: Int, gOff: Int, uOff: Int, dstOff: Int,
+        stride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("silu_mul_batch"))
+        var po = SIMD4<UInt32>(UInt32(count), UInt32(gOff), UInt32(uOff), UInt32(dstOff))
+        var s = UInt32(stride)
+        enc.setBuffer(buf, offset: 0, index: 0)
+        enc.setBuffer(buf, offset: 0, index: 1)
+        enc.setBuffer(buf, offset: 0, index: 2)
+        enc.setBytes(&po, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
+        enc.setBytes(&s, length: MemoryLayout<UInt32>.stride, index: 4)
+        dispatchThreads(
+            enc, threads: MTLSize(width: count, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, count), height: 1, depth: 1)
+        )
+    }
+
+    /// add_inplace over `tokens` hidden rows:
+    /// h[t*hStride + i] += r[rOff + t*rStride + i].
+    func encodeAddInplaceBatch(
+        _ enc: MTLComputeCommandEncoder,
+        h: MTLBuffer, hStride: Int, r: MTLBuffer, rOff: Int, rStride: Int,
+        count: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("add_inplace_batch"))
+        var po = SIMD4<UInt32>(
+            UInt32(count), UInt32(rOff), UInt32(hStride), UInt32(rStride))
+        enc.setBuffer(h, offset: 0, index: 0)
+        enc.setBuffer(r, offset: 0, index: 1)
+        enc.setBytes(&po, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 2)
+        dispatchThreads(
+            enc, threads: MTLSize(width: count, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, count), height: 1, depth: 1)
+        )
+    }
+
+    struct AccumBatchParams {
+        var D: UInt32
+        var K: UInt32
+        var dBase: UInt32
+        var shOff: UInt32
+        var gateOff: UInt32
+        var stride: UInt32
+        var hStride: UInt32
+    }
+
+    /// weighted_accum over `tokens`: token t reads its expert/shared rows at
+    /// t*stride, its own K weights at weights[t*K...], and accumulates into
+    /// hidden row t*hStride. The K-expert accumulation order stays inside
+    /// the kernel, exactly the single-token loop. weights.count == tokens*K.
+    func encodeWeightedAccumBatch(
+        _ enc: MTLComputeCommandEncoder,
+        h: MTLBuffer, hStride: Int, data: MTLBuffer,
+        count: Int, k: Int, dBase: Int, shOff: Int, gateOff: Int, stride: Int,
+        weights: [Float], tokens: Int
+    ) throws {
+        precondition(weights.count == tokens * k, "token-major weights table")
+        enc.setComputePipelineState(try pipeline("weighted_accum_batch"))
+        var p = AccumBatchParams(
+            D: UInt32(count), K: UInt32(k), dBase: UInt32(dBase),
+            shOff: UInt32(shOff), gateOff: UInt32(gateOff),
+            stride: UInt32(stride), hStride: UInt32(hStride)
+        )
+        enc.setBuffer(h, offset: 0, index: 0)
+        enc.setBuffer(data, offset: 0, index: 1)
+        enc.setBytes(&p, length: MemoryLayout<AccumBatchParams>.stride, index: 2)
+        weights.withUnsafeBufferPointer {
+            enc.setBytes($0.baseAddress!, length: max(1, $0.count) * 4, index: 3)
+        }
+        dispatchThreads(
+            enc, threads: MTLSize(width: count, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, count), height: 1, depth: 1)
+        )
+    }
+
+    struct DeintBatchParams {
+        var nk: UInt32
+        var dk: UInt32
+        var rep: UInt32
+        var dv: UInt32
+        var keyDim: UInt32
+        var srcOff: UInt32
+        var baOff: UInt32
+        var qkvOff: UInt32
+        var zOff: UInt32
+        var bOff: UInt32
+        var aOff: UInt32
+        var stride: UInt32
+    }
+
+    /// deinterleave_qkvz over `tokens` slots: slot t adds t*stride to every
+    /// source and destination offset.
+    func encodeDeinterleaveBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
+        nk: Int, dk: Int, rep: Int, dv: Int, keyDim: Int,
+        srcOff: Int, baOff: Int, qkvOff: Int, zOff: Int, bOff: Int, aOff: Int,
+        stride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("deinterleave_qkvz_batch"))
+        var p = DeintBatchParams(
+            nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(rep), dv: UInt32(dv),
+            keyDim: UInt32(keyDim), srcOff: UInt32(srcOff), baOff: UInt32(baOff),
+            qkvOff: UInt32(qkvOff), zOff: UInt32(zOff), bOff: UInt32(bOff),
+            aOff: UInt32(aOff), stride: UInt32(stride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBytes(&p, length: MemoryLayout<DeintBatchParams>.stride, index: 1)
+        dispatchThreads(
+            enc, threads: MTLSize(width: nk, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, nk), height: 1, depth: 1)
+        )
+    }
+
+    struct AttnPrepBatchParams {
+        var heads: UInt32
+        var headDim: UInt32
+        var rot: UInt32
+        var eps: Float
+        var theta: Float
+        var position: UInt32
+        var srcOff: UInt32
+        var dstOff: UInt32
+        var stride: UInt32
+    }
+
+    /// attn_q_prep over `tokens`: token t preps inside its own slot stride at
+    /// position basePosition + t. One simdgroup per (head, token).
+    func encodeAttnQPrepBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer,
+        heads: Int, headDim: Int, rotaryDims: Int, eps: Float, ropeTheta: Float,
+        basePosition: Int, srcOff: Int, dstOff: Int, slotStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("attn_q_prep_batch"))
+        var p = AttnPrepBatchParams(
+            heads: UInt32(heads), headDim: UInt32(headDim), rot: UInt32(rotaryDims),
+            eps: eps, theta: ropeTheta, position: UInt32(basePosition),
+            srcOff: UInt32(srcOff), dstOff: UInt32(dstOff), stride: UInt32(slotStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: 0, index: 1)
+        enc.setBytes(&p, length: MemoryLayout<AttnPrepBatchParams>.stride, index: 2)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: heads, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
+    struct AttnKVBatchParams {
+        var kvHeads: UInt32
+        var headDim: UInt32
+        var rot: UInt32
+        var eps: Float
+        var theta: Float
+        var position: UInt32
+        var kSrcOff: UInt32
+        var vSrcOff: UInt32
+        var stride: UInt32
+    }
+
+    /// attn_kv_append over `tokens`: token t appends at cache row index
+    /// basePosition + t — disjoint rows per token, so batching cannot
+    /// reorder any write. One simdgroup per (kv head, token).
+    func encodeAttnKVAppendBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer,
+        kCache: MTLBuffer, vCache: MTLBuffer,
+        kvHeads: Int, headDim: Int, rotaryDims: Int, eps: Float, ropeTheta: Float,
+        basePosition: Int, kSrcOff: Int, vSrcOff: Int, slotStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("attn_kv_append_batch"))
+        var p = AttnKVBatchParams(
+            kvHeads: UInt32(kvHeads), headDim: UInt32(headDim), rot: UInt32(rotaryDims),
+            eps: eps, theta: ropeTheta, position: UInt32(basePosition),
+            kSrcOff: UInt32(kSrcOff), vSrcOff: UInt32(vSrcOff), stride: UInt32(slotStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: 0, index: 1)
+        enc.setBuffer(kCache, offset: 0, index: 2)
+        enc.setBuffer(vCache, offset: 0, index: 3)
+        enc.setBytes(&p, length: MemoryLayout<AttnKVBatchParams>.stride, index: 4)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: kvHeads, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
     func encodeSiluMul(
         _ enc: MTLComputeCommandEncoder,
         buf: MTLBuffer, count: Int, gOff: Int, uOff: Int, dstOff: Int

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -659,6 +659,108 @@ public final class MetalEngine {
         )
     }
 
+    struct DeltaPreBatchParams {
+        var nv: UInt32
+        var aOff: UInt32
+        var bOff: UInt32
+        var outOff: UInt32
+        var stride: UInt32
+    }
+
+    /// delta_pre over `tokens` slots: slot t adds t*slotStride to every
+    /// offset (g at outOff, beta at outOff + nv; aLog/dtBias shared).
+    func encodeDeltaPreBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
+        aLog: MTLBuffer, dtBias: MTLBuffer,
+        nv: Int, aOff: Int, bOff: Int, outOff: Int, slotStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("delta_pre_batch"))
+        var p = DeltaPreBatchParams(
+            nv: UInt32(nv), aOff: UInt32(aOff), bOff: UInt32(bOff),
+            outOff: UInt32(outOff), stride: UInt32(slotStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(aLog, offset: 0, index: 1)
+        enc.setBuffer(dtBias, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<DeltaPreBatchParams>.stride, index: 3)
+        dispatchThreads(
+            enc, threads: MTLSize(width: nv, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, nv), height: 1, depth: 1)
+        )
+    }
+
+    struct NormBatchParams {
+        var rows: UInt32
+        var dim: UInt32
+        var eps: Float
+        var hasWeight: UInt32
+        var scale: Float
+        var off: UInt32
+        var stride: UInt32
+    }
+
+    /// rmsnorm_rows over `tokens` slots, in place: slot t norms `rows` rows
+    /// of `dim` at off + t*slotStride. Optional weight, optional extra scale
+    /// (the DeltaNet q/k norms are weightless, scaled 1/dk and 1/sqrt(dk)).
+    /// One simdgroup per (row, token).
+    func encodeRMSNormRowsBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer?,
+        off: Int, rows: Int, dim: Int, scale: Float, eps: Float,
+        slotStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("rmsnorm_rows_batch"))
+        var p = NormBatchParams(
+            rows: UInt32(rows), dim: UInt32(dim), eps: eps,
+            hasWeight: weight != nil ? 1 : 0, scale: scale,
+            off: UInt32(off), stride: UInt32(slotStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight ?? data, offset: 0, index: 1)
+        enc.setBytes(&p, length: MemoryLayout<NormBatchParams>.stride, index: 2)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: rows, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
+    struct GatedNormBatchParams {
+        var nv: UInt32
+        var dv: UInt32
+        var eps: Float
+        var yOff: UInt32
+        var zOff: UInt32
+        var outOff: UInt32
+        var yStride: UInt32
+        var zStride: UInt32
+        var outStride: UInt32
+    }
+
+    /// gated_norm_mul over `tokens` with per-stream strides: the chunked
+    /// recurrence reads y rows from the contiguous [T, row] staging block
+    /// while z and the output stay slot-strided. One simdgroup per
+    /// (v-head, token).
+    func encodeGatedNormMulBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer,
+        nv: Int, dv: Int, eps: Float,
+        yOff: Int, yStride: Int, zOff: Int, zStride: Int,
+        outOff: Int, outStride: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("gated_norm_mul_batch"))
+        var p = GatedNormBatchParams(
+            nv: UInt32(nv), dv: UInt32(dv), eps: eps,
+            yOff: UInt32(yOff), zOff: UInt32(zOff), outOff: UInt32(outOff),
+            yStride: UInt32(yStride), zStride: UInt32(zStride),
+            outStride: UInt32(outStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: 0, index: 1)
+        enc.setBytes(&p, length: MemoryLayout<GatedNormBatchParams>.stride, index: 2)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: nv, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
     struct DeltaGatherParams {
         var keyDim: UInt32
         var valueDim: UInt32

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -620,6 +620,45 @@ public final class MetalEngine {
         )
     }
 
+    struct AttnDecodeBatchParams {
+        var heads: UInt32
+        var kvHeads: UInt32
+        var headDim: UInt32
+        var position: UInt32
+        var qOff: UInt32
+        var qoutOff: UInt32
+        var outOff: UInt32
+        var stride: UInt32
+    }
+
+    /// attn_decode_gqa over `tokens`: token t attends inside its own slot
+    /// stride over cache rows [0, basePosition + t + 1) — the causal kvLen
+    /// derived in-kernel from the token grid. Callers must barrier between
+    /// the chunk's KV appends and this dispatch, because the youngest token
+    /// reads every appended row. One simdgroup per (head, token).
+    func encodeAttnDecodeBatch(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
+        kCache: MTLBuffer, vCache: MTLBuffer,
+        heads: Int, kvHeads: Int, headDim: Int, basePosition: Int,
+        qOff: Int, qoutOff: Int, outOff: Int, slotStride: Int, tokens: Int
+    ) throws {
+        precondition(headDim <= 256, "attn_decode_gqa accumulators cover headDim <= 256")
+        enc.setComputePipelineState(try pipeline("attn_decode_gqa_batch"))
+        var p = AttnDecodeBatchParams(
+            heads: UInt32(heads), kvHeads: UInt32(kvHeads), headDim: UInt32(headDim),
+            position: UInt32(basePosition), qOff: UInt32(qOff),
+            qoutOff: UInt32(qoutOff), outOff: UInt32(outOff), stride: UInt32(slotStride)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(kCache, offset: 0, index: 1)
+        enc.setBuffer(vCache, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<AttnDecodeBatchParams>.stride, index: 3)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: heads, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
     struct DeltaGatherParams {
         var keyDim: UInt32
         var valueDim: UInt32

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -363,6 +363,120 @@ public final class MetalEngine {
         ))
     }
 
+    // MARK: - Full-attention kernels (S2)
+
+    struct AttnPrepParams {
+        var heads: UInt32
+        var headDim: UInt32
+        var rot: UInt32
+        var eps: Float
+        var theta: Float
+        var position: UInt32
+        var srcOff: UInt32
+        var dstOff: UInt32
+    }
+
+    struct AttnKVParams {
+        var kvHeads: UInt32
+        var headDim: UInt32
+        var rot: UInt32
+        var eps: Float
+        var theta: Float
+        var position: UInt32
+        var kSrcOff: UInt32
+        var vSrcOff: UInt32
+    }
+
+    struct AttnDecodeParams {
+        var heads: UInt32
+        var kvHeads: UInt32
+        var headDim: UInt32
+        var kvLen: UInt32
+        var qOff: UInt32
+        var qoutOff: UInt32
+        var outOff: UInt32
+    }
+
+    /// Extract each head's query from the interleaved q|gate projection at
+    /// `srcOff` (floats, per head [q(hd) | gate(hd)]), RMSNorm it with
+    /// `weight`, apply partial RoPE for `position`, and write flat rows at
+    /// `dstOff`. The gate half stays untouched at `srcOff` for the attention
+    /// kernel. One simdgroup per head.
+    func encodeAttnQPrep(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer,
+        heads: Int, headDim: Int, rotaryDims: Int, eps: Float, ropeTheta: Float,
+        position: Int, srcOff: Int, dstOff: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("attn_q_prep"))
+        var p = AttnPrepParams(
+            heads: UInt32(heads), headDim: UInt32(headDim), rot: UInt32(rotaryDims),
+            eps: eps, theta: ropeTheta, position: UInt32(position),
+            srcOff: UInt32(srcOff), dstOff: UInt32(dstOff)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: 0, index: 1)
+        enc.setBytes(&p, length: MemoryLayout<AttnPrepParams>.stride, index: 2)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: heads, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
+    /// Append one position's K/V rows to the caches at row index `position`
+    /// (layout [position][kvHead][headDim], matching the CPU reference): K is
+    /// RMSNormed with `weight` and roped, V copies verbatim. One simdgroup
+    /// per kv head.
+    func encodeAttnKVAppend(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, weight: MTLBuffer,
+        kCache: MTLBuffer, vCache: MTLBuffer,
+        kvHeads: Int, headDim: Int, rotaryDims: Int, eps: Float, ropeTheta: Float,
+        position: Int, kSrcOff: Int, vSrcOff: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("attn_kv_append"))
+        var p = AttnKVParams(
+            kvHeads: UInt32(kvHeads), headDim: UInt32(headDim), rot: UInt32(rotaryDims),
+            eps: eps, theta: ropeTheta, position: UInt32(position),
+            kSrcOff: UInt32(kSrcOff), vSrcOff: UInt32(vSrcOff)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: 0, index: 1)
+        enc.setBuffer(kCache, offset: 0, index: 2)
+        enc.setBuffer(vCache, offset: 0, index: 3)
+        enc.setBytes(&p, length: MemoryLayout<AttnKVParams>.stride, index: 4)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: kvHeads, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
+    /// Gated causal GQA attention for one query token over cache rows
+    /// [0, kvLen): out = sigmoid(gate) * softmax(qK^T/sqrt(hd)) V, with the
+    /// online-softmax running max/sum in f32. Prepped q at `qOff`, the gate
+    /// half read from the raw projection at `qoutOff`, gated context written
+    /// to `outOff`. One simdgroup per query head; headDim <= 256.
+    func encodeAttnDecode(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
+        kCache: MTLBuffer, vCache: MTLBuffer,
+        heads: Int, kvHeads: Int, headDim: Int, kvLen: Int,
+        qOff: Int, qoutOff: Int, outOff: Int
+    ) throws {
+        precondition(headDim <= 256, "attn_decode_gqa accumulators cover headDim <= 256")
+        enc.setComputePipelineState(try pipeline("attn_decode_gqa"))
+        var p = AttnDecodeParams(
+            heads: UInt32(heads), kvHeads: UInt32(kvHeads), headDim: UInt32(headDim),
+            kvLen: UInt32(kvLen), qOff: UInt32(qOff), qoutOff: UInt32(qoutOff),
+            outOff: UInt32(outOff)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(kCache, offset: 0, index: 1)
+        enc.setBuffer(vCache, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<AttnDecodeParams>.stride, index: 3)
+        dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: heads, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+        )
+    }
+
     struct DeltaParams {
         var T: UInt32
         var Hk: UInt32

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -635,7 +635,8 @@ public final class MetalEngine {
     /// stride over cache rows [0, basePosition + t + 1) — the causal kvLen
     /// derived in-kernel from the token grid. Callers must barrier between
     /// the chunk's KV appends and this dispatch, because the youngest token
-    /// reads every appended row. One simdgroup per (head, token).
+    /// reads every appended row. One threadgroup of `attnDecodeSimdgroups`
+    /// simdgroups per (head, token), tiled across the KV rows.
     func encodeAttnDecodeBatch(
         _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
         kCache: MTLBuffer, vCache: MTLBuffer,
@@ -653,9 +654,10 @@ public final class MetalEngine {
         enc.setBuffer(kCache, offset: 0, index: 1)
         enc.setBuffer(vCache, offset: 0, index: 2)
         enc.setBytes(&p, length: MemoryLayout<AttnDecodeBatchParams>.stride, index: 3)
+        let width = 32 * Self.attnDecodeSimdgroups
         dispatchThreads(
-            enc, threads: MTLSize(width: 32, height: heads, depth: tokens),
-            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+            enc, threads: MTLSize(width: width, height: heads, depth: tokens),
+            threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1)
         )
     }
 
@@ -985,11 +987,18 @@ public final class MetalEngine {
         )
     }
 
+    /// Simdgroups cooperating on one (head, token) in the causal attends,
+    /// each scanning a strided subset of the KV rows with its own online
+    /// softmax, merged in-threadgroup. Must match ATTN_DECODE_SG in
+    /// Kernels.metal.txt.
+    static let attnDecodeSimdgroups = 4
+
     /// Gated causal GQA attention for one query token over cache rows
     /// [0, kvLen): out = sigmoid(gate) * softmax(qK^T/sqrt(hd)) V, with the
     /// online-softmax running max/sum in f32. Prepped q at `qOff`, the gate
     /// half read from the raw projection at `qoutOff`, gated context written
-    /// to `outOff`. One simdgroup per query head; headDim <= 256.
+    /// to `outOff`. One threadgroup of `attnDecodeSimdgroups` simdgroups
+    /// per query head, tiled across the KV rows; headDim <= 256.
     func encodeAttnDecode(
         _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
         kCache: MTLBuffer, vCache: MTLBuffer,
@@ -1007,9 +1016,10 @@ public final class MetalEngine {
         enc.setBuffer(kCache, offset: 0, index: 1)
         enc.setBuffer(vCache, offset: 0, index: 2)
         enc.setBytes(&p, length: MemoryLayout<AttnDecodeParams>.stride, index: 3)
+        let width = 32 * Self.attnDecodeSimdgroups
         dispatchThreads(
-            enc, threads: MTLSize(width: 32, height: heads, depth: 1),
-            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+            enc, threads: MTLSize(width: width, height: heads, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1)
         )
     }
 

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -44,6 +44,125 @@ public final class MetalEngine {
         return p
     }
 
+    // MARK: - Counter sampling probe (S3b follow-up)
+
+    /// What this device's Metal counter machinery can actually sample —
+    /// probed at runtime, never assumed. Capabilities come straight from
+    /// `supportsCounterSampling`; `stageBoundarySampleValid` is the result of
+    /// really running a sample pass, so "yes" means counters were exercised
+    /// on this device, not just advertised.
+    public struct CounterSamplingSupport: Equatable, Sendable {
+        public let deviceName: String
+        /// The MTLCommonCounterSet.timestamp counter set exists on the device.
+        public let hasTimestampCounterSet: Bool
+        public let atStageBoundary: Bool
+        public let atDispatchBoundary: Bool
+        public let atDrawBoundary: Bool
+        public let atBlitBoundary: Bool
+        public let atTileDispatchBoundary: Bool
+        /// Functional check: one trivial compute pass ran with stage-boundary
+        /// (encoder start/end) timestamp samples attached and both resolved
+        /// to a monotone, non-error pair. nil when stage-boundary sampling or
+        /// the timestamp set is unavailable, so the pass was never attempted.
+        public let stageBoundarySampleValid: Bool?
+
+        public var summary: String {
+            func yn(_ b: Bool) -> String { b ? "yes" : "no" }
+            let stageProbe: String
+            switch stageBoundarySampleValid {
+            case .some(true): stageProbe = "(sample resolved)"
+            case .some(false): stageProbe = "(sample did NOT resolve)"
+            case .none: stageProbe = "(not probed)"
+            }
+            return "device=\(deviceName) timestampSet=\(yn(hasTimestampCounterSet))"
+                + " stage=\(yn(atStageBoundary))\(stageProbe)"
+                + " dispatch=\(yn(atDispatchBoundary))"
+                + " draw=\(yn(atDrawBoundary))"
+                + " blit=\(yn(atBlitBoundary))"
+                + " tileDispatch=\(yn(atTileDispatchBoundary))"
+        }
+    }
+
+    private var counterSamplingCache: CounterSamplingSupport?
+
+    /// The device's timestamp counter set, if it exposes one.
+    var timestampCounterSet: MTLCounterSet? {
+        device.counterSets?.first {
+            $0.name.caseInsensitiveCompare(MTLCommonCounterSet.timestamp.rawValue) == .orderedSame
+        }
+    }
+
+    /// Probes counter-sampling capabilities once and caches the verdict.
+    /// Runs a real stage-boundary sample pass when the device advertises one,
+    /// so the report is evidence rather than a table of claims.
+    public func probeCounterSampling() -> CounterSamplingSupport {
+        if let cached = counterSamplingCache { return cached }
+        let tsSet = timestampCounterSet
+        let stage = device.supportsCounterSampling(.atStageBoundary)
+        var stageValid: Bool?
+        if stage, let tsSet {
+            stageValid = runStageBoundaryTimestampProbe(counterSet: tsSet)
+        }
+        let support = CounterSamplingSupport(
+            deviceName: device.name,
+            hasTimestampCounterSet: tsSet != nil,
+            atStageBoundary: stage,
+            atDispatchBoundary: device.supportsCounterSampling(.atDispatchBoundary),
+            atDrawBoundary: device.supportsCounterSampling(.atDrawBoundary),
+            atBlitBoundary: device.supportsCounterSampling(.atBlitBoundary),
+            atTileDispatchBoundary: device.supportsCounterSampling(.atTileDispatchBoundary),
+            stageBoundarySampleValid: stageValid
+        )
+        counterSamplingCache = support
+        return support
+    }
+
+    /// One tiny silu_mul dispatch in its own encoder with encoder start/end
+    /// timestamp samples attached — the boundary Apple GPUs support. True
+    /// when both samples resolve to a monotone, non-error pair. Deliberately
+    /// bypasses `dispatchThreads` so the probe never pollutes step counters.
+    private func runStageBoundaryTimestampProbe(counterSet: MTLCounterSet) -> Bool {
+        let desc = MTLCounterSampleBufferDescriptor()
+        desc.counterSet = counterSet
+        desc.storageMode = .shared
+        desc.sampleCount = 2
+        guard let sampleBuffer = try? device.makeCounterSampleBuffer(descriptor: desc),
+              let scratch = device.makeBuffer(length: 64, options: .storageModeShared),
+              let pipe = try? pipeline("silu_mul"),
+              let cb = queue.makeCommandBuffer()
+        else { return false }
+        let pass = MTLComputePassDescriptor()
+        guard let attachment = pass.sampleBufferAttachments[0] else { return false }
+        attachment.sampleBuffer = sampleBuffer
+        attachment.startOfEncoderSampleIndex = 0
+        attachment.endOfEncoderSampleIndex = 1
+        guard let enc = cb.makeComputeCommandEncoder(descriptor: pass) else { return false }
+        enc.setComputePipelineState(pipe)
+        var p = SIMD4<UInt32>(4, 0, 4, 8)
+        enc.setBuffer(scratch, offset: 0, index: 0)
+        enc.setBuffer(scratch, offset: 0, index: 1)
+        enc.setBuffer(scratch, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
+        enc.dispatchThreads(
+            MTLSize(width: 4, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 4, height: 1, depth: 1)
+        )
+        enc.endEncoding()
+        cb.commit()
+        cb.waitUntilCompleted()
+        guard cb.status == .completed,
+              let data = try? sampleBuffer.resolveCounterRange(0..<2),
+              data.count >= 2 * MemoryLayout<MTLCounterResultTimestamp>.stride
+        else { return false }
+        let stamps = data.withUnsafeBytes { raw -> (UInt64, UInt64) in
+            let t = raw.bindMemory(to: MTLCounterResultTimestamp.self)
+            return (t[0].timestamp, t[1].timestamp)
+        }
+        return stamps.0 != 0 && stamps.1 != 0
+            && stamps.0 != .max && stamps.1 != .max
+            && stamps.1 >= stamps.0
+    }
+
     struct GemvParams {
         var wOff: UInt64 = 0   // byte offsets, 64-bit (shards exceed 4 GB)
         var sOff: UInt64 = 0

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -801,6 +801,42 @@ public final class MetalEngine {
         )
     }
 
+    struct ConvScanParams {
+        var convDim: UInt32
+        var K: UInt32
+        var inOff: UInt32
+        var outOff: UInt32
+        var stride: UInt32
+        var T: UInt32
+    }
+
+    /// conv_scan over `tokens` slots: T sequential conv_step iterations in
+    /// one dispatch, one thread per channel — token t's qkv row read at
+    /// inOff + t*slotStride, its conv+silu row written at
+    /// outOff + t*slotStride, and the layer's K-1 history rows carried
+    /// across tokens in registers, written back once at the end. Bitwise
+    /// the chained per-token conv_step dispatches. K <= 8.
+    func encodeConvScan(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer, hist: MTLBuffer,
+        weight: MTLBuffer, convDim: Int, K: Int,
+        inOff: Int, outOff: Int, slotStride: Int, tokens: Int
+    ) throws {
+        precondition((2...8).contains(K), "conv_scan history registers cover 2 <= K <= 8")
+        enc.setComputePipelineState(try pipeline("conv_scan"))
+        var p = ConvScanParams(
+            convDim: UInt32(convDim), K: UInt32(K), inOff: UInt32(inOff),
+            outOff: UInt32(outOff), stride: UInt32(slotStride), T: UInt32(tokens)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBuffer(hist, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: 0, index: 2)
+        enc.setBytes(&p, length: MemoryLayout<ConvScanParams>.stride, index: 3)
+        dispatchThreads(
+            enc, threads: MTLSize(width: convDim, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, convDim), height: 1, depth: 1)
+        )
+    }
+
     func encodeSiluMul(
         _ enc: MTLComputeCommandEncoder,
         buf: MTLBuffer, count: Int, gOff: Int, uOff: Int, dstOff: Int

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -301,6 +301,96 @@ public final class MetalEngine {
         }
     }
 
+    /// The setBytes offset-table ceiling for one batched GEMV dispatch:
+    /// 512 uint2 entries stay well under Metal's 4 KB setBytes limit. Longer
+    /// tables split into further dispatches.
+    static let gemvBatchSlotLimit = 512
+
+    /// Encode the same linear applied to many token slots (S1b token
+    /// batching): the grid gains a slot dimension and each slice reads its
+    /// x/y float offsets from a small table, so one dispatch replaces the
+    /// per-token `encodeGemv` sequence. The per-row arithmetic is the
+    /// single-token kernel's verbatim, making every output row bitwise
+    /// identical to the unbatched encode. A single slot delegates to
+    /// `encodeGemv` so degenerate chunks keep the decode-shaped encode
+    /// stream; empty slot lists encode nothing.
+    func encodeGemvBatch(
+        _ enc: MTLComputeCommandEncoder,
+        _ lin: MetalShardStore.GPULinear,
+        rows: Int? = nil,
+        wExtra: Int = 0, sExtra: Int = 0, bExtra: Int = 0,
+        x: MTLBuffer, y: MTLBuffer,
+        slots: [(xOff: Int, yOff: Int)]
+    ) throws {
+        guard let first = slots.first else { return }
+        if slots.count == 1 {
+            try encodeGemv(enc, lin, rows: rows, wExtra: wExtra, sExtra: sExtra, bExtra: bExtra,
+                           x: x, xOff: first.xOff, y: y, yOff: first.yOff)
+            return
+        }
+        let outDim = rows ?? lin.outDim
+        var start = 0
+        while start < slots.count {
+            let end = min(start + Self.gemvBatchSlotLimit, slots.count)
+            let table = slots[start..<end].map {
+                SIMD2<UInt32>(UInt32($0.xOff), UInt32($0.yOff))
+            }
+            let n = end - start
+            if lin.isQuantized {
+                // Same kernel selection as encodeGemv: cooperative fast path
+                // when rows are 4-byte aligned, scalar fallback otherwise.
+                let aligned = (lin.wOff + wExtra) % 4 == 0
+                let fastName: String? = !Self.fastGemvEnabled || !aligned ? nil
+                    : lin.bits == 4 && lin.groupSize % 8 == 0 ? "gemv_affine_fast_batch"
+                    : lin.bits == 8 && lin.groupSize % 4 == 0 ? "gemv_affine_fast8_batch"
+                    : nil
+                enc.setComputePipelineState(try pipeline(fastName ?? "gemv_affine_batch"))
+                var p = GemvParams(
+                    wOff: UInt64(lin.wOff + wExtra), sOff: UInt64(lin.sOff + sExtra),
+                    bOff: UInt64(lin.bOff + bExtra),
+                    outDim: UInt32(outDim), inDim: UInt32(lin.inDim),
+                    groupSize: UInt32(lin.groupSize), bits: UInt32(lin.bits),
+                    scalesType: lin.scalesType
+                )
+                enc.setBuffer(x, offset: 0, index: 0)
+                enc.setBuffer(lin.wBuffer, offset: 0, index: 1)
+                enc.setBuffer(lin.sBuffer, offset: 0, index: 2)
+                enc.setBuffer(lin.bBuffer, offset: 0, index: 3)
+                enc.setBuffer(y, offset: 0, index: 4)
+                enc.setBytes(&p, length: MemoryLayout<GemvParams>.stride, index: 5)
+                table.withUnsafeBytes { enc.setBytes($0.baseAddress!, length: $0.count, index: 6) }
+                if fastName != nil {
+                    dispatchThreads(
+                        enc, threads: MTLSize(width: 32, height: outDim, depth: n),
+                        threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1)
+                    )
+                } else {
+                    dispatchThreads(
+                        enc, threads: MTLSize(width: outDim, height: n, depth: 1),
+                        threadsPerThreadgroup: MTLSize(width: min(64, outDim), height: 1, depth: 1)
+                    )
+                }
+            } else {
+                enc.setComputePipelineState(try pipeline("gemv_plain_batch"))
+                var p = GemvPlainParams(
+                    wOff: UInt64(lin.wOff + wExtra),
+                    outDim: UInt32(outDim), inDim: UInt32(lin.inDim),
+                    dtype: lin.plainDtype
+                )
+                enc.setBuffer(x, offset: 0, index: 0)
+                enc.setBuffer(lin.wBuffer, offset: 0, index: 1)
+                enc.setBuffer(y, offset: 0, index: 2)
+                enc.setBytes(&p, length: MemoryLayout<GemvPlainParams>.stride, index: 3)
+                table.withUnsafeBytes { enc.setBytes($0.baseAddress!, length: $0.count, index: 4) }
+                dispatchThreads(
+                    enc, threads: MTLSize(width: outDim, height: n, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, outDim), height: 1, depth: 1)
+                )
+            }
+            start = end
+        }
+    }
+
     func encodeSiluMul(
         _ enc: MTLComputeCommandEncoder,
         buf: MTLBuffer, count: Int, gOff: Int, uOff: Int, dstOff: Int

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -991,7 +991,7 @@ public final class MetalEngine {
     /// each scanning a strided subset of the KV rows with its own online
     /// softmax, merged in-threadgroup. Must match ATTN_DECODE_SG in
     /// Kernels.metal.txt.
-    static let attnDecodeSimdgroups = 4
+    static let attnDecodeSimdgroups = 8
 
     /// Gated causal GQA attention for one query token over cache rows
     /// [0, kvLen): out = sigmoid(gate) * softmax(qK^T/sqrt(hd)) V, with the

--- a/Sources/SwiftletCore/MetalEngine.swift
+++ b/Sources/SwiftletCore/MetalEngine.swift
@@ -620,6 +620,46 @@ public final class MetalEngine {
         )
     }
 
+    struct DeltaGatherParams {
+        var keyDim: UInt32
+        var valueDim: UInt32
+        var nv: UInt32
+        var slotStride: UInt32
+        var convOff: UInt32
+        var gbOff: UInt32
+        var qOut: UInt32
+        var kOut: UInt32
+        var vOut: UInt32
+        var gOut: UInt32
+        var bOut: UInt32
+    }
+
+    /// Packs every chunk token's normed q/k/v conv rows and g/beta pairs
+    /// from slot-strided regions into contiguous [tokens, row] blocks — the
+    /// layout gated_delta_step's T-step scan expects. Pure element copies;
+    /// staging cannot perturb numerics.
+    func encodeDeltaGather(
+        _ enc: MTLComputeCommandEncoder, data: MTLBuffer,
+        keyDim: Int, valueDim: Int, nv: Int,
+        slotStride: Int, convOff: Int, gbOff: Int,
+        qOut: Int, kOut: Int, vOut: Int, gOut: Int, bOut: Int, tokens: Int
+    ) throws {
+        enc.setComputePipelineState(try pipeline("delta_gather"))
+        var p = DeltaGatherParams(
+            keyDim: UInt32(keyDim), valueDim: UInt32(valueDim), nv: UInt32(nv),
+            slotStride: UInt32(slotStride), convOff: UInt32(convOff), gbOff: UInt32(gbOff),
+            qOut: UInt32(qOut), kOut: UInt32(kOut), vOut: UInt32(vOut),
+            gOut: UInt32(gOut), bOut: UInt32(bOut)
+        )
+        enc.setBuffer(data, offset: 0, index: 0)
+        enc.setBytes(&p, length: MemoryLayout<DeltaGatherParams>.stride, index: 1)
+        let width = 2 * keyDim + valueDim + 2 * nv
+        dispatchThreads(
+            enc, threads: MTLSize(width: width, height: tokens, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: min(64, width), height: 1, depth: 1)
+        )
+    }
+
     func encodeSiluMul(
         _ enc: MTLComputeCommandEncoder,
         buf: MTLBuffer, count: Int, gOff: Int, uOff: Int, dstOff: Int

--- a/Sources/SwiftletCore/PrefillExpertUnionPlan.swift
+++ b/Sources/SwiftletCore/PrefillExpertUnionPlan.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// S1b-a: executable planning oracle for layer-major prefill.
+///
+/// Given the per-token router outcomes a prompt produced, the plan holds, for
+/// every layer, the union of experts any prompt token routed to — the exact
+/// expert set a layer-major, chunked prefill must have resident while it
+/// sweeps that layer across all positions. This is pure CPU logic: it changes
+/// no existing schedule and is consumed on the CPU by tests today and by the
+/// S1b layer-major prefill path later.
+public struct PrefillExpertUnionPlan: Equatable, Sendable {
+    /// One layer's expert requirement.
+    public struct LayerPlan: Equatable, Sendable {
+        public let layerIndex: Int
+        /// Unique routed experts, ascending. Deterministic for a given set of
+        /// router outcomes regardless of token order or per-token pick order.
+        public let experts: [Int]
+    }
+
+    public enum BuildError: Swift.Error, Equatable {
+        /// A layer-major prefill over zero tokens is meaningless.
+        case emptyPrompt
+        /// Every token must report a route for the same set of layers.
+        case inconsistentLayerCount(token: Int, expected: Int, actual: Int)
+        /// The router always selects at least one expert per token and layer.
+        case emptyRoute(token: Int, layer: Int)
+        /// Expert index outside 0..<expertCount.
+        case expertOutOfRange(token: Int, layer: Int, expert: Int)
+        /// The router never picks the same expert twice for one token.
+        case duplicateExpert(token: Int, layer: Int, expert: Int)
+    }
+
+    public let tokenCount: Int
+    /// Ascending by layerIndex, one entry per layer.
+    public let layers: [LayerPlan]
+
+    /// Builds the plan from token-major router outcomes:
+    /// `tokenRoutes[token][layer]` lists the experts that token routed to at
+    /// that layer, in any order. Malformed input is rejected, not repaired —
+    /// an oracle that silently fixes its input proves nothing.
+    public init(tokenRoutes: [[[Int]]], expertCount: Int) throws {
+        guard let first = tokenRoutes.first else { throw BuildError.emptyPrompt }
+        let layerCount = first.count
+        var unions = [Set<Int>](repeating: [], count: layerCount)
+        for (token, perLayer) in tokenRoutes.enumerated() {
+            guard perLayer.count == layerCount else {
+                throw BuildError.inconsistentLayerCount(
+                    token: token, expected: layerCount, actual: perLayer.count
+                )
+            }
+            for (layer, route) in perLayer.enumerated() {
+                guard !route.isEmpty else {
+                    throw BuildError.emptyRoute(token: token, layer: layer)
+                }
+                var seen = Set<Int>()
+                for expert in route {
+                    guard expert >= 0, expert < expertCount else {
+                        throw BuildError.expertOutOfRange(
+                            token: token, layer: layer, expert: expert
+                        )
+                    }
+                    guard seen.insert(expert).inserted else {
+                        throw BuildError.duplicateExpert(
+                            token: token, layer: layer, expert: expert
+                        )
+                    }
+                    unions[layer].insert(expert)
+                }
+            }
+        }
+        tokenCount = tokenRoutes.count
+        layers = unions.enumerated().map {
+            LayerPlan(layerIndex: $0.offset, experts: $0.element.sorted())
+        }
+    }
+
+    /// Replays the plan in the order a layer-major prefill would consume it:
+    /// ascending layers, each with its ascending expert union.
+    public func replayLayerMajor(
+        _ body: (_ layerIndex: Int, _ experts: [Int]) throws -> Void
+    ) rethrows {
+        for layer in layers {
+            try body(layer.layerIndex, layer.experts)
+        }
+    }
+}

--- a/Sources/SwiftletCore/QwenCPUModel.swift
+++ b/Sources/SwiftletCore/QwenCPUModel.swift
@@ -177,20 +177,10 @@ public final class QwenCPUModel {
     }
 
     // MARK: - Decode state (carried across incremental steps)
-
-    /// Per-session recurrent state: grows KV for the GQA layers, fixed-size
-    /// conv tail + delta state for the DeltaNet layers.
-    public final class DecodeState {
-        /// Tokens already processed (RoPE offset for the next step).
-        public internal(set) var position = 0
-        /// layerIndex -> appended K/V rows, laid out [pos][kvHead][headDim].
-        var kv: [Int: (k: [Float], v: [Float])] = [:]
-        /// layerIndex -> last (convKernel-1) rows of mixed qkv, [row][convDim].
-        var convTail: [Int: [Float]] = [:]
-        /// layerIndex -> delta recurrence state, [vHead][vDim][kDim].
-        var deltaState: [Int: [Float]] = [:]
-        public init() {}
-    }
+    //
+    // The per-session state lives in QwenInferenceContext (KV rows for the
+    // GQA layers, conv tail + delta state for the DeltaNet layers); this
+    // model reads and advances it through the internal DecodeState alias.
 
     // MARK: - Forward
 
@@ -207,7 +197,7 @@ public final class QwenCPUModel {
         let S = tokens.count
         let D = cfg.hiddenSize
         var caps = Captures()
-        let state = DecodeState()
+        let state = DecodeState(owner: self)
 
         var h = [Float](repeating: 0, count: S * D)
         for (s, t) in tokens.enumerated() {
@@ -232,10 +222,11 @@ public final class QwenCPUModel {
         return caps
     }
 
-    /// Incremental step: process `tokens` continuing from `state`, returning
+    /// Incremental step: process `tokens` continuing from `context`, returning
     /// the last position's logits. Used for prefill (many tokens) and decode
-    /// (one token at a time).
-    public func step(_ tokens: [Int], state: DecodeState) throws -> [Float] {
+    /// (one token at a time). The context must come from this instance.
+    public func step(_ tokens: [Int], context state: QwenInferenceContext) throws -> [Float] {
+        try state.checkOwner(self)
         let cfg = config
         let S = tokens.count
         let D = cfg.hiddenSize
@@ -255,12 +246,12 @@ public final class QwenCPUModel {
     }
 
     /// One decoder layer: norm -> (DeltaNet | gated GQA) -> residual -> norm -> MoE -> residual.
-    /// Passing a fresh `DecodeState` reproduces the stateless whole-sequence pass.
-    public func layerForward(_ h: [Float], S: Int, layerIndex: Int, state: DecodeState? = nil) throws -> [Float] {
+    /// Passing no context reproduces the stateless whole-sequence pass.
+    public func layerForward(_ h: [Float], S: Int, layerIndex: Int, state: QwenInferenceContext? = nil) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
         let layer = try layerWeights(layerIndex)
-        let state = state ?? DecodeState()
+        let state = state ?? DecodeState(owner: self)
         var h = h
 
         var x = h

--- a/Sources/SwiftletCore/QwenInferenceContext.swift
+++ b/Sources/SwiftletCore/QwenInferenceContext.swift
@@ -87,3 +87,117 @@ extension QwenMetalModel: InferenceModel {
         return try step(tokens, context: ctx)
     }
 }
+
+// MARK: - Persistence (S6)
+
+extension QwenInferenceContext {
+    /// The context's fields as snapshot sections, one per (layer, kind),
+    /// in layer order. Callers on the Metal fast path capture the bound
+    /// context's GPU recurrence first (the CPU fields are otherwise stale).
+    func snapshotSections() -> [ConversationState.Section] {
+        var sections: [ConversationState.Section] = []
+        for layer in Set(kv.keys).union(convTail.keys).union(deltaState.keys).sorted() {
+            if let rows = kv[layer] {
+                sections.append(.init(layer: layer, kind: .k, values: rows.k))
+                sections.append(.init(layer: layer, kind: .v, values: rows.v))
+            }
+            if let tail = convTail[layer] {
+                sections.append(.init(layer: layer, kind: .convTail, values: tail))
+            }
+            if let state = deltaState[layer] {
+                sections.append(.init(layer: layer, kind: .deltaState, values: state))
+            }
+        }
+        return sections
+    }
+
+    /// Fills a fresh context from a decoded, verified snapshot.
+    func apply(_ snapshot: ConversationState.Snapshot) {
+        reset()
+        for section in snapshot.sections {
+            switch section.kind {
+            case .k: kv[section.layer, default: (k: [], v: [])].k = section.values
+            case .v: kv[section.layer, default: (k: [], v: [])].v = section.values
+            case .convTail: convTail[section.layer] = section.values
+            case .deltaState: deltaState[section.layer] = section.values
+            }
+        }
+        position = snapshot.position
+    }
+}
+
+extension QwenCPUModel: PersistableInferenceModel {
+    /// Model identity for snapshots: config plus hashes.json or the shard
+    /// headers, never weight bytes, so it is cheap enough to recompute.
+    var stateIdentity: ModelIdentity {
+        get throws { try ModelIdentity.compute(modelDir: ckpt.dir, shards: ckpt.shardURLs) }
+    }
+
+    public func snapshot(of context: any InferenceContext) throws -> Data {
+        guard let ctx = context as? QwenInferenceContext else {
+            throw InferenceContextError.foreignContext
+        }
+        try ctx.checkOwner(self)
+        let identity = try stateIdentity
+        return ConversationState.encode(.init(
+            identityScheme: identity.scheme, identity: identity.digest,
+            geometry: .init(config: config), position: ctx.position,
+            sections: ctx.snapshotSections()))
+    }
+
+    public func restoreContext(from data: Data) throws -> any InferenceContext {
+        try restoreQwenContext(from: data)
+    }
+
+    /// Typed restore for callers that hold the concrete model.
+    public func restoreQwenContext(from data: Data) throws -> QwenInferenceContext {
+        let snapshot = try ConversationState.decode(data)
+        try ConversationState.verify(snapshot, identity: try stateIdentity, geometry: .init(config: config))
+        let ctx = makeQwenContext()
+        ctx.apply(snapshot)
+        return ctx
+    }
+}
+
+extension QwenMetalModel: PersistableInferenceModel {
+    /// Model identity for snapshots: config plus hashes.json or the shard
+    /// headers, never weight bytes, so it is cheap enough to recompute.
+    var stateIdentity: ModelIdentity {
+        get throws { try ModelIdentity.compute(modelDir: ckpt.dir, shards: ckpt.shardURLs) }
+    }
+
+    /// Serializes `context`. If it is the bound context its conv history
+    /// and delta recurrence are read back from the GPU buffers first; the
+    /// KV sections come from the context's mirror, which appendKVMirror
+    /// copies from the GPU rows after every attention layer (see
+    /// ConversationStateTests.metalSnapshotMatchesDirectGPUReadback for
+    /// the bitwise proof of both). The context stays bound and live.
+    public func snapshot(of context: any InferenceContext) throws -> Data {
+        guard let ctx = context as? QwenInferenceContext else {
+            throw InferenceContextError.foreignContext
+        }
+        try ctx.checkOwner(self)
+        if let bound = boundContext, bound === ctx, ctx.position > 0 {
+            captureRecurrentState(into: ctx)
+        }
+        let identity = try stateIdentity
+        return ConversationState.encode(.init(
+            identityScheme: identity.scheme, identity: identity.digest,
+            geometry: .init(config: config), position: ctx.position,
+            sections: ctx.snapshotSections()))
+    }
+
+    public func restoreContext(from data: Data) throws -> any InferenceContext {
+        try restoreQwenContext(from: data)
+    }
+
+    /// Typed restore for callers that hold the concrete model. The restored
+    /// context is unbound; its first step loads it into the GPU buffers.
+    public func restoreQwenContext(from data: Data) throws -> QwenInferenceContext {
+        let snapshot = try ConversationState.decode(data)
+        try ConversationState.verify(snapshot, identity: try stateIdentity, geometry: .init(config: config))
+        let ctx = makeQwenContext()
+        ctx.apply(snapshot)
+        return ctx
+    }
+}

--- a/Sources/SwiftletCore/QwenInferenceContext.swift
+++ b/Sources/SwiftletCore/QwenInferenceContext.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Qwen's model-owned inference context: the per-session state both Qwen
+/// engines carry across incremental steps. Grows KV rows for the GQA layers;
+/// keeps a fixed-size conv tail and delta recurrence for the DeltaNet layers.
+///
+/// Ownership: a context belongs to the model instance that created it
+/// (`makeContext`), and that instance is the only one allowed to step it.
+/// On the Metal fast path the live recurrent state of the currently bound
+/// context sits in the model's GPU buffers; the CPU fields here hold the
+/// last captured copy, refreshed whenever the model unbinds or snapshots the
+/// context (see QwenMetalModel.bindContext).
+public final class QwenInferenceContext: InferenceContext {
+    /// Tokens already processed (RoPE offset for the next step).
+    public internal(set) var position = 0
+    /// layerIndex -> appended K/V rows, laid out [pos][kvHead][headDim].
+    var kv: [Int: (k: [Float], v: [Float])] = [:]
+    /// layerIndex -> last (convKernel-1) rows of mixed qkv, [row][convDim].
+    var convTail: [Int: [Float]] = [:]
+    /// layerIndex -> delta recurrence state, [vHead][vDim][kDim].
+    var deltaState: [Int: [Float]] = [:]
+
+    /// The model instance that created this context. Weak so a context can
+    /// outlive its model without keeping it alive; a context whose owner is
+    /// gone is refused by every model (its live GPU state died with the
+    /// owner, so continuing it anywhere else would be silently wrong).
+    private weak var owner: AnyObject?
+
+    init(owner: AnyObject) {
+        self.owner = owner
+    }
+
+    public func reset() {
+        position = 0
+        kv.removeAll()
+        convTail.removeAll()
+        deltaState.removeAll()
+    }
+
+    /// Refuses use by anything but the creating model instance.
+    func checkOwner(_ model: AnyObject) throws {
+        guard let owner, owner === model else { throw InferenceContextError.foreignContext }
+    }
+}
+
+extension QwenCPUModel {
+    /// Internal spelling kept for the engines' private signatures, so the
+    /// Metal file's per-layer helpers did not have to churn for the S7a
+    /// seam. Public callers use `QwenInferenceContext`.
+    typealias DecodeState = QwenInferenceContext
+}
+
+extension QwenCPUModel: InferenceModel {
+    public var modelDir: URL { ckpt.dir }
+    public var vocabSize: Int { config.vocabSize }
+
+    public func makeContext() -> any InferenceContext { makeQwenContext() }
+
+    /// Typed factory for callers that hold the concrete model.
+    public func makeQwenContext() -> QwenInferenceContext {
+        QwenInferenceContext(owner: self)
+    }
+
+    public func step(_ tokens: [Int], context: any InferenceContext) throws -> [Float] {
+        guard let ctx = context as? QwenInferenceContext else {
+            throw InferenceContextError.foreignContext
+        }
+        return try step(tokens, context: ctx)
+    }
+}
+
+extension QwenMetalModel: InferenceModel {
+    public var modelDir: URL { ckpt.dir }
+    public var vocabSize: Int { config.vocabSize }
+
+    public func makeContext() -> any InferenceContext { makeQwenContext() }
+
+    /// Typed factory for callers that hold the concrete model.
+    public func makeQwenContext() -> QwenInferenceContext {
+        QwenInferenceContext(owner: self)
+    }
+
+    public func step(_ tokens: [Int], context: any InferenceContext) throws -> [Float] {
+        guard let ctx = context as? QwenInferenceContext else {
+            throw InferenceContextError.foreignContext
+        }
+        return try step(tokens, context: ctx)
+    }
+}

--- a/Sources/SwiftletCore/QwenMetalModel+Context.swift
+++ b/Sources/SwiftletCore/QwenMetalModel+Context.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Metal
+
+/// Context binding for the Metal fast path.
+///
+/// The fast path keeps each DeltaNet layer's conv history and delta
+/// recurrence in per-layer GPU buffers (FastLayer.hist / .state) and each
+/// attention layer's KV rows in a GPU cache indexed by absolute position.
+/// Those buffers belong to the model, so at any moment they hold exactly one
+/// context's live state: `boundContext`. Stepping a different context first
+/// captures the outgoing context's recurrent state into its CPU fields, then
+/// loads the incoming context's CPU fields (conv tail, delta state, KV rows)
+/// back into the GPU buffers. The bound context's KV mirror is kept current
+/// by appendKVMirror on every step, so KV never needs a capture pass.
+///
+/// All of this is host-side memcpy between command buffers; it adds no
+/// dispatches and changes no arithmetic, so the pinned baselines and parity
+/// gates are unaffected. Layouts are shared with the CPU reference (conv
+/// tail [row][convDim], delta state [vHead][vDim][kDim], KV
+/// [pos][kvHead][headDim]), which is what lets a context move between
+/// engines through a snapshot.
+extension QwenMetalModel {
+    /// Makes `ctx` the context whose state the GPU buffers hold. Same
+    /// context mid-sequence: nothing. Position 0 (fresh or reset): the
+    /// recurrent buffers are zeroed; KV rows are simply overwritten from
+    /// row 0 by the following steps. Otherwise: capture the previous
+    /// context, then load `ctx`.
+    func bindContext(_ ctx: QwenInferenceContext) throws {
+        if let bound = boundContext, bound === ctx {
+            if ctx.position == 0 { resetGPUState() }
+            return
+        }
+        if let previous = boundContext, previous.position > 0 {
+            captureRecurrentState(into: previous)
+        }
+        boundContext = ctx
+        if ctx.position == 0 {
+            resetGPUState()
+        } else {
+            try loadGPUState(from: ctx)
+        }
+    }
+
+    /// Copies every DeltaNet layer's GPU conv history and delta recurrence
+    /// into `ctx`'s CPU fields. Only meaningful for the bound context;
+    /// callers guarantee no command buffer is in flight.
+    func captureRecurrentState(into ctx: QwenInferenceContext) {
+        for li in 0..<config.numHiddenLayers {
+            let fl = fastLayers[li]
+            if let h = fl.hist { ctx.convTail[li] = Self.floats(of: h) }
+            if let st = fl.state { ctx.deltaState[li] = Self.floats(of: st) }
+        }
+    }
+
+    /// Loads `ctx`'s CPU fields into the GPU buffers: conv tail and delta
+    /// state per DeltaNet layer, KV rows per attention layer. Validates the
+    /// whole context against the model geometry before touching any buffer,
+    /// so a malformed context leaves the GPU state as it was.
+    func loadGPUState(from ctx: QwenInferenceContext) throws {
+        let cfg = config
+        let tailFloats = (cfg.linearConvKernelDim - 1) * cfg.convDim
+        let stateFloats = cfg.linearNumValueHeads * cfg.linearValueHeadDim * cfg.linearKeyHeadDim
+        let kvFloats = ctx.position * kvRowFloats
+        for li in 0..<cfg.numHiddenLayers {
+            if cfg.isLinearLayer(li) {
+                guard let tail = ctx.convTail[li], tail.count == tailFloats else {
+                    throw InferenceContextError.inconsistentContext(
+                        "layer \(li): conv tail missing or not \(tailFloats) floats")
+                }
+                guard let st = ctx.deltaState[li], st.count == stateFloats else {
+                    throw InferenceContextError.inconsistentContext(
+                        "layer \(li): delta state missing or not \(stateFloats) floats")
+                }
+            } else {
+                guard let rows = ctx.kv[li], rows.k.count == kvFloats, rows.v.count == kvFloats else {
+                    throw InferenceContextError.inconsistentContext(
+                        "layer \(li): KV rows missing or not \(kvFloats) floats for position \(ctx.position)")
+                }
+            }
+        }
+        for li in 0..<cfg.numHiddenLayers {
+            if cfg.isLinearLayer(li) {
+                Self.fill(fastLayers[li].hist!, with: ctx.convTail[li]!)
+                Self.fill(fastLayers[li].state!, with: ctx.deltaState[li]!)
+            } else {
+                try ensureKVCapacity(li, rows: ctx.position)
+                let rows = ctx.kv[li]!
+                Self.fill(fastLayers[li].kCache!, with: rows.k, prefixOnly: true)
+                Self.fill(fastLayers[li].vCache!, with: rows.v, prefixOnly: true)
+            }
+        }
+    }
+
+    private static func floats(of buffer: MTLBuffer) -> [Float] {
+        let n = buffer.length / MemoryLayout<Float>.stride
+        return Array(UnsafeBufferPointer(
+            start: buffer.contents().bindMemory(to: Float.self, capacity: n), count: n))
+    }
+
+    /// Writes `values` at the start of `buffer`. Whole-buffer by default;
+    /// `prefixOnly` for the KV caches, whose capacity exceeds the rows held.
+    private static func fill(_ buffer: MTLBuffer, with values: [Float], prefixOnly: Bool = false) {
+        let bytes = values.count * MemoryLayout<Float>.stride
+        precondition(prefixOnly ? bytes <= buffer.length : bytes == buffer.length,
+                     "context field does not fit its GPU buffer")
+        guard bytes > 0 else { return }
+        values.withUnsafeBufferPointer {
+            buffer.contents().copyMemory(from: $0.baseAddress!, byteCount: bytes)
+        }
+    }
+}

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1862,9 +1862,12 @@ extension QwenMetalModel {
 // MARK: - S1b layer-major chunked prefill: inside a chunk, sweep each layer
 // across every token before moving on, so a layer's expert union is fetched
 // once per chunk and one decode-shaped buffer sequence covers the whole chunk
-// instead of every token. Per-token math is encoded through the same slot
-// helpers as the decode path, so numerics match the token-major schedule
-// exactly; S2 batches the attention core across the chunk's tokens on GPU.
+// instead of every token. Independent per-token projection GEMVs over shared
+// weights encode as token-batched dispatches (one per projection per chunk,
+// one per (expert, projection) for routed experts); every batched row is the
+// single-token kernel's arithmetic verbatim and the recurrent stages keep
+// ascending token order, so numerics match the token-major schedule exactly.
+// S2 batches the attention core across the chunk's tokens on GPU.
 extension QwenMetalModel {
 
     /// One layer's deferred MoE for a whole chunk: per-token picks/weights in
@@ -1897,6 +1900,12 @@ extension QwenMetalModel {
     private func prefillSlot(_ t: Int) -> TokenSlot {
         TokenSlot(scratch: prefillScratchBuf!, base: t * reg.total,
                   hidden: prefillHiddenBuf!, hiddenByteOffset: t * config.hiddenSize * 4)
+    }
+
+    /// Offset table for one token-batched projection: chunk token t reads
+    /// `src` and writes `dst` inside its own slot stride.
+    private func chunkGemvSlots(_ n: Int, src: Int, dst: Int) -> [(xOff: Int, yOff: Int)] {
+        (0..<n).map { t in (xOff: t * reg.total + src, yOff: t * reg.total + dst) }
     }
 
     /// Splits the prompt into chunks of at most `chunkCapacity` tokens and
@@ -1957,17 +1966,10 @@ extension QwenMetalModel {
                     pending = nil
                 }
                 try phase(.delta) {
-                    // Ascending token order: the conv history and recurrence
-                    // state are shared per layer, and the barriers inside
-                    // each token's sequence order token t+1 after token t.
-                    for t in 0..<S {
-                        try encDeltaCore(enc, delta: delta, fl: fl, slot: prefillSlot(t))
-                    }
+                    try encChunkDelta(enc, delta: delta, fl: fl, tokens: S)
                 }
                 try phase(.router) {
-                    for t in 0..<S {
-                        try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
-                    }
+                    try encChunkRouterProbe(enc, moeGate: L.moe.gate, fl: fl, tokens: S)
                 }
                 enc.endEncoding()
                 commitAndWait(cb)
@@ -1988,8 +1990,17 @@ extension QwenMetalModel {
                     pending = nil
                 }
                 try phase(.attention) {
+                    // Input norms per token, then q/k/v each as one
+                    // token-batched dispatch over every slot.
                     for t in 0..<S {
-                        try encAttentionProjections(enc, attn: attn, fl: fl, slot: prefillSlot(t))
+                        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: prefillSlot(t))
+                    }
+                    barrier(enc)
+                    for proj in [(attn.qProj, reg.qout), (attn.kProj, reg.knew),
+                                 (attn.vProj, reg.vnew)] {
+                        try engine.encodeGemvBatch(
+                            enc, proj.0, x: prefillScratchBuf!, y: prefillScratchBuf!,
+                            slots: chunkGemvSlots(S, src: reg.x0, dst: proj.1))
                     }
                     barrier(enc)
                     for t in 0..<S {
@@ -2002,14 +2013,15 @@ extension QwenMetalModel {
                             enc, layer: li, kvLen: basePosition + t + 1, slot: prefillSlot(t))
                     }
                     barrier(enc)
-                    for t in 0..<S {
-                        try encAttentionFinish(enc, attn: attn, slot: prefillSlot(t))
-                    }
+                    try engine.encodeGemvBatch(
+                        enc, attn.oProj, x: prefillScratchBuf!, y: prefillScratchBuf!,
+                        slots: chunkGemvSlots(S, src: reg.att, dst: reg.r))
+                    barrier(enc)
+                    for t in 0..<S { try encResidualAdd(enc, slot: prefillSlot(t)) }
+                    barrier(enc)
                 }
                 try phase(.router) {
-                    for t in 0..<S {
-                        try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
-                    }
+                    try encChunkRouterProbe(enc, moeGate: L.moe.gate, fl: fl, tokens: S)
                 }
                 enc.endEncoding()
                 commitAndWait(cb)
@@ -2060,9 +2072,58 @@ extension QwenMetalModel {
             count: cfg.vocabSize))
     }
 
-    /// One layer's MoE for a whole chunk. Every expert in the union is
-    /// touched once per stage, encoding the GEMVs of all tokens routed to it
-    /// back-to-back; outputs land in disjoint per-token slots so a stage runs
+    /// One DeltaNet layer over the whole chunk (S1b token batching): every
+    /// token's input norm, then one batched dispatch per in_proj tensor
+    /// covering all tokens, then the recurrence token-by-token in ascending
+    /// order (the conv history and recurrent state are shared per layer, and
+    /// the barriers inside each token's recurrence order token t+1 after
+    /// token t), then one batched output projection and the per-token
+    /// residual adds. One token degenerates to exactly the decode core's
+    /// encode stream.
+    private func encChunkDelta(
+        _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, tokens n: Int
+    ) throws {
+        for t in 0..<n {
+            try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: prefillSlot(t))
+        }
+        barrier(enc)
+        for proj in deltaInProjections(delta) {
+            try engine.encodeGemvBatch(
+                enc, proj.lin, x: prefillScratchBuf!, y: prefillScratchBuf!,
+                slots: chunkGemvSlots(n, src: reg.x0, dst: proj.dst))
+        }
+        barrier(enc)
+        if config.deltaLayout == .fusedInterleaved {
+            for t in 0..<n { try encDeltaDeinterleave(enc, slot: prefillSlot(t)) }
+            barrier(enc)
+        }
+        for t in 0..<n { try encDeltaRecurrence(enc, fl: fl, slot: prefillSlot(t)) }
+        try engine.encodeGemvBatch(
+            enc, delta.outProj, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(n, src: reg.dn, dst: reg.r))
+        barrier(enc)
+        for t in 0..<n { try encResidualAdd(enc, slot: prefillSlot(t)) }
+        barrier(enc)
+    }
+
+    /// Post-attention norms for every chunk token, then the router logits as
+    /// one token-batched dispatch.
+    private func encChunkRouterProbe(
+        _ enc: MTLComputeCommandEncoder, moeGate: GPULinear, fl: FastLayer, tokens n: Int
+    ) throws {
+        for t in 0..<n {
+            try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe, slot: prefillSlot(t))
+        }
+        barrier(enc)
+        try engine.encodeGemvBatch(
+            enc, moeGate, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(n, src: reg.xmoe, dst: reg.rout))
+    }
+
+    /// One layer's MoE for a whole chunk. Each routed projection encodes as
+    /// one token-batched dispatch per union expert covering every token
+    /// routed to it, and each shared projection as one dispatch covering the
+    /// whole chunk; outputs land in disjoint per-token slots so a stage runs
     /// fully in parallel, and each token's weighted accumulation uses the
     /// legacy pick order, keeping numerics identical to the token-major path.
     private func encodeChunkMoE(_ enc: MTLComputeCommandEncoder, _ pend: PendingChunkMoE) throws {
@@ -2090,36 +2151,39 @@ extension QwenMetalModel {
             return (st.gate.lin, st.up.lin, st.down.lin, expert)
         }
 
-        // Stage 1: routed gate/up grouped by expert, plus each token's shared
-        // gate/up and shared-gate logit.
+        // Stage 1: routed gate/up, one token-batched dispatch per (expert,
+        // projection); then the shared gate/up and shared-gate logit, each
+        // one dispatch covering every chunk token.
+        let S = pend.perToken.count
         for expert in pend.union {
             let lin = linears(for: expert)
-            for a in assignments[expert] ?? [] {
-                let slot = prefillSlot(a.t)
-                let K = pend.perToken[a.t].picks.count
-                try engine.encodeGemv(enc, lin.g, rows: inter,
-                    wExtra: lin.e * (moe.stacks?.gate.wStride ?? 0),
-                    sExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
-                    bExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
-                    x: slot.scratch, xOff: slot.base + reg.xmoe,
-                    y: slot.scratch, yOff: slot.base + reg.exp + a.ki * inter)
-                try engine.encodeGemv(enc, lin.u, rows: inter,
-                    wExtra: lin.e * (moe.stacks?.up.wStride ?? 0),
-                    sExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
-                    bExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
-                    x: slot.scratch, xOff: slot.base + reg.xmoe,
-                    y: slot.scratch, yOff: slot.base + reg.exp + K * inter + a.ki * inter)
-            }
+            let assigned = assignments[expert] ?? []
+            try engine.encodeGemvBatch(enc, lin.g, rows: inter,
+                wExtra: lin.e * (moe.stacks?.gate.wStride ?? 0),
+                sExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
+                bExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
+                x: prefillScratchBuf!, y: prefillScratchBuf!,
+                slots: assigned.map { a in
+                    (xOff: a.t * reg.total + reg.xmoe,
+                     yOff: a.t * reg.total + reg.exp + a.ki * inter)
+                })
+            try engine.encodeGemvBatch(enc, lin.u, rows: inter,
+                wExtra: lin.e * (moe.stacks?.up.wStride ?? 0),
+                sExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
+                bExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
+                x: prefillScratchBuf!, y: prefillScratchBuf!,
+                slots: assigned.map { a in
+                    let K = pend.perToken[a.t].picks.count
+                    return (xOff: a.t * reg.total + reg.xmoe,
+                            yOff: a.t * reg.total + reg.exp + K * inter + a.ki * inter)
+                })
         }
-        for t in 0..<pend.perToken.count {
-            let slot = prefillSlot(t)
-            try engine.encodeGemv(enc, moe.sharedGate, x: slot.scratch, xOff: slot.base + reg.xmoe,
-                y: slot.scratch, yOff: slot.base + reg.sh)
-            try engine.encodeGemv(enc, moe.sharedUp, x: slot.scratch, xOff: slot.base + reg.xmoe,
-                y: slot.scratch, yOff: slot.base + reg.sh + shInter)
-            try engine.encodeGemv(enc, fl.sharedGateLin, x: slot.scratch, xOff: slot.base + reg.xmoe,
-                y: slot.scratch, yOff: slot.base + reg.shg)
-        }
+        try engine.encodeGemvBatch(enc, moe.sharedGate, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(S, src: reg.xmoe, dst: reg.sh))
+        try engine.encodeGemvBatch(enc, moe.sharedUp, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(S, src: reg.xmoe, dst: reg.sh + shInter))
+        try engine.encodeGemvBatch(enc, fl.sharedGateLin, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(S, src: reg.xmoe, dst: reg.shg))
         barrier(enc)
 
         // Stage 2: silu(gate) * up for every (token, pick) and shared chain.
@@ -2138,26 +2202,23 @@ extension QwenMetalModel {
         }
         barrier(enc)
 
-        // Stage 3: down projections grouped by expert, plus shared down.
+        // Stage 3: down projections, one token-batched dispatch per union
+        // expert, plus the shared down covering every chunk token.
         for expert in pend.union {
             let lin = linears(for: expert)
-            for a in assignments[expert] ?? [] {
-                let slot = prefillSlot(a.t)
-                let K = pend.perToken[a.t].picks.count
-                try engine.encodeGemv(enc, lin.d, rows: D,
-                    wExtra: lin.e * (moe.stacks?.down.wStride ?? 0),
-                    sExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
-                    bExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
-                    x: slot.scratch, xOff: slot.base + reg.exp + 2 * K * inter + a.ki * inter,
-                    y: slot.scratch, yOff: slot.base + reg.dexp + a.ki * D)
-            }
+            try engine.encodeGemvBatch(enc, lin.d, rows: D,
+                wExtra: lin.e * (moe.stacks?.down.wStride ?? 0),
+                sExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
+                bExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
+                x: prefillScratchBuf!, y: prefillScratchBuf!,
+                slots: (assignments[expert] ?? []).map { a in
+                    let K = pend.perToken[a.t].picks.count
+                    return (xOff: a.t * reg.total + reg.exp + 2 * K * inter + a.ki * inter,
+                            yOff: a.t * reg.total + reg.dexp + a.ki * D)
+                })
         }
-        for t in 0..<pend.perToken.count {
-            let slot = prefillSlot(t)
-            try engine.encodeGemv(enc, moe.sharedDown,
-                x: slot.scratch, xOff: slot.base + reg.sh + 2 * shInter,
-                y: slot.scratch, yOff: slot.base + reg.sh + 3 * shInter)
-        }
+        try engine.encodeGemvBatch(enc, moe.sharedDown, x: prefillScratchBuf!, y: prefillScratchBuf!,
+            slots: chunkGemvSlots(S, src: reg.sh + 2 * shInter, dst: reg.sh + 3 * shInter))
         barrier(enc)
 
         // Stage 4: weighted accumulation per token, legacy pick order.

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -821,8 +821,10 @@ public final class QwenMetalModel {
 
     // MARK: - Step
 
-    /// Incremental step matching QwenCPUModel.step semantics.
-    public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
+    /// Incremental step matching QwenCPUModel.step semantics. The context
+    /// must come from this instance (see QwenInferenceContext).
+    public func step(_ tokens: [Int], context state: QwenInferenceContext) throws -> [Float] {
+        try state.checkOwner(self)
         let counters = StepCounters()
         if case .dispatchBoundaryCounters = phaseGpuSplitSupport {
             counters.phaseGpuSeconds = [:]

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Metal
+import os.signpost
 
 /// GPU runtime: every linear (dense projections, router, experts, lm_head)
 /// runs as a quantized GEMV directly on mmapped checkpoint bytes — weights are
@@ -25,11 +26,29 @@ public final class QwenMetalModel {
         case other
     }
 
+    /// How real a per-phase GPU/wait split can be on this device without
+    /// changing the schedule. The fast path deliberately encodes several
+    /// phases into one encoder per command buffer, so splitting a shared
+    /// buffer's GPU time by phase requires timestamp samples *inside* the
+    /// encoder — dispatch-boundary counter sampling. Devices that sample only
+    /// at encoder/stage boundaries (Apple GPUs) cannot provide that split for
+    /// this schedule, and the API says so instead of inventing numbers.
+    public enum PhaseGpuSplitSupport: Equatable, Sendable {
+        /// The device samples GPU timestamps at compute dispatch boundaries;
+        /// per-phase GPU time is measured inside shared buffers.
+        case dispatchBoundaryCounters
+        /// No in-encoder sampling on this device; per-phase GPU time is
+        /// absent (nil), never zeros. The reason names the device and the
+        /// missing capability.
+        case unsupported(reason: String)
+    }
+
     /// One committed command buffer, in commit order. Encode time and
     /// dispatch counts are attributed to phases exactly (encoding is CPU work
-    /// under our control); blocking-wait and GPU time exist only at
-    /// command-buffer granularity, so a buffer spanning several phases cannot
-    /// split them per phase.
+    /// under our control); blocking-wait time exists only at command-buffer
+    /// granularity, and GPU time splits per phase only when the device
+    /// supports dispatch-boundary counter sampling (see PhaseGpuSplitSupport)
+    /// — otherwise a buffer spanning several phases cannot split it.
     public struct CommandBufferSample: Equatable, Sendable {
         /// Compute dispatches encoded into this buffer, per phase.
         public let phaseDispatches: [StepPhase: Int]
@@ -42,6 +61,11 @@ public final class QwenMetalModel {
         /// GPU start-to-end duration; nil when the buffer failed or reported
         /// invalid timestamps. Not proof of exclusive GPU occupancy.
         public let gpuSeconds: Double?
+        /// GPU seconds per phase from dispatch-boundary counter samples
+        /// resolved for this buffer. nil when the device cannot sample inside
+        /// an encoder, or when any of this buffer's samples failed to resolve
+        /// — a partial split would silently under-report a phase.
+        public let phaseGpuSeconds: [StepPhase: Double]?
         /// Whether status was .completed after the blocking wait.
         public let completed: Bool
 
@@ -90,10 +114,23 @@ public final class QwenMetalModel {
         /// CPU wall time inside per-phase encode scopes; same partial-work
         /// semantics as phaseDispatchesEncoded.
         public let phaseEncodeSeconds: [StepPhase: Double]
+        /// GPU seconds per phase, summed over the buffers whose
+        /// dispatch-boundary counter samples resolved. nil whenever the
+        /// device cannot sample inside an encoder (phaseGpuSplitSupport is
+        /// .unsupported) — absent, never zeros that look like measurements.
+        public let phaseGpuSeconds: [StepPhase: Double]?
 
         public var avoidedLogitProjections: Int {
             max(0, tokensProcessed - logitProjections)
         }
+    }
+
+    /// Count of os_signpost intervals one step emitted, per interval name.
+    /// Rebuilt per step; exists so tests can pin emission to the timeline.
+    struct SignpostTally: Equatable {
+        var stepIntervals = 0
+        var phaseIntervals = 0
+        var commandBufferIntervals = 0
     }
 
     private final class StepCounters {
@@ -111,11 +148,23 @@ public final class QwenMetalModel {
         var timeline: [CommandBufferSample] = []
         var phaseDispatches: [StepPhase: Int] = [:]
         var phaseEncodeSeconds: [StepPhase: Double] = [:]
+        /// Step totals of resolved per-phase GPU seconds; nil unless the
+        /// device supports dispatch-boundary sampling.
+        var phaseGpuSeconds: [StepPhase: Double]?
         var currentPhase: StepPhase?
         var bufferOpen = false
         var bufferEncodeStart = 0.0
         var bufferPhaseDispatches: [StepPhase: Int] = [:]
         var bufferPhaseEncodeSeconds: [StepPhase: Double] = [:]
+        /// Encoder of the open buffer, for in-encoder counter samples only.
+        var currentEncoder: MTLComputeCommandEncoder?
+        var bufferSampleBuffer: MTLCounterSampleBuffer?
+        var bufferSampleIndex = 0
+        var bufferPhaseSampleRanges: [(phase: StepPhase, start: Int, end: Int)] = []
+        var bufferSamplingBroken = false
+        /// CPU/GPU correlation captured when the open buffer began encoding.
+        var bufferCorrelationStart: (cpu: MTLTimestamp, gpu: MTLTimestamp)?
+        var signpostTally = SignpostTally()
     }
 
     public let config: QwenConfig
@@ -190,9 +239,25 @@ public final class QwenMetalModel {
         computeDispatchesEncoded: 0, stepWallSeconds: 0, commandBufferErrors: 0,
         gpuExecutionSeconds: 0, gpuTimedCommandBuffers: 0, gpuUntimedCommandBuffers: 0,
         completedWithoutThrow: false,
-        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:]
+        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:],
+        phaseGpuSeconds: nil
     )
     private var activeStepCounters: StepCounters?
+    /// Whether a per-phase GPU split is real on this device, decided by the
+    /// runtime counter probe at init — never assumed from the OS or GPU name.
+    public let phaseGpuSplitSupport: PhaseGpuSplitSupport
+    /// The raw probe behind phaseGpuSplitSupport, for reporting.
+    public var counterSamplingSupport: MetalEngine.CounterSamplingSupport {
+        engine.probeCounterSampling()
+    }
+    /// Signpost intervals emitted by the latest step; mirrors the timeline.
+    internal private(set) var lastSignpostTally = SignpostTally()
+    /// os_signpost log for step/phase/commandBuffer intervals. Instruments'
+    /// os_signpost instrument groups them under subsystem "Swiftlet".
+    private static let signpostLog = OSLog(subsystem: "Swiftlet", category: "MetalStep")
+    /// Sample slots per command buffer: the fast path encodes at most three
+    /// phase scopes per buffer (2 samples each); headroom is harmless.
+    private static let maxPhaseSamplesPerBuffer = 16
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -227,6 +292,7 @@ public final class QwenMetalModel {
         ckpt = try Checkpoint(dir: modelDir)
         engine = try MetalEngine()
         store = MetalShardStore(device: engine.device)
+        phaseGpuSplitSupport = Self.probePhaseGpuSplit(engine: engine)
 
         let cfg = config
         let ckpt = self.ckpt
@@ -458,8 +524,30 @@ public final class QwenMetalModel {
         }
     }
 
+    /// Decides whether a per-phase GPU split is measurable here. The frozen
+    /// schedule shares one encoder across phases, so the split needs
+    /// dispatch-boundary sampling; anything less gets an explicit reason.
+    private static func probePhaseGpuSplit(engine: MetalEngine) -> PhaseGpuSplitSupport {
+        let probe = engine.probeCounterSampling()
+        if probe.atDispatchBoundary && probe.hasTimestampCounterSet {
+            return .dispatchBoundaryCounters
+        }
+        if !probe.hasTimestampCounterSet {
+            return .unsupported(reason:
+                "device \(probe.deviceName) exposes no timestamp counter set")
+        }
+        return .unsupported(reason:
+            "device \(probe.deviceName) samples timestamps only at encoder boundaries"
+            + " (stage=\(probe.atStageBoundary)), and the fast-path schedule encodes"
+            + " several phases into one encoder per command buffer; an in-buffer"
+            + " per-phase GPU split cannot be measured without changing the schedule")
+    }
+
     /// Starts a step command buffer and opens its S3b timeline accumulator so
-    /// encode time and dispatches attribute to this buffer until commit.
+    /// encode time and dispatches attribute to this buffer until commit. When
+    /// the device supports dispatch-boundary sampling, a fresh counter sample
+    /// buffer and a CPU/GPU correlation point are attached for the per-phase
+    /// GPU split; on other devices this adds nothing to the hot path.
     private func beginStepCommandBuffer() -> (MTLCommandBuffer, MTLComputeCommandEncoder) {
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
@@ -468,17 +556,53 @@ public final class QwenMetalModel {
             counters.bufferEncodeStart = ProcessInfo.processInfo.systemUptime
             counters.bufferPhaseDispatches = [:]
             counters.bufferPhaseEncodeSeconds = [:]
+            counters.currentEncoder = enc
+            counters.bufferSampleBuffer = nil
+            counters.bufferSampleIndex = 0
+            counters.bufferPhaseSampleRanges = []
+            counters.bufferSamplingBroken = false
+            counters.bufferCorrelationStart = nil
+            if case .dispatchBoundaryCounters = phaseGpuSplitSupport,
+               let tsSet = engine.timestampCounterSet {
+                let desc = MTLCounterSampleBufferDescriptor()
+                desc.counterSet = tsSet
+                desc.storageMode = .shared
+                desc.sampleCount = Self.maxPhaseSamplesPerBuffer
+                counters.bufferSampleBuffer =
+                    try? engine.device.makeCounterSampleBuffer(descriptor: desc)
+                counters.bufferSamplingBroken = counters.bufferSampleBuffer == nil
+                counters.bufferCorrelationStart = engine.device.sampleTimestamps()
+            }
         }
         return (cb, enc)
     }
 
     /// Attributes encode-side work (CPU encode wall time and dispatch counts)
-    /// to a phase label. Scopes never nest in the current schedule; if one
+    /// to a phase label, emits one os_signpost interval per scope, and — on
+    /// devices with dispatch-boundary sampling — brackets the scope with GPU
+    /// timestamp samples. Scopes never nest in the current schedule; if one
     /// ever did, its elapsed time would double-count, so keep call sites flat.
     private func phase<T>(_ p: StepPhase, _ body: () throws -> T) rethrows -> T {
         guard let counters = activeStepCounters else { return try body() }
         let previous = counters.currentPhase
         counters.currentPhase = p
+        let signpostID = OSSignpostID(log: Self.signpostLog)
+        os_signpost(.begin, log: Self.signpostLog, name: "phase",
+                    signpostID: signpostID, "%{public}@", p.rawValue)
+        counters.signpostTally.phaseIntervals += 1
+        var sampleStart = -1
+        if let sb = counters.bufferSampleBuffer, counters.bufferOpen,
+           let enc = counters.currentEncoder, !counters.bufferSamplingBroken {
+            if counters.bufferSampleIndex + 1 < Self.maxPhaseSamplesPerBuffer {
+                sampleStart = counters.bufferSampleIndex
+                counters.bufferSampleIndex += 2
+                enc.sampleCounters(sampleBuffer: sb, sampleIndex: sampleStart, barrier: true)
+            } else {
+                // Out of slots: drop the whole buffer's split rather than
+                // publish a partial one.
+                counters.bufferSamplingBroken = true
+            }
+        }
         let start = ProcessInfo.processInfo.systemUptime
         defer {
             let elapsed = max(0, ProcessInfo.processInfo.systemUptime - start)
@@ -486,6 +610,14 @@ public final class QwenMetalModel {
             if counters.bufferOpen {
                 counters.bufferPhaseEncodeSeconds[p, default: 0] += elapsed
             }
+            if sampleStart >= 0, let sb = counters.bufferSampleBuffer,
+               let enc = counters.currentEncoder, !counters.bufferSamplingBroken {
+                enc.sampleCounters(sampleBuffer: sb, sampleIndex: sampleStart + 1, barrier: true)
+                counters.bufferPhaseSampleRanges.append(
+                    (phase: p, start: sampleStart, end: sampleStart + 1))
+            }
+            os_signpost(.end, log: Self.signpostLog, name: "phase",
+                        signpostID: signpostID, "%{public}@", p.rawValue)
             counters.currentPhase = previous
         }
         return try body()
@@ -498,6 +630,11 @@ public final class QwenMetalModel {
             encodeSeconds = max(
                 0, ProcessInfo.processInfo.systemUptime - counters.bufferEncodeStart
             )
+        }
+        let signpostID = OSSignpostID(log: Self.signpostLog)
+        if counters != nil {
+            os_signpost(.begin, log: Self.signpostLog, name: "commandBuffer", signpostID: signpostID)
+            counters?.signpostTally.commandBufferIntervals += 1
         }
         cb.commit()
         counters?.commandBuffersCommitted += 1
@@ -523,17 +660,86 @@ public final class QwenMetalModel {
             }
         }
         guard let counters else { return }
+
+        var phaseGpu: [StepPhase: Double]?
+        if completed, let sb = counters.bufferSampleBuffer,
+           !counters.bufferSamplingBroken, !counters.bufferPhaseSampleRanges.isEmpty,
+           let correlationStart = counters.bufferCorrelationStart {
+            phaseGpu = resolvePhaseGpuSeconds(
+                sampleBuffer: sb, sampleCount: counters.bufferSampleIndex,
+                ranges: counters.bufferPhaseSampleRanges,
+                correlationStart: correlationStart
+            )
+            if let resolved = phaseGpu, counters.phaseGpuSeconds != nil {
+                for (p, s) in resolved {
+                    counters.phaseGpuSeconds![p, default: 0] += s
+                }
+            }
+        }
+
+        let label = StepPhase.allCases.filter {
+            counters.bufferPhaseDispatches[$0] != nil
+                || counters.bufferPhaseEncodeSeconds[$0] != nil
+        }.map(\.rawValue).joined(separator: "+")
+        os_signpost(.end, log: Self.signpostLog, name: "commandBuffer",
+                    signpostID: signpostID, "%{public}@ wait=%.6f gpu=%.6f",
+                    label, waitSeconds, gpuSeconds ?? -1)
+
         counters.timeline.append(CommandBufferSample(
             phaseDispatches: counters.bufferPhaseDispatches,
             phaseEncodeSeconds: counters.bufferPhaseEncodeSeconds,
             encodeSeconds: encodeSeconds,
             waitSeconds: waitSeconds,
             gpuSeconds: gpuSeconds,
+            phaseGpuSeconds: phaseGpu,
             completed: completed
         ))
         counters.bufferOpen = false
         counters.bufferPhaseDispatches = [:]
         counters.bufferPhaseEncodeSeconds = [:]
+        counters.currentEncoder = nil
+        counters.bufferSampleBuffer = nil
+        counters.bufferSampleIndex = 0
+        counters.bufferPhaseSampleRanges = []
+        counters.bufferSamplingBroken = false
+        counters.bufferCorrelationStart = nil
+    }
+
+    /// Converts resolved dispatch-boundary timestamp samples into per-phase
+    /// GPU seconds using a linear CPU/GPU correlation across the buffer's
+    /// lifetime (device.sampleTimestamps at encode start and now; CPU
+    /// timestamps are nanoseconds). Any unresolved or non-monotone sample
+    /// voids the whole buffer's split — partial splits under-report silently.
+    /// Only reachable on devices whose probe reports dispatch-boundary
+    /// sampling; Apple GPUs never enter here.
+    private func resolvePhaseGpuSeconds(
+        sampleBuffer: MTLCounterSampleBuffer,
+        sampleCount: Int,
+        ranges: [(phase: StepPhase, start: Int, end: Int)],
+        correlationStart: (cpu: MTLTimestamp, gpu: MTLTimestamp)
+    ) -> [StepPhase: Double]? {
+        let correlationEnd = engine.device.sampleTimestamps()
+        guard correlationEnd.cpu > correlationStart.cpu,
+              correlationEnd.gpu > correlationStart.gpu else { return nil }
+        let cpuSeconds = Double(correlationEnd.cpu - correlationStart.cpu) / 1e9
+        let ticksPerSecond = Double(correlationEnd.gpu - correlationStart.gpu) / cpuSeconds
+        guard ticksPerSecond > 0,
+              let data = try? sampleBuffer.resolveCounterRange(0..<sampleCount),
+              data.count >= sampleCount * MemoryLayout<MTLCounterResultTimestamp>.stride
+        else { return nil }
+        return data.withUnsafeBytes { raw -> [StepPhase: Double]? in
+            let stamps = raw.bindMemory(to: MTLCounterResultTimestamp.self)
+            var result: [StepPhase: Double] = [:]
+            for range in ranges {
+                let t0 = stamps[range.start].timestamp
+                let t1 = stamps[range.end].timestamp
+                guard t0 != 0, t1 != 0, t0 != .max, t1 != .max, t1 >= t0 else {
+                    return nil
+                }
+                result[range.phase, default: 0] += Double(t1 - t0) / ticksPerSecond
+            }
+            return result
+        }
     }
 
     private func runPhase(
@@ -557,8 +763,15 @@ public final class QwenMetalModel {
     /// Incremental step matching QwenCPUModel.step semantics.
     public func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float] {
         let counters = StepCounters()
+        if case .dispatchBoundaryCounters = phaseGpuSplitSupport {
+            counters.phaseGpuSeconds = [:]
+        }
         let wallStart = ProcessInfo.processInfo.systemUptime
         activeStepCounters = counters
+        let stepSignpostID = OSSignpostID(log: Self.signpostLog)
+        os_signpost(.begin, log: Self.signpostLog, name: "step",
+                    signpostID: stepSignpostID, "tokens=%d", tokens.count)
+        counters.signpostTally.stepIntervals += 1
         engine.computeDispatchObserver = {
             counters.computeDispatchesEncoded += 1
             let bucket = counters.currentPhase ?? .other
@@ -570,6 +783,9 @@ public final class QwenMetalModel {
         defer {
             engine.computeDispatchObserver = nil
             activeStepCounters = nil
+            os_signpost(.end, log: Self.signpostLog, name: "step",
+                        signpostID: stepSignpostID)
+            lastSignpostTally = counters.signpostTally
             lastStepMetrics = StepMetrics(
                 tokensProcessed: counters.tokensProcessed,
                 logitProjections: counters.logitProjections,
@@ -585,7 +801,8 @@ public final class QwenMetalModel {
                 completedWithoutThrow: counters.completedWithoutThrow,
                 commandBufferTimeline: counters.timeline,
                 phaseDispatchesEncoded: counters.phaseDispatches,
-                phaseEncodeSeconds: counters.phaseEncodeSeconds
+                phaseEncodeSeconds: counters.phaseEncodeSeconds,
+                phaseGpuSeconds: counters.phaseGpuSeconds
             )
         }
 

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -325,7 +325,9 @@ public final class QwenMetalModel {
     var sBuf: MTLBuffer?
     var hBuf: MTLBuffer?
     var reg = Regions()
-    var boundStateID: ObjectIdentifier?
+    /// The context whose conv history and delta recurrence currently sit in
+    /// the fast path's per-layer GPU buffers (see bindContext).
+    weak var boundContext: QwenInferenceContext?
     struct PendingMoE {
         var bufs: [MTLBuffer]
         var weights: [Float]
@@ -1344,7 +1346,7 @@ extension QwenMetalModel {
             count: n))
     }
 
-    private func resetGPUState() {
+    func resetGPUState() {
         for fl in fastLayers {
             if let h = fl.hist { memset(h.contents(), 0, h.length) }
             if let st = fl.state { memset(st.contents(), 0, st.length) }
@@ -1519,10 +1521,7 @@ extension QwenMetalModel {
     ) throws -> [Float] {
         let cfg = config
         let D = cfg.hiddenSize
-        if boundStateID != ObjectIdentifier(state) || state.position == 0 {
-            boundStateID = ObjectIdentifier(state)
-            if state.position == 0 { resetGPUState() }
-        }
+        try bindContext(state)
 
         let h0 = try ckpt.moduleWeightSlice("model.embed_tokens", rowRange: token..<(token + 1))
         h0.withUnsafeBufferPointer {
@@ -1813,7 +1812,7 @@ extension QwenMetalModel {
         case kvCacheAllocationFailed(layer: Int, rows: Int)
     }
 
-    private var kvRowFloats: Int { config.numKeyValueHeads * config.headDim }
+    var kvRowFloats: Int { config.numKeyValueHeads * config.headDim }
 
     /// Grows layer `li`'s GPU KV cache to hold at least `rows` positions
     /// (doubling; written rows copied across). Only called between command
@@ -2128,10 +2127,7 @@ extension QwenMetalModel {
         let cfg = config
         let D = cfg.hiddenSize
         let S = chunk.count
-        if boundStateID != ObjectIdentifier(state) || state.position == 0 {
-            boundStateID = ObjectIdentifier(state)
-            if state.position == 0 { resetGPUState() }
-        }
+        try bindContext(state)
         let basePosition = state.position
 
         for (t, token) in chunk.enumerated() {

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -258,6 +258,11 @@ public final class QwenMetalModel {
     /// Sample slots per command buffer: the fast path encodes at most three
     /// phase scopes per buffer (2 samples each); headroom is harmless.
     private static let maxPhaseSamplesPerBuffer = 16
+    /// Test hook (S1b-a): observes the routed expert list for every
+    /// (token, layer) exactly as the existing token-by-token path selects it.
+    /// The prefill expert-union planning oracle derives its input from these
+    /// outcomes; the hook changes no schedule and stays internal.
+    var routedExpertObserver: ((_ layer: Int, _ experts: [Int]) -> Void)?
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -1090,6 +1095,7 @@ public final class QwenMetalModel {
                 picks.sort { $0.1 > $1.1 }
             }
         }
+        routedExpertObserver?(layerIndex, picks.map { $0.0 })
 
         // Scratch layout in yBuf (floats):
         //   [0, K*inter)                        expert gate outputs
@@ -1425,6 +1431,7 @@ extension QwenMetalModel {
             }
 
             let (picks, weights) = routerPicks()
+            routedExpertObserver?(li, picks.map { $0.0 })
             var bufs: [MTLBuffer] = []
             if let cache = expertCache {
                 bufs = try cache.buffers(layer: li, experts: picks.map { $0.0 })

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -7,8 +7,60 @@ import Metal
 /// delta recurrence, attention softmax over cached KV, top-k routing), all of
 /// it microseconds per token. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
-    /// S3a whole-step aggregate baseline. These totals do not identify phases,
-    /// layer costs, overlap, or command-buffer timeline gaps.
+    /// S3b command-buffer phase labels. A label names the work a phase scope
+    /// encoded; it claims nothing about when the GPU actually ran that work.
+    public enum StepPhase: String, CaseIterable, Sendable {
+        /// Attention norm + q/k/v projections, output projection, residual add.
+        case attention
+        /// DeltaNet mixer: projections, conv step, recurrence, gated norm,
+        /// output projection, residual add.
+        case delta
+        /// Routed expert GEMVs plus the shared-expert chain and accumulation.
+        case moe
+        /// Pre-MoE norm and the router logits projection.
+        case router
+        /// Final norm and vocabulary projection.
+        case lmHead
+        /// Dispatches encoded outside every labeled scope (must stay empty).
+        case other
+    }
+
+    /// One committed command buffer, in commit order. Encode time and
+    /// dispatch counts are attributed to phases exactly (encoding is CPU work
+    /// under our control); blocking-wait and GPU time exist only at
+    /// command-buffer granularity, so a buffer spanning several phases cannot
+    /// split them per phase.
+    public struct CommandBufferSample: Equatable, Sendable {
+        /// Compute dispatches encoded into this buffer, per phase.
+        public let phaseDispatches: [StepPhase: Int]
+        /// CPU wall time inside each phase's encode scope for this buffer.
+        public let phaseEncodeSeconds: [StepPhase: Double]
+        /// CPU wall time from encoder creation to commit (>= the phase sum).
+        public let encodeSeconds: Double
+        /// Wall time inside this buffer's waitUntilCompleted call.
+        public let waitSeconds: Double
+        /// GPU start-to-end duration; nil when the buffer failed or reported
+        /// invalid timestamps. Not proof of exclusive GPU occupancy.
+        public let gpuSeconds: Double?
+        /// Whether status was .completed after the blocking wait.
+        public let completed: Bool
+
+        /// Phases encoded into this buffer, in declaration order (a canonical
+        /// label, not the encode order within the buffer).
+        public var phases: [StepPhase] {
+            StepPhase.allCases.filter {
+                phaseDispatches[$0] != nil || phaseEncodeSeconds[$0] != nil
+            }
+        }
+
+        public var dispatchesEncoded: Int { phaseDispatches.values.reduce(0, +) }
+    }
+
+    /// S3a whole-step aggregates plus the S3b committed-buffer timeline.
+    /// The aggregates still cannot identify overlap; the timeline labels each
+    /// buffer's encoded phases and reports per-buffer encode/wait/GPU cost,
+    /// but it is not an Instruments trace: it cannot see gaps between buffers
+    /// or split a multi-phase buffer's wait/GPU time by phase.
     public struct StepMetrics: Equatable, Sendable {
         public let tokensProcessed: Int
         public let logitProjections: Int
@@ -28,6 +80,16 @@ public final class QwenMetalModel {
         public let gpuUntimedCommandBuffers: Int
         /// False when step exited by throwing after publishing partial counters.
         public let completedWithoutThrow: Bool
+        /// S3b: committed command buffers in commit order. A throwing step's
+        /// never-committed encodes are absent here but still counted in
+        /// computeDispatchesEncoded and the phase totals below.
+        public let commandBufferTimeline: [CommandBufferSample]
+        /// Encode-side dispatch totals per phase, including partial work from
+        /// a buffer the step never committed before throwing.
+        public let phaseDispatchesEncoded: [StepPhase: Int]
+        /// CPU wall time inside per-phase encode scopes; same partial-work
+        /// semantics as phaseDispatchesEncoded.
+        public let phaseEncodeSeconds: [StepPhase: Double]
 
         public var avoidedLogitProjections: Int {
             max(0, tokensProcessed - logitProjections)
@@ -46,6 +108,14 @@ public final class QwenMetalModel {
         var gpuTimedCommandBuffers = 0
         var gpuUntimedCommandBuffers = 0
         var completedWithoutThrow = false
+        var timeline: [CommandBufferSample] = []
+        var phaseDispatches: [StepPhase: Int] = [:]
+        var phaseEncodeSeconds: [StepPhase: Double] = [:]
+        var currentPhase: StepPhase?
+        var bufferOpen = false
+        var bufferEncodeStart = 0.0
+        var bufferPhaseDispatches: [StepPhase: Int] = [:]
+        var bufferPhaseEncodeSeconds: [StepPhase: Double] = [:]
     }
 
     public let config: QwenConfig
@@ -119,7 +189,8 @@ public final class QwenMetalModel {
         commandBuffersCommitted: 0, blockingWaits: 0, blockingWaitSeconds: 0,
         computeDispatchesEncoded: 0, stepWallSeconds: 0, commandBufferErrors: 0,
         gpuExecutionSeconds: 0, gpuTimedCommandBuffers: 0, gpuUntimedCommandBuffers: 0,
-        completedWithoutThrow: false
+        completedWithoutThrow: false,
+        commandBufferTimeline: [], phaseDispatchesEncoded: [:], phaseEncodeSeconds: [:]
     )
     private var activeStepCounters: StepCounters?
 
@@ -387,34 +458,89 @@ public final class QwenMetalModel {
         }
     }
 
-    private func commitAndWait(_ cb: MTLCommandBuffer) {
-        cb.commit()
-        activeStepCounters?.commandBuffersCommitted += 1
-        let waitStart = ProcessInfo.processInfo.systemUptime
-        cb.waitUntilCompleted()
-        activeStepCounters?.blockingWaits += 1
-        activeStepCounters?.blockingWaitSeconds += max(
-            0, ProcessInfo.processInfo.systemUptime - waitStart
-        )
-
-        guard cb.status == .completed else {
-            activeStepCounters?.commandBufferErrors += 1
-            return
-        }
-        let start = cb.gpuStartTime
-        let end = cb.gpuEndTime
-        guard start.isFinite, end.isFinite, start > 0, end > 0, end >= start else {
-            activeStepCounters?.gpuUntimedCommandBuffers += 1
-            return
-        }
-        activeStepCounters?.gpuExecutionSeconds += end - start
-        activeStepCounters?.gpuTimedCommandBuffers += 1
-    }
-
-    private func runPhase(_ body: (MTLComputeCommandEncoder) throws -> Void) throws {
+    /// Starts a step command buffer and opens its S3b timeline accumulator so
+    /// encode time and dispatches attribute to this buffer until commit.
+    private func beginStepCommandBuffer() -> (MTLCommandBuffer, MTLComputeCommandEncoder) {
         let cb = engine.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
-        try body(enc)
+        if let counters = activeStepCounters {
+            counters.bufferOpen = true
+            counters.bufferEncodeStart = ProcessInfo.processInfo.systemUptime
+            counters.bufferPhaseDispatches = [:]
+            counters.bufferPhaseEncodeSeconds = [:]
+        }
+        return (cb, enc)
+    }
+
+    /// Attributes encode-side work (CPU encode wall time and dispatch counts)
+    /// to a phase label. Scopes never nest in the current schedule; if one
+    /// ever did, its elapsed time would double-count, so keep call sites flat.
+    private func phase<T>(_ p: StepPhase, _ body: () throws -> T) rethrows -> T {
+        guard let counters = activeStepCounters else { return try body() }
+        let previous = counters.currentPhase
+        counters.currentPhase = p
+        let start = ProcessInfo.processInfo.systemUptime
+        defer {
+            let elapsed = max(0, ProcessInfo.processInfo.systemUptime - start)
+            counters.phaseEncodeSeconds[p, default: 0] += elapsed
+            if counters.bufferOpen {
+                counters.bufferPhaseEncodeSeconds[p, default: 0] += elapsed
+            }
+            counters.currentPhase = previous
+        }
+        return try body()
+    }
+
+    private func commitAndWait(_ cb: MTLCommandBuffer) {
+        let counters = activeStepCounters
+        var encodeSeconds = 0.0
+        if let counters, counters.bufferOpen {
+            encodeSeconds = max(
+                0, ProcessInfo.processInfo.systemUptime - counters.bufferEncodeStart
+            )
+        }
+        cb.commit()
+        counters?.commandBuffersCommitted += 1
+        let waitStart = ProcessInfo.processInfo.systemUptime
+        cb.waitUntilCompleted()
+        counters?.blockingWaits += 1
+        let waitSeconds = max(0, ProcessInfo.processInfo.systemUptime - waitStart)
+        counters?.blockingWaitSeconds += waitSeconds
+
+        let completed = cb.status == .completed
+        var gpuSeconds: Double?
+        if !completed {
+            counters?.commandBufferErrors += 1
+        } else {
+            let start = cb.gpuStartTime
+            let end = cb.gpuEndTime
+            if start.isFinite, end.isFinite, start > 0, end > 0, end >= start {
+                gpuSeconds = end - start
+                counters?.gpuExecutionSeconds += end - start
+                counters?.gpuTimedCommandBuffers += 1
+            } else {
+                counters?.gpuUntimedCommandBuffers += 1
+            }
+        }
+        guard let counters else { return }
+        counters.timeline.append(CommandBufferSample(
+            phaseDispatches: counters.bufferPhaseDispatches,
+            phaseEncodeSeconds: counters.bufferPhaseEncodeSeconds,
+            encodeSeconds: encodeSeconds,
+            waitSeconds: waitSeconds,
+            gpuSeconds: gpuSeconds,
+            completed: completed
+        ))
+        counters.bufferOpen = false
+        counters.bufferPhaseDispatches = [:]
+        counters.bufferPhaseEncodeSeconds = [:]
+    }
+
+    private func runPhase(
+        _ label: StepPhase, _ body: (MTLComputeCommandEncoder) throws -> Void
+    ) throws {
+        let (cb, enc) = beginStepCommandBuffer()
+        try phase(label) { try body(enc) }
         enc.endEncoding()
         commitAndWait(cb)
     }
@@ -433,7 +559,14 @@ public final class QwenMetalModel {
         let counters = StepCounters()
         let wallStart = ProcessInfo.processInfo.systemUptime
         activeStepCounters = counters
-        engine.computeDispatchObserver = { counters.computeDispatchesEncoded += 1 }
+        engine.computeDispatchObserver = {
+            counters.computeDispatchesEncoded += 1
+            let bucket = counters.currentPhase ?? .other
+            counters.phaseDispatches[bucket, default: 0] += 1
+            if counters.bufferOpen {
+                counters.bufferPhaseDispatches[bucket, default: 0] += 1
+            }
+        }
         defer {
             engine.computeDispatchObserver = nil
             activeStepCounters = nil
@@ -449,7 +582,10 @@ public final class QwenMetalModel {
                 gpuExecutionSeconds: counters.gpuExecutionSeconds,
                 gpuTimedCommandBuffers: counters.gpuTimedCommandBuffers,
                 gpuUntimedCommandBuffers: counters.gpuUntimedCommandBuffers,
-                completedWithoutThrow: counters.completedWithoutThrow
+                completedWithoutThrow: counters.completedWithoutThrow,
+                commandBufferTimeline: counters.timeline,
+                phaseDispatchesEncoded: counters.phaseDispatches,
+                phaseEncodeSeconds: counters.phaseEncodeSeconds
             )
         }
 
@@ -500,7 +636,7 @@ public final class QwenMetalModel {
         guard projectLogits else { return [] }
         QwenCPUModel.rmsNorm(&h, rows: 1, dim: D, weight: finalNorm, eps: Float(cfg.rmsNormEps))
         loadX(h)
-        try runPhase { enc in
+        try runPhase(.lmHead) { enc in
             try engine.encodeGemv(enc, lmHead, x: xBuf, y: logitsBuf, yOff: 0)
         }
         activeStepCounters?.logitProjections += 1
@@ -521,7 +657,7 @@ public final class QwenMetalModel {
         let kvDim = KVH * hd
 
         loadX(x)
-        try runPhase { enc in
+        try runPhase(.attention) { enc in
             try engine.encodeGemv(enc, w.qProj, x: xBuf, y: yBuf, yOff: 0)
             try engine.encodeGemv(enc, w.kProj, x: xBuf, y: yBuf, yOff: qOutDim)
             try engine.encodeGemv(enc, w.vProj, x: xBuf, y: yBuf, yOff: qOutDim + kvDim)
@@ -571,7 +707,7 @@ public final class QwenMetalModel {
         for i in 0..<attnOut.count { attnOut[i] *= QwenCPUModel.sigmoid(gate[i]) }
 
         loadX(attnOut)
-        try runPhase { enc in
+        try runPhase(.attention) { enc in
             try engine.encodeGemv(enc, w.oProj, x: xBuf, y: yBuf, yOff: 0)
         }
         return readY(0, cfg.hiddenSize)
@@ -614,7 +750,7 @@ public final class QwenMetalModel {
         switch cfg.deltaLayout {
         case .fusedInterleaved:
             let qkvzDim = 2 * keyDim + 2 * valueDim
-            try runPhase { enc in
+            try runPhase(.delta) { enc in
                 try engine.encodeGemv(enc, w.qkvz!, x: xBuf, y: yBuf, yOff: 0)
                 try engine.encodeGemv(enc, w.ba!, x: xBuf, y: yBuf, yOff: qkvzDim)
             }
@@ -644,7 +780,7 @@ public final class QwenMetalModel {
                 }
             }
         case .split:
-            try runPhase { enc in
+            try runPhase(.delta) { enc in
                 try engine.encodeGemv(enc, w.qkv!, x: xBuf, y: yBuf, yOff: 0)
                 try engine.encodeGemv(enc, w.zProj!, x: xBuf, y: yBuf, yOff: convDim)
                 try engine.encodeGemv(enc, w.bProj!, x: xBuf, y: yBuf, yOff: convDim + valueDim)
@@ -706,7 +842,7 @@ public final class QwenMetalModel {
         for i in 0..<normed.count { normed[i] *= QwenCPUModel.silu(z[i]) }
 
         loadX(normed)
-        try runPhase { enc in
+        try runPhase(.delta) { enc in
             try engine.encodeGemv(enc, w.outProj, x: xBuf, y: yBuf, yOff: 0)
         }
         return readY(0, cfg.hiddenSize)
@@ -721,7 +857,7 @@ public final class QwenMetalModel {
         let topK = cfg.numExpertsPerTok
 
         loadX(x)
-        try runPhase { enc in
+        try runPhase(.router) { enc in
             try engine.encodeGemv(enc, w.gate, x: xBuf, y: yBuf, yOff: 0)
         }
         var router = readY(0, E)
@@ -756,7 +892,7 @@ public final class QwenMetalModel {
             expertBufs = try cache.buffers(layer: layerIndex, experts: picks.map { $0.0 })
         }
 
-        try runPhase { enc in
+        try runPhase(.moe) { enc in
             for (ki, pick) in picks.enumerated() {
                 let e = pick.0
                 if let projs = expertProjs {
@@ -1021,43 +1157,52 @@ extension QwenMetalModel {
             let fl = fastLayers[li]
 
             if let delta = L.delta {
-                let cb = engine.queue.makeCommandBuffer()!
-                let enc = cb.makeComputeCommandEncoder()!
-                if let p = pending { try encodePendingMoE(enc, p); pending = nil }
+                let (cb, enc) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodePendingMoE(enc, p) }
+                    pending = nil
+                }
                 try encDeltaLayer(enc, delta: delta, fl: fl, moeGate: L.moe.gate)
                 enc.endEncoding()
                 commitAndWait(cb)
             } else {
                 // Attention: projections, CPU core, then out-proj + router.
-                let cb1 = engine.queue.makeCommandBuffer()!
-                let e1 = cb1.makeComputeCommandEncoder()!
-                if let p = pending { try encodePendingMoE(e1, p); pending = nil }
-                try encNormCopy(e1, w: fl.inputNorm, dstOff: reg.x0)
-                barrier(e1)
+                let (cb1, e1) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodePendingMoE(e1, p) }
+                    pending = nil
+                }
                 let attn = L.attn!
-                try engine.encodeGemv(e1, attn.qProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qout)
-                try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
-                try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
+                try phase(.attention) {
+                    try encNormCopy(e1, w: fl.inputNorm, dstOff: reg.x0)
+                    barrier(e1)
+                    try engine.encodeGemv(e1, attn.qProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qout)
+                    try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
+                    try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
+                }
                 e1.endEncoding()
                 commitAndWait(cb1)
 
                 let attnOut = attnCoreCPU(layerIndex: li, state: state, attn: attn)
                 writeS(reg.att, attnOut)
 
-                let cb2 = engine.queue.makeCommandBuffer()!
-                let e2 = cb2.makeComputeCommandEncoder()!
-                try engine.encodeGemv(e2, attn.oProj, x: sBuf!, xOff: reg.att, y: sBuf!, yOff: reg.r)
-                barrier(e2)
-                var np = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-                e2.setComputePipelineState(try engine.pipeline("add_inplace"))
-                e2.setBuffer(hBuf!, offset: 0, index: 0)
-                e2.setBuffer(sBuf!, offset: 0, index: 1)
-                setBytesParams(e2, &np, index: 2)
-                dispatchN(e2, D)
-                barrier(e2)
-                try encNormCopy(e2, w: fl.postNorm, dstOff: reg.xmoe)
-                barrier(e2)
-                try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+                let (cb2, e2) = beginStepCommandBuffer()
+                try phase(.attention) {
+                    try engine.encodeGemv(e2, attn.oProj, x: sBuf!, xOff: reg.att, y: sBuf!, yOff: reg.r)
+                    barrier(e2)
+                    var np = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
+                    e2.setComputePipelineState(try engine.pipeline("add_inplace"))
+                    e2.setBuffer(hBuf!, offset: 0, index: 0)
+                    e2.setBuffer(sBuf!, offset: 0, index: 1)
+                    setBytesParams(e2, &np, index: 2)
+                    dispatchN(e2, D)
+                    barrier(e2)
+                }
+                try phase(.router) {
+                    try encNormCopy(e2, w: fl.postNorm, dstOff: reg.xmoe)
+                    barrier(e2)
+                    try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+                }
                 e2.endEncoding()
                 commitAndWait(cb2)
             }
@@ -1072,19 +1217,20 @@ extension QwenMetalModel {
 
         // Always apply the last layer's experts. Only the final token in a
         // multi-token call also needs final norm + vocabulary projection.
-        let cb = engine.queue.makeCommandBuffer()!
-        let enc = cb.makeComputeCommandEncoder()!
-        if let p = pending { try encodePendingMoE(enc, p) }
+        let (cb, enc) = beginStepCommandBuffer()
+        if let p = pending { try phase(.moe) { try encodePendingMoE(enc, p) } }
         if projectLogits {
-            enc.setComputePipelineState(try engine.pipeline("norm_copy"))
-            var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
-            enc.setBuffer(hBuf!, offset: 0, index: 0)
-            enc.setBuffer(sBuf!, offset: 0, index: 1)
-            enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
-            setBytesParams(enc, &np, index: 3)
-            dispatchRows(enc, rows: 1)
-            barrier(enc)
-            try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            try phase(.lmHead) {
+                enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+                var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
+                enc.setBuffer(hBuf!, offset: 0, index: 0)
+                enc.setBuffer(sBuf!, offset: 0, index: 1)
+                enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
+                setBytesParams(enc, &np, index: 3)
+                dispatchRows(enc, rows: 1)
+                barrier(enc)
+                try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+            }
             activeStepCounters?.logitProjections += 1
         }
         enc.endEncoding()
@@ -1103,97 +1249,101 @@ extension QwenMetalModel {
         let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
         let keyDim = cfg.keyDim, convDim = cfg.convDim
 
-        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0)
-        barrier(enc)
-        switch config.deltaLayout {
-        case .split:
-            try engine.encodeGemv(enc, delta.qkv!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkv)
-            try engine.encodeGemv(enc, delta.zProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.z)
-            try engine.encodeGemv(enc, delta.bProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.b)
-            try engine.encodeGemv(enc, delta.aProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.a)
+        try phase(.delta) {
+            try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0)
             barrier(enc)
-        case .fusedInterleaved:
-            try engine.encodeGemv(enc, delta.qkvz!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkvzStage)
-            try engine.encodeGemv(enc, delta.ba!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.baStage)
-            barrier(enc)
-            enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
-            struct DeintParams {
-                var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
-                var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
-                var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+            switch config.deltaLayout {
+            case .split:
+                try engine.encodeGemv(enc, delta.qkv!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkv)
+                try engine.encodeGemv(enc, delta.zProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.z)
+                try engine.encodeGemv(enc, delta.bProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.b)
+                try engine.encodeGemv(enc, delta.aProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.a)
+                barrier(enc)
+            case .fusedInterleaved:
+                try engine.encodeGemv(enc, delta.qkvz!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkvzStage)
+                try engine.encodeGemv(enc, delta.ba!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.baStage)
+                barrier(enc)
+                enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
+                struct DeintParams {
+                    var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
+                    var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
+                    var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+                }
+                var dip = DeintParams(
+                    nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
+                    keyDim: UInt32(keyDim), srcOff: UInt32(reg.qkvzStage), baOff: UInt32(reg.baStage),
+                    qkvOff: UInt32(reg.qkv), zOff: UInt32(reg.z), bOff: UInt32(reg.b), aOff: UInt32(reg.a)
+                )
+                enc.setBuffer(sBuf!, offset: 0, index: 0)
+                setBytesParams(enc, &dip, index: 1)
+                dispatchN(enc, nk)
+                barrier(enc)
             }
-            var dip = DeintParams(
-                nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
-                keyDim: UInt32(keyDim), srcOff: UInt32(reg.qkvzStage), baOff: UInt32(reg.baStage),
-                qkvOff: UInt32(reg.qkv), zOff: UInt32(reg.z), bOff: UInt32(reg.b), aOff: UInt32(reg.a)
-            )
+
+            enc.setComputePipelineState(try engine.pipeline("conv_step"))
+            var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim), UInt32(reg.qkv), UInt32(reg.conv))
             enc.setBuffer(sBuf!, offset: 0, index: 0)
-            setBytesParams(enc, &dip, index: 1)
-            dispatchN(enc, nk)
+            enc.setBuffer(fl.hist!, offset: 0, index: 1)
+            enc.setBuffer(fl.convW!, offset: 0, index: 2)
+            setBytesParams(enc, &cp, index: 3)
+            dispatchN(enc, convDim)
+
+            enc.setComputePipelineState(try engine.pipeline("delta_pre"))
+            var dp = SIMD4<UInt32>(UInt32(nv), UInt32(reg.a), UInt32(reg.b), UInt32(reg.gb))
+            enc.setBuffer(sBuf!, offset: 0, index: 0)
+            enc.setBuffer(fl.aLog!, offset: 0, index: 1)
+            enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
+            setBytesParams(enc, &dp, index: 3)
+            dispatchN(enc, nv)
+            barrier(enc)
+
+            let invScale = 1 / Float(dk).squareRoot()
+            try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil, scale: invScale * invScale, eps: 1e-6)
+            try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil, scale: invScale, eps: 1e-6)
+            barrier(enc)
+
+            enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
+            var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
+            enc.setBuffer(sBuf!, offset: reg.conv * 4, index: 0)                    // q
+            enc.setBuffer(sBuf!, offset: (reg.conv + keyDim) * 4, index: 1)         // k
+            enc.setBuffer(sBuf!, offset: (reg.conv + 2 * keyDim) * 4, index: 2)     // v
+            enc.setBuffer(sBuf!, offset: reg.gb * 4, index: 3)                      // g
+            enc.setBuffer(sBuf!, offset: (reg.gb + nv) * 4, index: 4)               // beta
+            enc.setBuffer(fl.state!, offset: 0, index: 5)
+            enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
+            enc.setBuffer(fl.state!, offset: 0, index: 7)
+            setBytesParams(enc, &delp, index: 8)
+            engine.dispatchThreads(
+                enc, threads: MTLSize(width: 32, height: dv, depth: nv),
+                threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
+            )
+            barrier(enc)
+
+            enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
+            struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
+            var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
+                         yOff: UInt32(reg.dy), zOff: UInt32(reg.z), outOff: UInt32(reg.dn))
+            enc.setBuffer(sBuf!, offset: 0, index: 0)
+            enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
+            setBytesParams(enc, &gp, index: 2)
+            dispatchRows(enc, rows: nv)
+            barrier(enc)
+
+            try engine.encodeGemv(enc, delta.outProj, x: sBuf!, xOff: reg.dn, y: sBuf!, yOff: reg.r)
+            barrier(enc)
+            var ap = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
+            enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+            enc.setBuffer(hBuf!, offset: 0, index: 0)
+            enc.setBuffer(sBuf!, offset: 0, index: 1)
+            setBytesParams(enc, &ap, index: 2)
+            dispatchN(enc, D)
             barrier(enc)
         }
-
-        enc.setComputePipelineState(try engine.pipeline("conv_step"))
-        var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim), UInt32(reg.qkv), UInt32(reg.conv))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.hist!, offset: 0, index: 1)
-        enc.setBuffer(fl.convW!, offset: 0, index: 2)
-        setBytesParams(enc, &cp, index: 3)
-        dispatchN(enc, convDim)
-
-        enc.setComputePipelineState(try engine.pipeline("delta_pre"))
-        var dp = SIMD4<UInt32>(UInt32(nv), UInt32(reg.a), UInt32(reg.b), UInt32(reg.gb))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.aLog!, offset: 0, index: 1)
-        enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
-        setBytesParams(enc, &dp, index: 3)
-        dispatchN(enc, nv)
-        barrier(enc)
-
-        let invScale = 1 / Float(dk).squareRoot()
-        try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil, scale: invScale * invScale, eps: 1e-6)
-        try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil, scale: invScale, eps: 1e-6)
-        barrier(enc)
-
-        enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
-        var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
-        enc.setBuffer(sBuf!, offset: reg.conv * 4, index: 0)                    // q
-        enc.setBuffer(sBuf!, offset: (reg.conv + keyDim) * 4, index: 1)         // k
-        enc.setBuffer(sBuf!, offset: (reg.conv + 2 * keyDim) * 4, index: 2)     // v
-        enc.setBuffer(sBuf!, offset: reg.gb * 4, index: 3)                      // g
-        enc.setBuffer(sBuf!, offset: (reg.gb + nv) * 4, index: 4)               // beta
-        enc.setBuffer(fl.state!, offset: 0, index: 5)
-        enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
-        enc.setBuffer(fl.state!, offset: 0, index: 7)
-        setBytesParams(enc, &delp, index: 8)
-        engine.dispatchThreads(
-            enc, threads: MTLSize(width: 32, height: dv, depth: nv),
-            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
-        )
-        barrier(enc)
-
-        enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
-        struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
-        var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
-                     yOff: UInt32(reg.dy), zOff: UInt32(reg.z), outOff: UInt32(reg.dn))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
-        setBytesParams(enc, &gp, index: 2)
-        dispatchRows(enc, rows: nv)
-        barrier(enc)
-
-        try engine.encodeGemv(enc, delta.outProj, x: sBuf!, xOff: reg.dn, y: sBuf!, yOff: reg.r)
-        barrier(enc)
-        var ap = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-        enc.setComputePipelineState(try engine.pipeline("add_inplace"))
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
-        setBytesParams(enc, &ap, index: 2)
-        dispatchN(enc, D)
-        barrier(enc)
-        try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe)
-        barrier(enc)
-        try engine.encodeGemv(enc, moeGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+        try phase(.router) {
+            try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe)
+            barrier(enc)
+            try engine.encodeGemv(enc, moeGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+        }
     }
 
     private func attnCoreCPU(layerIndex: Int, state: QwenCPUModel.DecodeState, attn: AttnGPU) -> [Float] {

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1674,9 +1674,10 @@ extension QwenMetalModel {
     /// slot's projection regions and advances the layer's shared conv
     /// history and recurrent state, so chunked callers must encode tokens in
     /// ascending order (the decode core encodes exactly one). Assembled
-    /// from the stage helpers below; the chunked prefill reuses them but
-    /// runs the gated scan once per chunk with T = chunk length (S1b
-    /// chunked recurrence).
+    /// from the stage helpers below; the chunked prefill keeps only the
+    /// conv steps per token, batches decay/beta prep, the q/k norms, and
+    /// the gated norm through their stride twins, and runs the gated scan
+    /// once per chunk with T = chunk length (S1b chunked recurrence).
     private func encDeltaRecurrence(
         _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
     ) throws {
@@ -2258,8 +2259,9 @@ extension QwenMetalModel {
     /// One DeltaNet layer over the whole chunk (S1b token batching): one
     /// batched input norm, then one batched dispatch per in_proj tensor
     /// covering all tokens, one batched deinterleave, then the chunked
-    /// recurrence (per-token conv/prep/norms in ascending order feeding one
-    /// T=n gated scan), then one batched output projection and one batched
+    /// recurrence (per-token conv steps in ascending order, batched
+    /// decay/beta prep and q/k norms, one T=n gated scan, one batched gated
+    /// norm), then one batched output projection and one batched
     /// residual add. One token degenerates to exactly the decode core's
     /// encode stream, keeping the per-token scan alive as the chunked
     /// path's oracle.
@@ -2292,27 +2294,45 @@ extension QwenMetalModel {
     }
 
     /// The chunk's recurrence stage with the T-step scan (S1b chunked
-    /// recurrence): conv steps and decay/beta prep stay per token in
-    /// ascending order (the conv history is shared state, so a barrier
-    /// separates consecutive tokens), the q/k norms run per token on each
-    /// slot's conv rows, one delta_gather packs the normed rows into the
-    /// contiguous [T, row] staging blocks, and a single T=n gated_delta_step
-    /// replaces the n per-token scans. The kernel's internal step loop
-    /// performs the same ascending-order arithmetic the per-token dispatches
-    /// did — state carried in f32 registers instead of a per-token f32
-    /// device round trip — so every y row and the final state are bitwise
-    /// identical. Ends on a barrier like the decode core.
+    /// recurrence): only the conv steps stay per token in ascending order
+    /// (the conv history is shared state, so a barrier separates consecutive
+    /// tokens); decay/beta prep and the weightless q/k norms are independent
+    /// per token and encode once per chunk through their stride twins; one
+    /// delta_gather packs the normed rows into the contiguous [T, row]
+    /// staging blocks, a single T=n gated_delta_step replaces the n
+    /// per-token scans, and one batched gated norm reads the scan's staged y
+    /// rows. Every batched row is the single-token kernel's arithmetic
+    /// verbatim and the scan's internal step loop performs the same
+    /// ascending-order arithmetic the per-token dispatches did — state
+    /// carried in f32 registers instead of a per-token f32 device round trip
+    /// — so every y row and the final state are bitwise identical. Ends on a
+    /// barrier like the decode core.
     private func encChunkDeltaRecurrence(
         _ enc: MTLComputeCommandEncoder, fl: FastLayer, tokens n: Int
     ) throws {
-        let valueDim = config.valueDim
+        let cfg = config
+        let valueDim = cfg.valueDim
         for t in 0..<n {
-            let slot = prefillSlot(t)
-            try encConvStep(enc, fl: fl, slot: slot)
-            try encDeltaPre(enc, fl: fl, slot: slot)
+            try encConvStep(enc, fl: fl, slot: prefillSlot(t))
             barrier(enc)   // token t+1's conv reads the advanced history
         }
-        for t in 0..<n { try encDeltaQKNorms(enc, slot: prefillSlot(t)) }
+        // Reads the slots' a/b projection rows (behind encChunkDelta's
+        // barrier) and writes gb, disjoint from the conv rows the norms
+        // touch in place — one barrier below covers both for the gather.
+        try engine.encodeDeltaPreBatch(
+            enc, data: prefillScratchBuf!, aLog: fl.aLog!, dtBias: fl.dtBias!,
+            nv: cfg.linearNumValueHeads, aOff: reg.a, bOff: reg.b, outOff: reg.gb,
+            slotStride: reg.total, tokens: n)
+        let nk = cfg.linearNumKeyHeads, dk = cfg.linearKeyHeadDim
+        let invScale = 1 / Float(dk).squareRoot()
+        try engine.encodeRMSNormRowsBatch(
+            enc, data: prefillScratchBuf!, weight: nil, off: reg.conv,
+            rows: nk, dim: dk, scale: invScale * invScale, eps: 1e-6,
+            slotStride: reg.total, tokens: n)
+        try engine.encodeRMSNormRowsBatch(
+            enc, data: prefillScratchBuf!, weight: nil, off: reg.conv + cfg.keyDim,
+            rows: nk, dim: dk, scale: invScale, eps: 1e-6,
+            slotStride: reg.total, tokens: n)
         barrier(enc)
         try engine.encodeDeltaGather(
             enc, data: prefillScratchBuf!,
@@ -2326,12 +2346,13 @@ extension QwenMetalModel {
             qOff: prefillStage.q, kOff: prefillStage.k, vOff: prefillStage.v,
             gOff: prefillStage.g, bOff: prefillStage.b, yOff: prefillStage.y)
         barrier(enc)
-        for t in 0..<n {
-            try encGatedNormMul(
-                enc, fl: fl, data: prefillScratchBuf!,
-                yOff: prefillStage.y + t * valueDim,
-                zOff: t * reg.total + reg.z, outOff: t * reg.total + reg.dn)
-        }
+        try engine.encodeGatedNormMulBatch(
+            enc, data: prefillScratchBuf!, weight: fl.deltaNormW!,
+            nv: cfg.linearNumValueHeads, dv: cfg.linearValueHeadDim,
+            eps: Float(cfg.rmsNormEps),
+            yOff: prefillStage.y, yStride: valueDim,
+            zOff: reg.z, zStride: reg.total,
+            outOff: reg.dn, outStride: reg.total, tokens: n)
         barrier(enc)
     }
 

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1925,8 +1925,9 @@ extension QwenMetalModel {
 // recurrent stages keep ascending token order (conv history per token, the
 // gated recurrence as one T=chunk in-dispatch scan), so numerics match the
 // token-major schedule exactly. S2 batches the attention core across the
-// chunk's tokens on GPU; the causal attend stays per token because each
-// token reads a different kvLen.
+// chunk's tokens on GPU, including the causal attend: its batch twin derives
+// each token's kvLen from the token grid, and every KV append lands behind a
+// barrier before any token attends.
 extension QwenMetalModel {
 
     /// One layer's deferred MoE for a whole chunk: per-token picks/weights in
@@ -2069,6 +2070,29 @@ extension QwenMetalModel {
             kSrcOff: reg.knew, vSrcOff: reg.vnew, slotStride: reg.total, tokens: n)
     }
 
+    /// Causal attends for every chunk token as one attn_decode_gqa_batch:
+    /// token t attends over cache rows [0, basePosition + t + 1), a kvLen
+    /// the kernel derives from the token grid. Callers must barrier between
+    /// the chunk's KV appends and this encode — the youngest token reads
+    /// every appended row.
+    private func encChunkAttentionAttend(
+        _ enc: MTLComputeCommandEncoder, layer li: Int, basePosition: Int, tokens n: Int
+    ) throws {
+        if n == 1 {
+            try encAttentionAttend(
+                enc, layer: li, kvLen: basePosition + 1, slot: prefillSlot(0))
+            return
+        }
+        let cfg = config
+        let fl = fastLayers[li] // fresh copy: ensureKVCapacity may have swapped buffers
+        try engine.encodeAttnDecodeBatch(
+            enc, data: prefillScratchBuf!, kCache: fl.kCache!, vCache: fl.vCache!,
+            heads: cfg.numAttentionHeads, kvHeads: cfg.numKeyValueHeads,
+            headDim: cfg.headDim, basePosition: basePosition,
+            qOff: reg.qprep, qoutOff: reg.qout, outOff: reg.att,
+            slotStride: reg.total, tokens: n)
+    }
+
     /// Splits the prompt into chunks of at most `chunkCapacity` tokens and
     /// prefills each chunk layer-major. Only the final chunk projects logits
     /// (the S1a single-LM-head property).
@@ -2165,13 +2189,12 @@ extension QwenMetalModel {
                     try encChunkAttentionPrep(
                         enc, layer: li, basePosition: basePosition, tokens: S)
                     barrier(enc)
-                    // The causal attend stays per token: token t reads cache
-                    // rows [0, basePosition + t + 1), a kvLen no batched grid
-                    // slice shares.
-                    for t in 0..<S {
-                        try encAttentionAttend(
-                            enc, layer: li, kvLen: basePosition + t + 1, slot: prefillSlot(t))
-                    }
+                    // One batched causal attend: token t reads cache rows
+                    // [0, basePosition + t + 1), a kvLen the kernel derives
+                    // from the token grid; the barrier above guarantees
+                    // every row the youngest token can see has landed.
+                    try encChunkAttentionAttend(
+                        enc, layer: li, basePosition: basePosition, tokens: S)
                     barrier(enc)
                     try engine.encodeGemvBatch(
                         enc, attn.oProj, x: prefillScratchBuf!, y: prefillScratchBuf!,

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -259,10 +259,38 @@ public final class QwenMetalModel {
     /// phase scopes per buffer (2 samples each); headroom is harmless.
     private static let maxPhaseSamplesPerBuffer = 16
     /// Test hook (S1b-a): observes the routed expert list for every
-    /// (token, layer) exactly as the existing token-by-token path selects it.
-    /// The prefill expert-union planning oracle derives its input from these
-    /// outcomes; the hook changes no schedule and stays internal.
+    /// (token, layer) exactly as the current schedule selects it — token
+    /// order in the token-major paths, layer-major order (per layer, tokens
+    /// ascending) in the S1b prefill. The routes themselves are identical
+    /// either way; only the visit order differs. Stays internal.
     var routedExpertObserver: ((_ layer: Int, _ experts: [Int]) -> Void)?
+    /// Test hook (S1b): the expert union the layer-major prefill actually
+    /// fetched and encoded for one (chunk, layer), ascending expert order —
+    /// what the PrefillExpertUnionPlan oracle predicts. Stays internal.
+    var prefillExpertUnionObserver: ((_ layer: Int, _ experts: [Int]) -> Void)?
+
+    /// Prompt-prefill schedule for multi-token step calls. Single-token
+    /// decode steps never consult this.
+    public enum PrefillMode: Equatable, Sendable {
+        /// Legacy S1a schedule: the decode schedule repeated per token, with
+        /// intermediate LM heads elided.
+        case tokenMajor
+        /// S1b schedule: split the prompt into chunks of at most chunkTokens;
+        /// inside a chunk, sweep layer-by-layer across all tokens and touch
+        /// each layer's expert union once per chunk. chunkTokens bounds
+        /// scratch memory: the chunk keeps chunkTokens x Regions.total
+        /// scratch floats and chunkTokens hidden rows resident.
+        case layerMajor(chunkTokens: Int)
+    }
+
+    /// Default: layer-major with 32-token chunks. One 11-buffer sequence per
+    /// chunk instead of per token, and expert fetches per (layer, union)
+    /// instead of per (token, layer, pick). 32 keeps scratch bounded to a few
+    /// tens of MB on 80B-class configs while letting short prompts run as a
+    /// single chunk; unions saturate toward the full expert set beyond a few
+    /// dozen tokens, so larger chunks add memory faster than they add
+    /// expert-traffic savings. `.tokenMajor` restores the S1a schedule.
+    public var prefillMode: PrefillMode = .layerMajor(chunkTokens: 32)
 
     // MARK: Fast path (split DeltaNet layout): one command buffer per layer.
     struct Regions {
@@ -291,6 +319,14 @@ public final class QwenMetalModel {
         var stacksLayer: Int
         var picks: [(Int, Float)]
     }
+
+    // S1b layer-major prefill scratch: one Regions stride and one hidden row
+    // per chunk token. Allocated lazily on the first layer-major prompt call
+    // and kept for the model's lifetime; failure to allocate falls back to
+    // the token-major schedule instead of crashing.
+    var prefillScratchBuf: MTLBuffer?
+    var prefillHiddenBuf: MTLBuffer?
+    var prefillSlotCapacity = 0
 
     public init(modelDir: URL, cacheBudgetGB: Double = 8) throws {
         config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
@@ -812,14 +848,28 @@ public final class QwenMetalModel {
         }
 
         var logits: [Float] = []
-        for (index, t) in tokens.enumerated() {
-            // S1a LM-head elision: a multi-token call consumes only the final
-            // position's logits, so intermediate vocabulary projections are
-            // unnecessary.
-            let projectLogits = index == tokens.count - 1
-            logits = try stepOne(t, state: state, projectLogits: projectLogits)
-            state.position += 1
-            counters.tokensProcessed += 1
+        // S1b: multi-token prompt calls take the layer-major chunked schedule
+        // when enabled and the fast path plus chunk scratch are available;
+        // everything else keeps the token-major loop (single-token decode
+        // steps always do).
+        var chunkCapacity = 0
+        if tokens.count > 1, sBuf != nil, hBuf != nil,
+           case .layerMajor(let chunkTokens) = prefillMode {
+            let wanted = min(max(1, chunkTokens), tokens.count)
+            if ensurePrefillCapacity(wanted) { chunkCapacity = wanted }
+        }
+        if chunkCapacity > 0 {
+            logits = try prefillLayerMajor(tokens, state: state, chunkCapacity: chunkCapacity)
+        } else {
+            for (index, t) in tokens.enumerated() {
+                // S1a LM-head elision: a multi-token call consumes only the
+                // final position's logits, so intermediate vocabulary
+                // projections are unnecessary.
+                let projectLogits = index == tokens.count - 1
+                logits = try stepOne(t, state: state, projectLogits: projectLogits)
+                state.position += 1
+                counters.tokensProcessed += 1
+            }
         }
         counters.completedWithoutThrow = true
         return logits
@@ -1733,5 +1783,311 @@ extension QwenMetalModel {
                 x[base + half + j] = b * c + a * sn
             }
         }
+    }
+}
+
+// MARK: - S1b layer-major chunked prefill: inside a chunk, sweep each layer
+// across every token before moving on, so a layer's expert union is fetched
+// once per chunk and one 11-buffer sequence covers the whole chunk instead of
+// every token. Per-token math is encoded through the same slot helpers as the
+// decode path, so numerics match the token-major schedule exactly.
+extension QwenMetalModel {
+
+    /// One layer's deferred MoE for a whole chunk: per-token picks/weights in
+    /// the legacy order, plus the layer's ascending expert union with each
+    /// expert's resident buffer fetched exactly once (qpack mode; raw
+    /// checkpoints address stacked tensors by stride and keep this empty).
+    struct PendingChunkMoE {
+        var layer: Int
+        var union: [Int]
+        var buffers: [Int: MTLBuffer]
+        var perToken: [(picks: [(Int, Float)], weights: [Float])]
+    }
+
+    /// Grows the chunk scratch to hold `n` token slots. Returns false when
+    /// the device cannot allocate them (callers fall back to token-major).
+    private func ensurePrefillCapacity(_ n: Int) -> Bool {
+        if prefillSlotCapacity >= n, prefillScratchBuf != nil, prefillHiddenBuf != nil {
+            return true
+        }
+        let opts: MTLResourceOptions = [.storageModeShared, .hazardTrackingModeUntracked]
+        guard let scratch = engine.device.makeBuffer(length: n * reg.total * 4, options: opts),
+              let hidden = engine.device.makeBuffer(length: n * config.hiddenSize * 4, options: opts)
+        else { return false }
+        prefillScratchBuf = scratch
+        prefillHiddenBuf = hidden
+        prefillSlotCapacity = n
+        return true
+    }
+
+    private func prefillSlot(_ t: Int) -> TokenSlot {
+        TokenSlot(scratch: prefillScratchBuf!, base: t * reg.total,
+                  hidden: prefillHiddenBuf!, hiddenByteOffset: t * config.hiddenSize * 4)
+    }
+
+    /// Splits the prompt into chunks of at most `chunkCapacity` tokens and
+    /// prefills each chunk layer-major. Only the final chunk projects logits
+    /// (the S1a single-LM-head property).
+    func prefillLayerMajor(
+        _ tokens: [Int], state: QwenCPUModel.DecodeState, chunkCapacity: Int
+    ) throws -> [Float] {
+        var logits: [Float] = []
+        var start = 0
+        while start < tokens.count {
+            let end = min(start + chunkCapacity, tokens.count)
+            logits = try prefillChunkLayerMajor(
+                Array(tokens[start..<end]), state: state,
+                projectLogits: end == tokens.count
+            )
+            start = end
+        }
+        return logits
+    }
+
+    /// One chunk, layer-major. The buffer sequence per chunk is exactly the
+    /// legacy per-token shape (one buffer per DeltaNet layer, two per
+    /// attention layer, one tail), each buffer now carrying every chunk
+    /// token's work for that layer in per-token slots. Within a layer,
+    /// tokens are encoded in ascending order so the conv history, recurrence
+    /// state, and KV appends advance exactly as the token-major path does.
+    private func prefillChunkLayerMajor(
+        _ chunk: [Int], state: QwenCPUModel.DecodeState, projectLogits: Bool
+    ) throws -> [Float] {
+        let cfg = config
+        let D = cfg.hiddenSize
+        let S = chunk.count
+        if boundStateID != ObjectIdentifier(state) || state.position == 0 {
+            boundStateID = ObjectIdentifier(state)
+            if state.position == 0 { resetGPUState() }
+        }
+        let basePosition = state.position
+
+        for (t, token) in chunk.enumerated() {
+            let h0 = try ckpt.moduleWeightSlice("model.embed_tokens", rowRange: token..<(token + 1))
+            h0.withUnsafeBufferPointer {
+                prefillHiddenBuf!.contents().advanced(by: t * D * 4)
+                    .copyMemory(from: $0.baseAddress!, byteCount: D * 4)
+            }
+        }
+
+        var pending: PendingChunkMoE?
+
+        for li in 0..<cfg.numHiddenLayers {
+            let L = layers[li]
+            let fl = fastLayers[li]
+
+            if let delta = L.delta {
+                let (cb, enc) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodeChunkMoE(enc, p) }
+                    pending = nil
+                }
+                try phase(.delta) {
+                    // Ascending token order: the conv history and recurrence
+                    // state are shared per layer, and the barriers inside
+                    // each token's sequence order token t+1 after token t.
+                    for t in 0..<S {
+                        try encDeltaCore(enc, delta: delta, fl: fl, slot: prefillSlot(t))
+                    }
+                }
+                try phase(.router) {
+                    for t in 0..<S {
+                        try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
+                    }
+                }
+                enc.endEncoding()
+                commitAndWait(cb)
+            } else {
+                let attn = L.attn!
+                let (cb1, e1) = beginStepCommandBuffer()
+                if let p = pending {
+                    try phase(.moe) { try encodeChunkMoE(e1, p) }
+                    pending = nil
+                }
+                try phase(.attention) {
+                    for t in 0..<S {
+                        try encAttentionProjections(e1, attn: attn, fl: fl, slot: prefillSlot(t))
+                    }
+                }
+                e1.endEncoding()
+                commitAndWait(cb1)
+
+                // CPU attention core in ascending token order: token t
+                // attends to the chunk's earlier tokens through the KV rows
+                // they appended just before it.
+                for t in 0..<S {
+                    let slot = prefillSlot(t)
+                    let attnOut = attnCoreCPU(
+                        layerIndex: li, state: state, attn: attn,
+                        position: basePosition + t, slot: slot
+                    )
+                    writeSlot(slot, reg.att, attnOut)
+                }
+
+                let (cb2, e2) = beginStepCommandBuffer()
+                try phase(.attention) {
+                    for t in 0..<S {
+                        try encAttentionFinish(e2, attn: attn, slot: prefillSlot(t))
+                    }
+                }
+                try phase(.router) {
+                    for t in 0..<S {
+                        try encRouterProbe(e2, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
+                    }
+                }
+                e2.endEncoding()
+                commitAndWait(cb2)
+            }
+
+            // Routing on CPU for every chunk token, then one union fetch for
+            // the whole chunk: the schedule consumes exactly what the S1b-a
+            // plan predicts from these routes.
+            var perToken: [(picks: [(Int, Float)], weights: [Float])] = []
+            var unionSet = Set<Int>()
+            for t in 0..<S {
+                let (picks, weights) = routerPicks(slot: prefillSlot(t))
+                routedExpertObserver?(li, picks.map { $0.0 })
+                unionSet.formUnion(picks.map { $0.0 })
+                perToken.append((picks, weights))
+            }
+            let union = unionSet.sorted()
+            prefillExpertUnionObserver?(li, union)
+            var buffers: [Int: MTLBuffer] = [:]
+            if let cache = expertCache {
+                let bufs = try cache.buffers(layer: li, experts: union)
+                for (i, e) in union.enumerated() { buffers[e] = bufs[i] }
+            }
+            pending = PendingChunkMoE(
+                layer: li, union: union, buffers: buffers, perToken: perToken)
+        }
+
+        // Tail: flush the last layer's experts for the whole chunk; only the
+        // prompt's final token also needs final norm + vocabulary projection.
+        let (cb, enc) = beginStepCommandBuffer()
+        if let p = pending { try phase(.moe) { try encodeChunkMoE(enc, p) } }
+        if projectLogits {
+            try phase(.lmHead) {
+                try encFinalLMHead(enc, slot: prefillSlot(S - 1))
+            }
+            activeStepCounters?.logitProjections += 1
+        }
+        enc.endEncoding()
+        commitAndWait(cb)
+
+        state.position += S
+        activeStepCounters?.tokensProcessed += S
+
+        guard projectLogits else { return [] }
+        return Array(UnsafeBufferPointer(
+            start: logitsBuf.contents().bindMemory(to: Float.self, capacity: cfg.vocabSize),
+            count: cfg.vocabSize))
+    }
+
+    /// One layer's MoE for a whole chunk. Every expert in the union is
+    /// touched once per stage, encoding the GEMVs of all tokens routed to it
+    /// back-to-back; outputs land in disjoint per-token slots so a stage runs
+    /// fully in parallel, and each token's weighted accumulation uses the
+    /// legacy pick order, keeping numerics identical to the token-major path.
+    private func encodeChunkMoE(_ enc: MTLComputeCommandEncoder, _ pend: PendingChunkMoE) throws {
+        let cfg = config
+        let D = cfg.hiddenSize, inter = cfg.moeIntermediateSize
+        let shInter = cfg.sharedExpertIntermediateSize
+        let moe = layers[pend.layer].moe
+        let fl = fastLayers[pend.layer]
+        let projs = expertProjs
+
+        // expert -> [(token, pick index)] in ascending token order.
+        var assignments: [Int: [(t: Int, ki: Int)]] = [:]
+        for (t, entry) in pend.perToken.enumerated() {
+            for (ki, pick) in entry.picks.enumerated() {
+                assignments[pick.0, default: []].append((t, ki))
+            }
+        }
+
+        func linears(for expert: Int) -> (g: GPULinear, u: GPULinear, d: GPULinear, e: Int) {
+            if let projs, let buf = pend.buffers[expert] {
+                return (projs.gate.linear(on: buf), projs.up.linear(on: buf),
+                        projs.down.linear(on: buf), 0)
+            }
+            let st = moe.stacks!
+            return (st.gate.lin, st.up.lin, st.down.lin, expert)
+        }
+
+        // Stage 1: routed gate/up grouped by expert, plus each token's shared
+        // gate/up and shared-gate logit.
+        for expert in pend.union {
+            let lin = linears(for: expert)
+            for a in assignments[expert] ?? [] {
+                let slot = prefillSlot(a.t)
+                let K = pend.perToken[a.t].picks.count
+                try engine.encodeGemv(enc, lin.g, rows: inter,
+                    wExtra: lin.e * (moe.stacks?.gate.wStride ?? 0),
+                    sExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
+                    bExtra: lin.e * (moe.stacks?.gate.sStride ?? 0),
+                    x: slot.scratch, xOff: slot.base + reg.xmoe,
+                    y: slot.scratch, yOff: slot.base + reg.exp + a.ki * inter)
+                try engine.encodeGemv(enc, lin.u, rows: inter,
+                    wExtra: lin.e * (moe.stacks?.up.wStride ?? 0),
+                    sExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
+                    bExtra: lin.e * (moe.stacks?.up.sStride ?? 0),
+                    x: slot.scratch, xOff: slot.base + reg.xmoe,
+                    y: slot.scratch, yOff: slot.base + reg.exp + K * inter + a.ki * inter)
+            }
+        }
+        for t in 0..<pend.perToken.count {
+            let slot = prefillSlot(t)
+            try engine.encodeGemv(enc, moe.sharedGate, x: slot.scratch, xOff: slot.base + reg.xmoe,
+                y: slot.scratch, yOff: slot.base + reg.sh)
+            try engine.encodeGemv(enc, moe.sharedUp, x: slot.scratch, xOff: slot.base + reg.xmoe,
+                y: slot.scratch, yOff: slot.base + reg.sh + shInter)
+            try engine.encodeGemv(enc, fl.sharedGateLin, x: slot.scratch, xOff: slot.base + reg.xmoe,
+                y: slot.scratch, yOff: slot.base + reg.shg)
+        }
+        barrier(enc)
+
+        // Stage 2: silu(gate) * up for every (token, pick) and shared chain.
+        for (t, entry) in pend.perToken.enumerated() {
+            let slot = prefillSlot(t)
+            let K = entry.picks.count
+            for ki in 0..<K {
+                try engine.encodeSiluMul(enc, buf: slot.scratch, count: inter,
+                    gOff: slot.base + reg.exp + ki * inter,
+                    uOff: slot.base + reg.exp + K * inter + ki * inter,
+                    dstOff: slot.base + reg.exp + 2 * K * inter + ki * inter)
+            }
+            try engine.encodeSiluMul(enc, buf: slot.scratch, count: shInter,
+                gOff: slot.base + reg.sh, uOff: slot.base + reg.sh + shInter,
+                dstOff: slot.base + reg.sh + 2 * shInter)
+        }
+        barrier(enc)
+
+        // Stage 3: down projections grouped by expert, plus shared down.
+        for expert in pend.union {
+            let lin = linears(for: expert)
+            for a in assignments[expert] ?? [] {
+                let slot = prefillSlot(a.t)
+                let K = pend.perToken[a.t].picks.count
+                try engine.encodeGemv(enc, lin.d, rows: D,
+                    wExtra: lin.e * (moe.stacks?.down.wStride ?? 0),
+                    sExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
+                    bExtra: lin.e * (moe.stacks?.down.sStride ?? 0),
+                    x: slot.scratch, xOff: slot.base + reg.exp + 2 * K * inter + a.ki * inter,
+                    y: slot.scratch, yOff: slot.base + reg.dexp + a.ki * D)
+            }
+        }
+        for t in 0..<pend.perToken.count {
+            let slot = prefillSlot(t)
+            try engine.encodeGemv(enc, moe.sharedDown,
+                x: slot.scratch, xOff: slot.base + reg.sh + 2 * shInter,
+                y: slot.scratch, yOff: slot.base + reg.sh + 3 * shInter)
+        }
+        barrier(enc)
+
+        // Stage 4: weighted accumulation per token, legacy pick order.
+        for (t, entry) in pend.perToken.enumerated() {
+            try encWeightedAccum(enc, weights: entry.weights, count: entry.picks.count,
+                                 slot: prefillSlot(t))
+        }
+        barrier(enc)
     }
 }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -4,14 +4,19 @@ import os.signpost
 
 /// GPU runtime: every linear (dense projections, router, experts, lm_head)
 /// runs as a quantized GEMV directly on mmapped checkpoint bytes — weights are
-/// never decompressed. The CPU keeps only glue math (norms, RoPE, conv step,
-/// delta recurrence, attention softmax over cached KV, top-k routing), all of
-/// it microseconds per token. Numerics mirror QwenCPUModel exactly.
+/// never decompressed. On the fast path the full-attention layers run their
+/// core on GPU too (S2): q/k prep + RoPE, KV append into a GPU-resident
+/// cache, and gated causal softmax attention. The CPU keeps only glue —
+/// top-k routing over GPU-computed router logits, expert-cache fetches,
+/// embedding row copies, and the state.kv mirror append — while the
+/// no-fast-path fallback still computes attention (norms, RoPE, softmax) on
+/// CPU. Numerics mirror QwenCPUModel exactly.
 public final class QwenMetalModel {
     /// S3b command-buffer phase labels. A label names the work a phase scope
     /// encoded; it claims nothing about when the GPU actually ran that work.
     public enum StepPhase: String, CaseIterable, Sendable {
-        /// Attention norm + q/k/v projections, output projection, residual add.
+        /// Attention norm + q/k/v projections, q/k prep + RoPE, KV append,
+        /// causal softmax attention, output projection, residual add.
         case attention
         /// DeltaNet mixer: projections, conv step, recurrence, gated norm,
         /// output projection, residual add.
@@ -283,8 +288,8 @@ public final class QwenMetalModel {
         case layerMajor(chunkTokens: Int)
     }
 
-    /// Default: layer-major with 32-token chunks. One 11-buffer sequence per
-    /// chunk instead of per token, and expert fetches per (layer, union)
+    /// Default: layer-major with 32-token chunks. One decode-shaped buffer
+    /// sequence per chunk instead of per token, and expert fetches per (layer, union)
     /// instead of per (token, layer, pick). 32 keeps scratch bounded to a few
     /// tens of MB on 80B-class configs while letting short prompts run as a
     /// single chunk; unions saturate toward the full expert set beyond a few
@@ -296,7 +301,7 @@ public final class QwenMetalModel {
     struct Regions {
         var x0 = 0, qkv = 0, z = 0, b = 0, a = 0, conv = 0, gb = 0
         var dy = 0, dn = 0, r = 0, xmoe = 0, rout = 0
-        var qout = 0, knew = 0, vnew = 0, att = 0
+        var qout = 0, knew = 0, vnew = 0, att = 0, qprep = 0
         var qkvzStage = 0, baStage = 0
         var exp = 0, dexp = 0, sh = 0, shg = 0
         var total = 0
@@ -306,6 +311,14 @@ public final class QwenMetalModel {
         var convW, aLog, dtBias, deltaNormW: MTLBuffer?
         var hist, state: MTLBuffer?
         var sharedGateLin: GPULinear
+        // S2, attention layers only: q/k norm weights and the GPU-resident
+        // KV cache ([position][kvHead][headDim] rows, grown on demand). Rows
+        // are indexed by absolute position, so a fresh state simply
+        // overwrites from row 0; rows past the current position are never
+        // read.
+        var qNormW, kNormW: MTLBuffer?
+        var kCache, vCache: MTLBuffer?
+        var kvCapacity = 0
     }
     var fastLayers: [FastLayer] = []
     var finalNormBuf: MTLBuffer?
@@ -512,6 +525,7 @@ public final class QwenMetalModel {
         o.knew = take(KVH * hd)
         o.vnew = take(KVH * hd)
         o.att = take(H * hd)
+        o.qprep = take(H * hd)
         o.qkvzStage = take(2 * cfg.keyDim + 2 * cfg.valueDim)
         o.baStage = take(2 * nv)
         o.exp = take(3 * K * inter)
@@ -542,6 +556,11 @@ public final class QwenMetalModel {
                 fl.hist = engine.device.makeBuffer(length: (cfg.linearConvKernelDim - 1) * cfg.convDim * 4, options: opts)
                 fl.state = engine.device.makeBuffer(
                     length: nv * cfg.linearValueHeadDim * cfg.linearKeyHeadDim * 4, options: opts)
+            }
+            if let a = L.attn {
+                fl.qNormW = engine.makeBuffer(a.qNorm)
+                fl.kNormW = engine.makeBuffer(a.kNorm)
+                // kCache/vCache grow on demand in ensureKVCapacity.
             }
             fastLayers.append(fl)
         }
@@ -1234,9 +1253,10 @@ public final class QwenMetalModel {
 }
 
 
-// MARK: - Fast path: one command buffer per DeltaNet layer, two per attention
-// layer, explicit barriers on an untracked scratch buffer so independent
-// dispatches (e.g. all expert GEMVs) actually run in parallel.
+// MARK: - Fast path: one command buffer per layer in decode (S2 folded the
+// attention layers' former two-buffer CPU round trip into one), explicit
+// barriers on an untracked scratch buffer so independent dispatches (e.g.
+// all expert GEMVs) actually run in parallel.
 extension QwenMetalModel {
 
     /// Where one token's fast-path scratch and hidden row live. The decode
@@ -1541,34 +1561,32 @@ extension QwenMetalModel {
                 enc.endEncoding()
                 commitAndWait(cb)
             } else {
-                // Attention: projections, CPU core, then out-proj + router.
-                let (cb1, e1) = beginStepCommandBuffer()
+                // S2: the whole attention layer in one command buffer — no
+                // CPU round trip. Projections, q prep + KV append into the
+                // GPU-resident cache, causal attention over it, out-proj +
+                // residual, then the router probe.
+                let attn = L.attn!
+                try ensureKVCapacity(li, rows: state.position + 1)
+                let (cb, enc) = beginStepCommandBuffer()
                 if let p = pending {
-                    try phase(.moe) { try encodePendingMoE(e1, p, slot: slot) }
+                    try phase(.moe) { try encodePendingMoE(enc, p, slot: slot) }
                     pending = nil
                 }
-                let attn = L.attn!
                 try phase(.attention) {
-                    try encAttentionProjections(e1, attn: attn, fl: fl, slot: slot)
-                }
-                e1.endEncoding()
-                commitAndWait(cb1)
-
-                let attnOut = attnCoreCPU(
-                    layerIndex: li, state: state, attn: attn,
-                    position: state.position, slot: slot
-                )
-                writeSlot(slot, reg.att, attnOut)
-
-                let (cb2, e2) = beginStepCommandBuffer()
-                try phase(.attention) {
-                    try encAttentionFinish(e2, attn: attn, slot: slot)
+                    try encAttentionProjections(enc, attn: attn, fl: fl, slot: slot)
+                    barrier(enc)
+                    try encAttentionPrep(enc, layer: li, position: state.position, slot: slot)
+                    barrier(enc)
+                    try encAttentionAttend(enc, layer: li, kvLen: state.position + 1, slot: slot)
+                    barrier(enc)
+                    try encAttentionFinish(enc, attn: attn, slot: slot)
                 }
                 try phase(.router) {
-                    try encRouterProbe(e2, moeGate: L.moe.gate, fl: fl, slot: slot)
+                    try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: slot)
                 }
-                e2.endEncoding()
-                commitAndWait(cb2)
+                enc.endEncoding()
+                commitAndWait(cb)
+                appendKVMirror(state, layer: li, position: state.position, count: 1)
             }
 
             let (picks, weights) = routerPicks(slot: slot)
@@ -1714,83 +1732,124 @@ extension QwenMetalModel {
         barrier(enc)
     }
 
-    private func attnCoreCPU(
-        layerIndex: Int, state: QwenCPUModel.DecodeState, attn: AttnGPU,
-        position: Int, slot: TokenSlot
-    ) -> [Float] {
+    // MARK: - S2 GPU-resident KV cache
+
+    /// GPU KV cache bookkeeping failed; the fast path has no CPU fallback
+    /// for attention, so the step surfaces the allocation failure.
+    public enum RuntimeError: Swift.Error {
+        case kvCacheAllocationFailed(layer: Int, rows: Int)
+    }
+
+    private var kvRowFloats: Int { config.numKeyValueHeads * config.headDim }
+
+    /// Grows layer `li`'s GPU KV cache to hold at least `rows` positions
+    /// (doubling; written rows copied across). Only called between command
+    /// buffers, when every prior buffer has been waited on.
+    func ensureKVCapacity(_ li: Int, rows: Int) throws {
+        let current = fastLayers[li].kvCapacity
+        if current >= rows, fastLayers[li].kCache != nil { return }
+        let newCapacity = max(rows, max(256, 2 * current))
+        let bytes = newCapacity * kvRowFloats * 4
+        let opts: MTLResourceOptions = [.storageModeShared, .hazardTrackingModeUntracked]
+        guard let k = engine.device.makeBuffer(length: bytes, options: opts),
+              let v = engine.device.makeBuffer(length: bytes, options: opts)
+        else { throw RuntimeError.kvCacheAllocationFailed(layer: li, rows: rows) }
+        if let oldK = fastLayers[li].kCache, let oldV = fastLayers[li].vCache, current > 0 {
+            memcpy(k.contents(), oldK.contents(), current * kvRowFloats * 4)
+            memcpy(v.contents(), oldV.contents(), current * kvRowFloats * 4)
+        }
+        fastLayers[li].kCache = k
+        fastLayers[li].vCache = v
+        fastLayers[li].kvCapacity = newCapacity
+    }
+
+    /// Appends rows [position, position + count) of layer `li`'s GPU KV
+    /// cache to the CPU-side mirror in state.kv. The GPU rows are the
+    /// source of truth for the attention math; the mirror keeps state.kv the
+    /// observable KV state (parity assertions and future persistence read
+    /// it) at the cost of one memcpy out of shared memory per layer.
+    func appendKVMirror(
+        _ state: QwenCPUModel.DecodeState, layer li: Int, position: Int, count: Int
+    ) {
+        guard let k = fastLayers[li].kCache, let v = fastLayers[li].vCache else { return }
+        let n = count * kvRowFloats
+        let byteOff = position * kvRowFloats * 4
+        var cache = state.kv[li] ?? (k: [], v: [])
+        cache.k.append(contentsOf: UnsafeBufferPointer(
+            start: k.contents().advanced(by: byteOff).bindMemory(to: Float.self, capacity: n),
+            count: n))
+        cache.v.append(contentsOf: UnsafeBufferPointer(
+            start: v.contents().advanced(by: byteOff).bindMemory(to: Float.self, capacity: n),
+            count: n))
+        state.kv[li] = cache
+    }
+
+    /// Test/introspection hook: layer `li`'s GPU-resident KV rows for
+    /// positions [0, count), or nil when the layer keeps no cache (DeltaNet
+    /// layers, or attention before its first step). Stays internal.
+    func attentionKVCacheRows(layer li: Int, count: Int) -> (k: [Float], v: [Float])? {
+        guard let k = fastLayers[li].kCache, let v = fastLayers[li].vCache,
+              fastLayers[li].kvCapacity >= count else { return nil }
+        let n = count * kvRowFloats
+        return (
+            k: Array(UnsafeBufferPointer(
+                start: k.contents().bindMemory(to: Float.self, capacity: n), count: n)),
+            v: Array(UnsafeBufferPointer(
+                start: v.contents().bindMemory(to: Float.self, capacity: n), count: n))
+        )
+    }
+
+    /// Attention core, stage 1 of 2 on GPU: query prep (extract + RMSNorm +
+    /// RoPE into reg.qprep) and the KV append for `position` (K normed +
+    /// roped, V verbatim). Callers barrier between the q/k/v projections and
+    /// this, and between this and the attend stage — batched prefill must
+    /// append every token's rows before any token attends.
+    func encAttentionPrep(
+        _ enc: MTLComputeCommandEncoder, layer li: Int, position: Int, slot: TokenSlot
+    ) throws {
         let cfg = config
-        let H = cfg.numAttentionHeads, KVH = cfg.numKeyValueHeads, hd = cfg.headDim
-        let eps = Float(cfg.rmsNormEps)
-        let past = position
-        let qOut = readSlot(slot, reg.qout, H * hd * 2)
-        var k = readSlot(slot, reg.knew, KVH * hd)
-        let v = readSlot(slot, reg.vnew, KVH * hd)
-
-        var q = [Float](repeating: 0, count: H * hd)
-        var gate = [Float](repeating: 0, count: H * hd)
-        for head in 0..<H {
-            for i in 0..<hd {
-                q[head * hd + i] = qOut[head * 2 * hd + i]
-                gate[head * hd + i] = qOut[head * 2 * hd + hd + i]
-            }
-        }
-        QwenCPUModel.rmsNorm(&q, rows: H, dim: hd, weight: attn.qNorm, eps: eps)
-        QwenCPUModel.rmsNorm(&k, rows: KVH, dim: hd, weight: attn.kNorm, eps: eps)
-        applyRopeFast(&q, heads: H, position: past)
-        applyRopeFast(&k, heads: KVH, position: past)
-
-        var cache = state.kv[layerIndex] ?? (k: [], v: [])
-        cache.k.append(contentsOf: k)
-        cache.v.append(contentsOf: v)
-        state.kv[layerIndex] = cache
-        let kAll = cache.k, vAll = cache.v
-        let kvLen = past + 1
-        let scale = 1 / Float(hd).squareRoot()
-        var attnOut = [Float](repeating: 0, count: H * hd)
-        let group = H / KVH
-        var scores = [Float](repeating: 0, count: kvLen)
-        for head in 0..<H {
-            let kvHead = head / group
-            for sj in 0..<kvLen {
-                var dot: Float = 0
-                for i in 0..<hd { dot += q[head * hd + i] * kAll[(sj * KVH + kvHead) * hd + i] }
-                scores[sj] = dot * scale
-            }
-            QwenCPUModel.softmaxRow(&scores, base: 0, count: kvLen)
-            for sj in 0..<kvLen {
-                let p = scores[sj]
-                let vBase = (sj * KVH + kvHead) * hd
-                for i in 0..<hd { attnOut[head * hd + i] += p * vAll[vBase + i] }
-            }
-        }
-        for i in 0..<attnOut.count { attnOut[i] *= QwenCPUModel.sigmoid(gate[i]) }
-        return attnOut
+        let fl = fastLayers[li] // fresh copy: ensureKVCapacity may have swapped buffers
+        try engine.encodeAttnQPrep(
+            enc, data: slot.scratch, weight: fl.qNormW!,
+            heads: cfg.numAttentionHeads, headDim: cfg.headDim,
+            rotaryDims: cfg.rotaryDims, eps: Float(cfg.rmsNormEps),
+            ropeTheta: Float(cfg.ropeTheta), position: position,
+            srcOff: slot.base + reg.qout, dstOff: slot.base + reg.qprep
+        )
+        try engine.encodeAttnKVAppend(
+            enc, data: slot.scratch, weight: fl.kNormW!,
+            kCache: fl.kCache!, vCache: fl.vCache!,
+            kvHeads: cfg.numKeyValueHeads, headDim: cfg.headDim,
+            rotaryDims: cfg.rotaryDims, eps: Float(cfg.rmsNormEps),
+            ropeTheta: Float(cfg.ropeTheta), position: position,
+            kSrcOff: slot.base + reg.knew, vSrcOff: slot.base + reg.vnew
+        )
     }
 
-    private func applyRopeFast(_ x: inout [Float], heads: Int, position: Int) {
-        let hd = config.headDim
-        let rot = config.rotaryDims
-        let half = rot / 2
-        for head in 0..<heads {
-            let base = head * hd
-            for j in 0..<half {
-                let invFreq = powf(Float(config.ropeTheta), -Float(2 * j) / Float(rot))
-                let angle = Float(position) * invFreq
-                let c = cosf(angle), sn = sinf(angle)
-                let a = x[base + j]
-                let b = x[base + half + j]
-                x[base + j] = a * c - b * sn
-                x[base + half + j] = b * c + a * sn
-            }
-        }
+    /// Attention core, stage 2 of 2: gated causal softmax attention over
+    /// cache rows [0, kvLen) into the slot's att region.
+    func encAttentionAttend(
+        _ enc: MTLComputeCommandEncoder, layer li: Int, kvLen: Int, slot: TokenSlot
+    ) throws {
+        let cfg = config
+        let fl = fastLayers[li] // fresh copy: ensureKVCapacity may have swapped buffers
+        try engine.encodeAttnDecode(
+            enc, data: slot.scratch, kCache: fl.kCache!, vCache: fl.vCache!,
+            heads: cfg.numAttentionHeads, kvHeads: cfg.numKeyValueHeads,
+            headDim: cfg.headDim, kvLen: kvLen,
+            qOff: slot.base + reg.qprep, qoutOff: slot.base + reg.qout,
+            outOff: slot.base + reg.att
+        )
     }
+
 }
 
 // MARK: - S1b layer-major chunked prefill: inside a chunk, sweep each layer
 // across every token before moving on, so a layer's expert union is fetched
-// once per chunk and one 11-buffer sequence covers the whole chunk instead of
-// every token. Per-token math is encoded through the same slot helpers as the
-// decode path, so numerics match the token-major schedule exactly.
+// once per chunk and one decode-shaped buffer sequence covers the whole chunk
+// instead of every token. Per-token math is encoded through the same slot
+// helpers as the decode path, so numerics match the token-major schedule
+// exactly; S2 batches the attention core across the chunk's tokens on GPU.
 extension QwenMetalModel {
 
     /// One layer's deferred MoE for a whole chunk: per-token picks/weights in
@@ -1845,11 +1904,11 @@ extension QwenMetalModel {
     }
 
     /// One chunk, layer-major. The buffer sequence per chunk is exactly the
-    /// legacy per-token shape (one buffer per DeltaNet layer, two per
-    /// attention layer, one tail), each buffer now carrying every chunk
-    /// token's work for that layer in per-token slots. Within a layer,
-    /// tokens are encoded in ascending order so the conv history, recurrence
-    /// state, and KV appends advance exactly as the token-major path does.
+    /// decode per-token shape (one buffer per layer, one tail), each buffer
+    /// now carrying every chunk token's work for that layer in per-token
+    /// slots. Within a layer, tokens are encoded in ascending order so the
+    /// conv history, recurrence state, and KV appends advance exactly as the
+    /// token-major path does.
     private func prefillChunkLayerMajor(
         _ chunk: [Int], state: QwenCPUModel.DecodeState, projectLogits: Bool
     ) throws -> [Float] {
@@ -1898,45 +1957,48 @@ extension QwenMetalModel {
                 enc.endEncoding()
                 commitAndWait(cb)
             } else {
+                // S2 batched attention: one command buffer carries the whole
+                // chunk. Every token's q/k/v projections, then every token's
+                // KV append (rows land at disjoint absolute positions), one
+                // barrier, and only then the per-token causal attention —
+                // token t reads rows [0, basePosition + t + 1), which the
+                // append stage has fully written. Ascending-token state
+                // semantics hold because position order, not encode order,
+                // indexes the cache.
                 let attn = L.attn!
-                let (cb1, e1) = beginStepCommandBuffer()
+                try ensureKVCapacity(li, rows: basePosition + S)
+                let (cb, enc) = beginStepCommandBuffer()
                 if let p = pending {
-                    try phase(.moe) { try encodeChunkMoE(e1, p) }
+                    try phase(.moe) { try encodeChunkMoE(enc, p) }
                     pending = nil
                 }
                 try phase(.attention) {
                     for t in 0..<S {
-                        try encAttentionProjections(e1, attn: attn, fl: fl, slot: prefillSlot(t))
+                        try encAttentionProjections(enc, attn: attn, fl: fl, slot: prefillSlot(t))
                     }
-                }
-                e1.endEncoding()
-                commitAndWait(cb1)
-
-                // CPU attention core in ascending token order: token t
-                // attends to the chunk's earlier tokens through the KV rows
-                // they appended just before it.
-                for t in 0..<S {
-                    let slot = prefillSlot(t)
-                    let attnOut = attnCoreCPU(
-                        layerIndex: li, state: state, attn: attn,
-                        position: basePosition + t, slot: slot
-                    )
-                    writeSlot(slot, reg.att, attnOut)
-                }
-
-                let (cb2, e2) = beginStepCommandBuffer()
-                try phase(.attention) {
+                    barrier(enc)
                     for t in 0..<S {
-                        try encAttentionFinish(e2, attn: attn, slot: prefillSlot(t))
+                        try encAttentionPrep(
+                            enc, layer: li, position: basePosition + t, slot: prefillSlot(t))
+                    }
+                    barrier(enc)
+                    for t in 0..<S {
+                        try encAttentionAttend(
+                            enc, layer: li, kvLen: basePosition + t + 1, slot: prefillSlot(t))
+                    }
+                    barrier(enc)
+                    for t in 0..<S {
+                        try encAttentionFinish(enc, attn: attn, slot: prefillSlot(t))
                     }
                 }
                 try phase(.router) {
                     for t in 0..<S {
-                        try encRouterProbe(e2, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
+                        try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: prefillSlot(t))
                     }
                 }
-                e2.endEncoding()
-                commitAndWait(cb2)
+                enc.endEncoding()
+                commitAndWait(cb)
+                appendKVMirror(state, layer: li, position: basePosition, count: S)
             }
 
             // Routing on CPU for every chunk token, then one union fetch for

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1908,6 +1908,83 @@ extension QwenMetalModel {
         (0..<n).map { t in (xOff: t * reg.total + src, yOff: t * reg.total + dst) }
     }
 
+    // MARK: Chunk-level batch twins for the per-token glue kernels. Every
+    // helper encodes one batched dispatch covering all chunk tokens, and a
+    // single-token chunk delegates to the legacy per-token encode so the
+    // degenerate chunk keeps the decode-shaped stream byte-identical.
+
+    /// Input/post norms for every chunk token as one norm_copy_batch.
+    private func encChunkNormCopy(
+        _ enc: MTLComputeCommandEncoder, w: MTLBuffer, dstOff: Int, tokens n: Int
+    ) throws {
+        if n == 1 {
+            try encNormCopy(enc, w: w, dstOff: dstOff, slot: prefillSlot(0))
+            return
+        }
+        try engine.encodeNormCopyBatch(
+            enc, h: prefillHiddenBuf!, hByteOffset: 0, hStride: config.hiddenSize,
+            dst: prefillScratchBuf!, weight: w,
+            dim: config.hiddenSize, eps: Float(config.rmsNormEps),
+            dstOff: dstOff, dstStride: reg.total, tokens: n)
+    }
+
+    /// Residual adds for every chunk token as one add_inplace_batch.
+    private func encChunkResidualAdd(_ enc: MTLComputeCommandEncoder, tokens n: Int) throws {
+        if n == 1 {
+            try encResidualAdd(enc, slot: prefillSlot(0))
+            return
+        }
+        try engine.encodeAddInplaceBatch(
+            enc, h: prefillHiddenBuf!, hStride: config.hiddenSize,
+            r: prefillScratchBuf!, rOff: reg.r, rStride: reg.total,
+            count: config.hiddenSize, tokens: n)
+    }
+
+    /// Fused qkvz/ba splits for every chunk token as one
+    /// deinterleave_qkvz_batch (fusedInterleaved layout only).
+    private func encChunkDeinterleave(_ enc: MTLComputeCommandEncoder, tokens n: Int) throws {
+        if n == 1 {
+            try encDeltaDeinterleave(enc, slot: prefillSlot(0))
+            return
+        }
+        let cfg = config
+        try engine.encodeDeinterleaveBatch(
+            enc, data: prefillScratchBuf!,
+            nk: cfg.linearNumKeyHeads, dk: cfg.linearKeyHeadDim,
+            rep: cfg.linearNumValueHeads / cfg.linearNumKeyHeads,
+            dv: cfg.linearValueHeadDim, keyDim: cfg.keyDim,
+            srcOff: reg.qkvzStage, baOff: reg.baStage,
+            qkvOff: reg.qkv, zOff: reg.z, bOff: reg.b, aOff: reg.a,
+            stride: reg.total, tokens: n)
+    }
+
+    /// Query prep and KV append for every chunk token: one batched dispatch
+    /// each. Token t preps at position basePosition + t and appends into its
+    /// own (disjoint) cache row, so batching cannot reorder any write.
+    private func encChunkAttentionPrep(
+        _ enc: MTLComputeCommandEncoder, layer li: Int, basePosition: Int, tokens n: Int
+    ) throws {
+        if n == 1 {
+            try encAttentionPrep(enc, layer: li, position: basePosition, slot: prefillSlot(0))
+            return
+        }
+        let cfg = config
+        let fl = fastLayers[li] // fresh copy: ensureKVCapacity may have swapped buffers
+        try engine.encodeAttnQPrepBatch(
+            enc, data: prefillScratchBuf!, weight: fl.qNormW!,
+            heads: cfg.numAttentionHeads, headDim: cfg.headDim,
+            rotaryDims: cfg.rotaryDims, eps: Float(cfg.rmsNormEps),
+            ropeTheta: Float(cfg.ropeTheta), basePosition: basePosition,
+            srcOff: reg.qout, dstOff: reg.qprep, slotStride: reg.total, tokens: n)
+        try engine.encodeAttnKVAppendBatch(
+            enc, data: prefillScratchBuf!, weight: fl.kNormW!,
+            kCache: fl.kCache!, vCache: fl.vCache!,
+            kvHeads: cfg.numKeyValueHeads, headDim: cfg.headDim,
+            rotaryDims: cfg.rotaryDims, eps: Float(cfg.rmsNormEps),
+            ropeTheta: Float(cfg.ropeTheta), basePosition: basePosition,
+            kSrcOff: reg.knew, vSrcOff: reg.vnew, slotStride: reg.total, tokens: n)
+    }
+
     /// Splits the prompt into chunks of at most `chunkCapacity` tokens and
     /// prefills each chunk layer-major. Only the final chunk projects logits
     /// (the S1a single-LM-head property).
@@ -1990,11 +2067,9 @@ extension QwenMetalModel {
                     pending = nil
                 }
                 try phase(.attention) {
-                    // Input norms per token, then q/k/v each as one
-                    // token-batched dispatch over every slot.
-                    for t in 0..<S {
-                        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: prefillSlot(t))
-                    }
+                    // One batched input norm over every slot, then q/k/v each
+                    // as one token-batched dispatch.
+                    try encChunkNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, tokens: S)
                     barrier(enc)
                     for proj in [(attn.qProj, reg.qout), (attn.kProj, reg.knew),
                                  (attn.vProj, reg.vnew)] {
@@ -2003,11 +2078,12 @@ extension QwenMetalModel {
                             slots: chunkGemvSlots(S, src: reg.x0, dst: proj.1))
                     }
                     barrier(enc)
-                    for t in 0..<S {
-                        try encAttentionPrep(
-                            enc, layer: li, position: basePosition + t, slot: prefillSlot(t))
-                    }
+                    try encChunkAttentionPrep(
+                        enc, layer: li, basePosition: basePosition, tokens: S)
                     barrier(enc)
+                    // The causal attend stays per token: token t reads cache
+                    // rows [0, basePosition + t + 1), a kvLen no batched grid
+                    // slice shares.
                     for t in 0..<S {
                         try encAttentionAttend(
                             enc, layer: li, kvLen: basePosition + t + 1, slot: prefillSlot(t))
@@ -2017,7 +2093,7 @@ extension QwenMetalModel {
                         enc, attn.oProj, x: prefillScratchBuf!, y: prefillScratchBuf!,
                         slots: chunkGemvSlots(S, src: reg.att, dst: reg.r))
                     barrier(enc)
-                    for t in 0..<S { try encResidualAdd(enc, slot: prefillSlot(t)) }
+                    try encChunkResidualAdd(enc, tokens: S)
                     barrier(enc)
                 }
                 try phase(.router) {
@@ -2072,20 +2148,18 @@ extension QwenMetalModel {
             count: cfg.vocabSize))
     }
 
-    /// One DeltaNet layer over the whole chunk (S1b token batching): every
-    /// token's input norm, then one batched dispatch per in_proj tensor
-    /// covering all tokens, then the recurrence token-by-token in ascending
-    /// order (the conv history and recurrent state are shared per layer, and
-    /// the barriers inside each token's recurrence order token t+1 after
-    /// token t), then one batched output projection and the per-token
-    /// residual adds. One token degenerates to exactly the decode core's
-    /// encode stream.
+    /// One DeltaNet layer over the whole chunk (S1b token batching): one
+    /// batched input norm, then one batched dispatch per in_proj tensor
+    /// covering all tokens, one batched deinterleave, then the recurrence
+    /// token-by-token in ascending order (the conv history and recurrent
+    /// state are shared per layer, and the barriers inside each token's
+    /// recurrence order token t+1 after token t), then one batched output
+    /// projection and one batched residual add. One token degenerates to
+    /// exactly the decode core's encode stream.
     private func encChunkDelta(
         _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, tokens n: Int
     ) throws {
-        for t in 0..<n {
-            try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: prefillSlot(t))
-        }
+        try encChunkNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, tokens: n)
         barrier(enc)
         for proj in deltaInProjections(delta) {
             try engine.encodeGemvBatch(
@@ -2094,7 +2168,7 @@ extension QwenMetalModel {
         }
         barrier(enc)
         if config.deltaLayout == .fusedInterleaved {
-            for t in 0..<n { try encDeltaDeinterleave(enc, slot: prefillSlot(t)) }
+            try encChunkDeinterleave(enc, tokens: n)
             barrier(enc)
         }
         for t in 0..<n { try encDeltaRecurrence(enc, fl: fl, slot: prefillSlot(t)) }
@@ -2102,18 +2176,16 @@ extension QwenMetalModel {
             enc, delta.outProj, x: prefillScratchBuf!, y: prefillScratchBuf!,
             slots: chunkGemvSlots(n, src: reg.dn, dst: reg.r))
         barrier(enc)
-        for t in 0..<n { try encResidualAdd(enc, slot: prefillSlot(t)) }
+        try encChunkResidualAdd(enc, tokens: n)
         barrier(enc)
     }
 
-    /// Post-attention norms for every chunk token, then the router logits as
-    /// one token-batched dispatch.
+    /// One batched post-attention norm over every chunk token, then the
+    /// router logits as one token-batched dispatch.
     private func encChunkRouterProbe(
         _ enc: MTLComputeCommandEncoder, moeGate: GPULinear, fl: FastLayer, tokens n: Int
     ) throws {
-        for t in 0..<n {
-            try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe, slot: prefillSlot(t))
-        }
+        try encChunkNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe, tokens: n)
         barrier(enc)
         try engine.encodeGemvBatch(
             enc, moeGate, x: prefillScratchBuf!, y: prefillScratchBuf!,
@@ -2130,6 +2202,7 @@ extension QwenMetalModel {
         let cfg = config
         let D = cfg.hiddenSize, inter = cfg.moeIntermediateSize
         let shInter = cfg.sharedExpertIntermediateSize
+        let topK = cfg.numExpertsPerTok
         let moe = layers[pend.layer].moe
         let fl = fastLayers[pend.layer]
         let projs = expertProjs
@@ -2187,18 +2260,36 @@ extension QwenMetalModel {
         barrier(enc)
 
         // Stage 2: silu(gate) * up for every (token, pick) and shared chain.
-        for (t, entry) in pend.perToken.enumerated() {
-            let slot = prefillSlot(t)
-            let K = entry.picks.count
-            for ki in 0..<K {
-                try engine.encodeSiluMul(enc, buf: slot.scratch, count: inter,
-                    gOff: slot.base + reg.exp + ki * inter,
-                    uOff: slot.base + reg.exp + K * inter + ki * inter,
-                    dstOff: slot.base + reg.exp + 2 * K * inter + ki * inter)
+        // Pick slot ki's rows sit at the same offsets in every token slot, so
+        // each ki batches into one strided dispatch over the chunk (as does
+        // the shared chain); a single-token chunk or a rare non-uniform pick
+        // count keeps the legacy per-token loop.
+        let uniformK = pend.perToken.allSatisfy { $0.picks.count == topK }
+        if S > 1, uniformK {
+            for ki in 0..<topK {
+                try engine.encodeSiluMulBatch(enc, buf: prefillScratchBuf!, count: inter,
+                    gOff: reg.exp + ki * inter,
+                    uOff: reg.exp + topK * inter + ki * inter,
+                    dstOff: reg.exp + 2 * topK * inter + ki * inter,
+                    stride: reg.total, tokens: S)
             }
-            try engine.encodeSiluMul(enc, buf: slot.scratch, count: shInter,
-                gOff: slot.base + reg.sh, uOff: slot.base + reg.sh + shInter,
-                dstOff: slot.base + reg.sh + 2 * shInter)
+            try engine.encodeSiluMulBatch(enc, buf: prefillScratchBuf!, count: shInter,
+                gOff: reg.sh, uOff: reg.sh + shInter, dstOff: reg.sh + 2 * shInter,
+                stride: reg.total, tokens: S)
+        } else {
+            for (t, entry) in pend.perToken.enumerated() {
+                let slot = prefillSlot(t)
+                let K = entry.picks.count
+                for ki in 0..<K {
+                    try engine.encodeSiluMul(enc, buf: slot.scratch, count: inter,
+                        gOff: slot.base + reg.exp + ki * inter,
+                        uOff: slot.base + reg.exp + K * inter + ki * inter,
+                        dstOff: slot.base + reg.exp + 2 * K * inter + ki * inter)
+                }
+                try engine.encodeSiluMul(enc, buf: slot.scratch, count: shInter,
+                    gOff: slot.base + reg.sh, uOff: slot.base + reg.sh + shInter,
+                    dstOff: slot.base + reg.sh + 2 * shInter)
+            }
         }
         barrier(enc)
 
@@ -2221,10 +2312,23 @@ extension QwenMetalModel {
             slots: chunkGemvSlots(S, src: reg.sh + 2 * shInter, dst: reg.sh + 3 * shInter))
         barrier(enc)
 
-        // Stage 4: weighted accumulation per token, legacy pick order.
-        for (t, entry) in pend.perToken.enumerated() {
-            try encWeightedAccum(enc, weights: entry.weights, count: entry.picks.count,
-                                 slot: prefillSlot(t))
+        // Stage 4: weighted accumulation, one batched dispatch over the
+        // chunk with a token-major weights table. Each token's K-expert
+        // accumulation order stays inside the kernel, exactly the legacy
+        // per-token loop, so batching cannot reorder any float sum.
+        if S > 1, uniformK {
+            var weights: [Float] = []
+            weights.reserveCapacity(S * topK)
+            for entry in pend.perToken { weights.append(contentsOf: entry.weights) }
+            try engine.encodeWeightedAccumBatch(
+                enc, h: prefillHiddenBuf!, hStride: D, data: prefillScratchBuf!,
+                count: D, k: topK, dBase: reg.dexp, shOff: reg.sh + 3 * shInter,
+                gateOff: reg.shg, stride: reg.total, weights: weights, tokens: S)
+        } else {
+            for (t, entry) in pend.perToken.enumerated() {
+                try encWeightedAccum(enc, weights: entry.weights, count: entry.picks.count,
+                                     slot: prefillSlot(t))
+            }
         }
         barrier(enc)
     }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1479,16 +1479,10 @@ extension QwenMetalModel {
     private func encAttentionFinish(
         _ enc: MTLComputeCommandEncoder, attn: AttnGPU, slot: TokenSlot
     ) throws {
-        let D = config.hiddenSize
         try engine.encodeGemv(enc, attn.oProj, x: slot.scratch, xOff: slot.base + reg.att,
             y: slot.scratch, yOff: slot.base + reg.r)
         barrier(enc)
-        var np = SIMD2<UInt32>(UInt32(D), UInt32(slot.base + reg.r))
-        enc.setComputePipelineState(try engine.pipeline("add_inplace"))
-        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
-        enc.setBuffer(slot.scratch, offset: 0, index: 1)
-        setBytesParams(enc, &np, index: 2)
-        dispatchN(enc, D)
+        try encResidualAdd(enc, slot: slot)
         barrier(enc)
     }
 
@@ -1611,53 +1605,81 @@ extension QwenMetalModel {
     }
 
     /// DeltaNet mixer for one token, entirely on GPU: projections, conv step,
-    /// gated recurrence, gated norm, output projection, residual add.
+    /// gated recurrence, gated norm, output projection, residual add. Encoded
+    /// through the stage helpers below in exactly the legacy order; the
+    /// chunked prefill reuses the stages but batches the projection GEMVs
+    /// across tokens (S1b token batching).
     private func encDeltaCore(
         _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, slot: TokenSlot
     ) throws {
+        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: slot)
+        barrier(enc)
+        for proj in deltaInProjections(delta) {
+            try engine.encodeGemv(enc, proj.lin, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + proj.dst)
+        }
+        barrier(enc)
+        if config.deltaLayout == .fusedInterleaved {
+            try encDeltaDeinterleave(enc, slot: slot)
+            barrier(enc)
+        }
+        try encDeltaRecurrence(enc, fl: fl, slot: slot)
+        try engine.encodeGemv(enc, delta.outProj, x: slot.scratch, xOff: slot.base + reg.dn,
+            y: slot.scratch, yOff: slot.base + reg.r)
+        barrier(enc)
+        try encResidualAdd(enc, slot: slot)
+        barrier(enc)
+    }
+
+    /// The DeltaNet input projections as (linear, destination region) pairs
+    /// in the layout's canonical encode order; the decode core and the
+    /// batched chunk pass dispatch exactly these.
+    private func deltaInProjections(_ delta: DeltaGPU) -> [(lin: GPULinear, dst: Int)] {
+        switch config.deltaLayout {
+        case .split:
+            return [(delta.qkv!, reg.qkv), (delta.zProj!, reg.z),
+                    (delta.bProj!, reg.b), (delta.aProj!, reg.a)]
+        case .fusedInterleaved:
+            return [(delta.qkvz!, reg.qkvzStage), (delta.ba!, reg.baStage)]
+        }
+    }
+
+    /// Splits the fused qkvz/ba staging rows into the flat qkv/z/b/a regions
+    /// (fusedInterleaved layout only).
+    private func encDeltaDeinterleave(_ enc: MTLComputeCommandEncoder, slot: TokenSlot) throws {
         let cfg = config
-        let D = cfg.hiddenSize
+        let nk = cfg.linearNumKeyHeads, nv = cfg.linearNumValueHeads
+        let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
+        enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
+        struct DeintParams {
+            var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
+            var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
+            var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+        }
+        var dip = DeintParams(
+            nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
+            keyDim: UInt32(cfg.keyDim),
+            srcOff: UInt32(slot.base + reg.qkvzStage), baOff: UInt32(slot.base + reg.baStage),
+            qkvOff: UInt32(slot.base + reg.qkv), zOff: UInt32(slot.base + reg.z),
+            bOff: UInt32(slot.base + reg.b), aOff: UInt32(slot.base + reg.a)
+        )
+        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+        setBytesParams(enc, &dip, index: 1)
+        dispatchN(enc, nk)
+    }
+
+    /// Conv step, decay/beta preparation, q/k norms, gated recurrence, and
+    /// the gated output norm for one token, ending on a barrier. Reads the
+    /// slot's projection regions and advances the layer's shared conv
+    /// history and recurrent state, so chunked callers must encode tokens in
+    /// ascending order (the decode core encodes exactly one).
+    private func encDeltaRecurrence(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
+    ) throws {
+        let cfg = config
         let nk = cfg.linearNumKeyHeads, nv = cfg.linearNumValueHeads
         let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
         let keyDim = cfg.keyDim, convDim = cfg.convDim
-
-        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: slot)
-        barrier(enc)
-        switch config.deltaLayout {
-        case .split:
-            try engine.encodeGemv(enc, delta.qkv!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.qkv)
-            try engine.encodeGemv(enc, delta.zProj!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.z)
-            try engine.encodeGemv(enc, delta.bProj!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.b)
-            try engine.encodeGemv(enc, delta.aProj!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.a)
-            barrier(enc)
-        case .fusedInterleaved:
-            try engine.encodeGemv(enc, delta.qkvz!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.qkvzStage)
-            try engine.encodeGemv(enc, delta.ba!, x: slot.scratch, xOff: slot.base + reg.x0,
-                y: slot.scratch, yOff: slot.base + reg.baStage)
-            barrier(enc)
-            enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
-            struct DeintParams {
-                var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
-                var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
-                var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
-            }
-            var dip = DeintParams(
-                nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
-                keyDim: UInt32(keyDim),
-                srcOff: UInt32(slot.base + reg.qkvzStage), baOff: UInt32(slot.base + reg.baStage),
-                qkvOff: UInt32(slot.base + reg.qkv), zOff: UInt32(slot.base + reg.z),
-                bOff: UInt32(slot.base + reg.b), aOff: UInt32(slot.base + reg.a)
-            )
-            enc.setBuffer(slot.scratch, offset: 0, index: 0)
-            setBytesParams(enc, &dip, index: 1)
-            dispatchN(enc, nk)
-            barrier(enc)
-        }
 
         enc.setComputePipelineState(try engine.pipeline("conv_step"))
         var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim),
@@ -1712,17 +1734,17 @@ extension QwenMetalModel {
         setBytesParams(enc, &gp, index: 2)
         dispatchRows(enc, rows: nv)
         barrier(enc)
+    }
 
-        try engine.encodeGemv(enc, delta.outProj, x: slot.scratch, xOff: slot.base + reg.dn,
-            y: slot.scratch, yOff: slot.base + reg.r)
-        barrier(enc)
-        var ap = SIMD2<UInt32>(UInt32(D), UInt32(slot.base + reg.r))
+    /// h[slot] += the slot's reg.r row (a mixer's output-projection result).
+    private func encResidualAdd(_ enc: MTLComputeCommandEncoder, slot: TokenSlot) throws {
+        let D = config.hiddenSize
         enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+        var p = SIMD2<UInt32>(UInt32(D), UInt32(slot.base + reg.r))
         enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
         enc.setBuffer(slot.scratch, offset: 0, index: 1)
-        setBytesParams(enc, &ap, index: 2)
+        setBytesParams(enc, &p, index: 2)
         dispatchN(enc, D)
-        barrier(enc)
     }
 
     // MARK: - S2 GPU-resident KV cache

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1341,13 +1341,6 @@ extension QwenMetalModel {
             count: n))
     }
 
-    private func writeSlot(_ slot: TokenSlot, _ off: Int, _ v: [Float]) {
-        v.withUnsafeBufferPointer {
-            slot.scratch.contents().advanced(by: (slot.base + off) * 4)
-                .copyMemory(from: $0.baseAddress!, byteCount: v.count * 4)
-        }
-    }
-
     private func resetGPUState() {
         for fl in fastLayers {
             if let h = fl.hist { memset(h.contents(), 0, h.length) }

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -340,6 +340,7 @@ public final class QwenMetalModel {
     var prefillScratchBuf: MTLBuffer?
     var prefillHiddenBuf: MTLBuffer?
     var prefillSlotCapacity = 0
+    var prefillStage = PrefillStage()
 
     public init(modelDir: URL, cacheBudgetGB: Double = 8) throws {
         config = try QwenConfig(url: modelDir.appendingPathComponent("config.json"))
@@ -1672,24 +1673,56 @@ extension QwenMetalModel {
     /// the gated output norm for one token, ending on a barrier. Reads the
     /// slot's projection regions and advances the layer's shared conv
     /// history and recurrent state, so chunked callers must encode tokens in
-    /// ascending order (the decode core encodes exactly one).
+    /// ascending order (the decode core encodes exactly one). Assembled
+    /// from the stage helpers below; the chunked prefill reuses them but
+    /// runs the gated scan once per chunk with T = chunk length (S1b
+    /// chunked recurrence).
     private func encDeltaRecurrence(
         _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
     ) throws {
-        let cfg = config
-        let nk = cfg.linearNumKeyHeads, nv = cfg.linearNumValueHeads
-        let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
-        let keyDim = cfg.keyDim, convDim = cfg.convDim
+        let nv = config.linearNumValueHeads
+        let keyDim = config.keyDim
+        try encConvStep(enc, fl: fl, slot: slot)
+        try encDeltaPre(enc, fl: fl, slot: slot)
+        barrier(enc)
+        try encDeltaQKNorms(enc, slot: slot)
+        barrier(enc)
+        try encGatedDeltaScan(
+            enc, fl: fl, steps: 1, data: slot.scratch,
+            qOff: slot.base + reg.conv, kOff: slot.base + reg.conv + keyDim,
+            vOff: slot.base + reg.conv + 2 * keyDim,
+            gOff: slot.base + reg.gb, bOff: slot.base + reg.gb + nv,
+            yOff: slot.base + reg.dy)
+        barrier(enc)
+        try encGatedNormMul(
+            enc, fl: fl, data: slot.scratch,
+            yOff: slot.base + reg.dy, zOff: slot.base + reg.z,
+            outOff: slot.base + reg.dn)
+        barrier(enc)
+    }
 
+    /// Depthwise causal conv + silu on one token's qkv row, advancing the
+    /// layer's shared history (order-sensitive across tokens).
+    private func encConvStep(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
+    ) throws {
+        let cfg = config
         enc.setComputePipelineState(try engine.pipeline("conv_step"))
-        var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim),
+        var cp = SIMD4<UInt32>(UInt32(cfg.convDim), UInt32(cfg.linearConvKernelDim),
                                UInt32(slot.base + reg.qkv), UInt32(slot.base + reg.conv))
         enc.setBuffer(slot.scratch, offset: 0, index: 0)
         enc.setBuffer(fl.hist!, offset: 0, index: 1)
         enc.setBuffer(fl.convW!, offset: 0, index: 2)
         setBytesParams(enc, &cp, index: 3)
-        dispatchN(enc, convDim)
+        dispatchN(enc, cfg.convDim)
+    }
 
+    /// g = exp(-exp(A_log) * softplus(a + dt_bias)) and beta = sigmoid(b)
+    /// into the slot's gb region.
+    private func encDeltaPre(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
+    ) throws {
+        let nv = config.linearNumValueHeads
         enc.setComputePipelineState(try engine.pipeline("delta_pre"))
         var dp = SIMD4<UInt32>(UInt32(nv), UInt32(slot.base + reg.a),
                                UInt32(slot.base + reg.b), UInt32(slot.base + reg.gb))
@@ -1698,42 +1731,63 @@ extension QwenMetalModel {
         enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
         setBytesParams(enc, &dp, index: 3)
         dispatchN(enc, nv)
-        barrier(enc)
+    }
 
+    /// Weightless q/k RMSNorms (scaled 1/dk and 1/sqrt(dk)) in place on the
+    /// slot's conv rows.
+    private func encDeltaQKNorms(_ enc: MTLComputeCommandEncoder, slot: TokenSlot) throws {
+        let cfg = config
+        let nk = cfg.linearNumKeyHeads, dk = cfg.linearKeyHeadDim
         let invScale = 1 / Float(dk).squareRoot()
         try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil,
                        scale: invScale * invScale, eps: 1e-6, slot: slot)
-        try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil,
+        try encRMSNorm(enc, off: reg.conv + cfg.keyDim, rows: nk, dim: dk, w: nil,
                        scale: invScale, eps: 1e-6, slot: slot)
-        barrier(enc)
+    }
 
+    /// One gated_delta_step dispatch scanning `steps` timesteps from the
+    /// q/k/v/g/beta float offsets in `data` (contiguous [steps, row] blocks
+    /// when steps > 1), reading and writing the layer's recurrent state.
+    private func encGatedDeltaScan(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, steps: Int, data: MTLBuffer,
+        qOff: Int, kOff: Int, vOff: Int, gOff: Int, bOff: Int, yOff: Int
+    ) throws {
+        let cfg = config
+        let nk = cfg.linearNumKeyHeads, nv = cfg.linearNumValueHeads
+        let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
         enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
-        var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv) * 4, index: 0)            // q
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv + keyDim) * 4, index: 1)   // k
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv + 2 * keyDim) * 4, index: 2) // v
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.gb) * 4, index: 3)              // g
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.gb + nv) * 4, index: 4)         // beta
+        var delp = MetalEngine.DeltaParams(
+            T: UInt32(steps), Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
+        enc.setBuffer(data, offset: qOff * 4, index: 0)
+        enc.setBuffer(data, offset: kOff * 4, index: 1)
+        enc.setBuffer(data, offset: vOff * 4, index: 2)
+        enc.setBuffer(data, offset: gOff * 4, index: 3)
+        enc.setBuffer(data, offset: bOff * 4, index: 4)
         enc.setBuffer(fl.state!, offset: 0, index: 5)
-        enc.setBuffer(slot.scratch, offset: (slot.base + reg.dy) * 4, index: 6)
+        enc.setBuffer(data, offset: yOff * 4, index: 6)
         enc.setBuffer(fl.state!, offset: 0, index: 7)
         setBytesParams(enc, &delp, index: 8)
         engine.dispatchThreads(
             enc, threads: MTLSize(width: 32, height: dv, depth: nv),
             threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
         )
-        barrier(enc)
+    }
 
+    /// Gated RMSNorm * silu(z) per v-head, y rows read at `yOff` in `data`.
+    private func encGatedNormMul(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, data: MTLBuffer,
+        yOff: Int, zOff: Int, outOff: Int
+    ) throws {
+        let cfg = config
+        let nv = cfg.linearNumValueHeads, dv = cfg.linearValueHeadDim
         enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
         struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
         var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
-                     yOff: UInt32(slot.base + reg.dy), zOff: UInt32(slot.base + reg.z),
-                     outOff: UInt32(slot.base + reg.dn))
-        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+                     yOff: UInt32(yOff), zOff: UInt32(zOff), outOff: UInt32(outOff))
+        enc.setBuffer(data, offset: 0, index: 0)
         enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
         setBytesParams(enc, &gp, index: 2)
         dispatchRows(enc, rows: nv)
-        barrier(enc)
     }
 
     /// h[slot] += the slot's reg.r row (a mixer's output-projection result).
@@ -1862,12 +1916,17 @@ extension QwenMetalModel {
 // MARK: - S1b layer-major chunked prefill: inside a chunk, sweep each layer
 // across every token before moving on, so a layer's expert union is fetched
 // once per chunk and one decode-shaped buffer sequence covers the whole chunk
-// instead of every token. Independent per-token projection GEMVs over shared
-// weights encode as token-batched dispatches (one per projection per chunk,
-// one per (expert, projection) for routed experts); every batched row is the
-// single-token kernel's arithmetic verbatim and the recurrent stages keep
-// ascending token order, so numerics match the token-major schedule exactly.
-// S2 batches the attention core across the chunk's tokens on GPU.
+// instead of every token. Independent per-token work over shared weights
+// encodes as token-batched dispatches: projection GEMVs (one per projection
+// per chunk, one per (expert, projection) for routed experts) and the glue
+// kernels (norms, deinterleave, silu, residual adds, weighted accumulation,
+// attention q prep / KV append) via their batch twins. Every batched row is
+// the single-token kernel's arithmetic verbatim; the order-sensitive
+// recurrent stages keep ascending token order (conv history per token, the
+// gated recurrence as one T=chunk in-dispatch scan), so numerics match the
+// token-major schedule exactly. S2 batches the attention core across the
+// chunk's tokens on GPU; the causal attend stays per token because each
+// token reads a different kvLen.
 extension QwenMetalModel {
 
     /// One layer's deferred MoE for a whole chunk: per-token picks/weights in
@@ -1881,19 +1940,44 @@ extension QwenMetalModel {
         var perToken: [(picks: [(Int, Float)], weights: [Float])]
     }
 
-    /// Grows the chunk scratch to hold `n` token slots. Returns false when
-    /// the device cannot allocate them (callers fall back to token-major).
+    /// Where the chunked DeltaNet recurrence stages its contiguous
+    /// [chunk, row] blocks (float offsets inside prefillScratchBuf, after
+    /// every token slot stride): the normed q/k/v conv rows, g/beta, and
+    /// the y output — the exact layout gated_delta_step's T-step scan
+    /// expects.
+    struct PrefillStage {
+        var q = 0, k = 0, v = 0, g = 0, b = 0, y = 0
+    }
+
+    /// Grows the chunk scratch to hold `n` token slots plus the chunked
+    /// recurrence staging blocks. Returns false when the device cannot
+    /// allocate them (callers fall back to token-major).
     private func ensurePrefillCapacity(_ n: Int) -> Bool {
         if prefillSlotCapacity >= n, prefillScratchBuf != nil, prefillHiddenBuf != nil {
             return true
         }
         let opts: MTLResourceOptions = [.storageModeShared, .hazardTrackingModeUntracked]
-        guard let scratch = engine.device.makeBuffer(length: n * reg.total * 4, options: opts),
-              let hidden = engine.device.makeBuffer(length: n * config.hiddenSize * 4, options: opts)
+        let cfg = config
+        var stage = PrefillStage()
+        var floats = n * reg.total
+        func take(_ rowFloats: Int) -> Int {
+            let v = floats
+            floats += n * rowFloats
+            return v
+        }
+        stage.q = take(cfg.keyDim)
+        stage.k = take(cfg.keyDim)
+        stage.v = take(cfg.valueDim)
+        stage.g = take(cfg.linearNumValueHeads)
+        stage.b = take(cfg.linearNumValueHeads)
+        stage.y = take(cfg.valueDim)
+        guard let scratch = engine.device.makeBuffer(length: floats * 4, options: opts),
+              let hidden = engine.device.makeBuffer(length: n * cfg.hiddenSize * 4, options: opts)
         else { return false }
         prefillScratchBuf = scratch
         prefillHiddenBuf = hidden
         prefillSlotCapacity = n
+        prefillStage = stage
         return true
     }
 
@@ -2150,12 +2234,12 @@ extension QwenMetalModel {
 
     /// One DeltaNet layer over the whole chunk (S1b token batching): one
     /// batched input norm, then one batched dispatch per in_proj tensor
-    /// covering all tokens, one batched deinterleave, then the recurrence
-    /// token-by-token in ascending order (the conv history and recurrent
-    /// state are shared per layer, and the barriers inside each token's
-    /// recurrence order token t+1 after token t), then one batched output
-    /// projection and one batched residual add. One token degenerates to
-    /// exactly the decode core's encode stream.
+    /// covering all tokens, one batched deinterleave, then the chunked
+    /// recurrence (per-token conv/prep/norms in ascending order feeding one
+    /// T=n gated scan), then one batched output projection and one batched
+    /// residual add. One token degenerates to exactly the decode core's
+    /// encode stream, keeping the per-token scan alive as the chunked
+    /// path's oracle.
     private func encChunkDelta(
         _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, tokens n: Int
     ) throws {
@@ -2171,12 +2255,60 @@ extension QwenMetalModel {
             try encChunkDeinterleave(enc, tokens: n)
             barrier(enc)
         }
-        for t in 0..<n { try encDeltaRecurrence(enc, fl: fl, slot: prefillSlot(t)) }
+        if n == 1 {
+            try encDeltaRecurrence(enc, fl: fl, slot: prefillSlot(0))
+        } else {
+            try encChunkDeltaRecurrence(enc, fl: fl, tokens: n)
+        }
         try engine.encodeGemvBatch(
             enc, delta.outProj, x: prefillScratchBuf!, y: prefillScratchBuf!,
             slots: chunkGemvSlots(n, src: reg.dn, dst: reg.r))
         barrier(enc)
         try encChunkResidualAdd(enc, tokens: n)
+        barrier(enc)
+    }
+
+    /// The chunk's recurrence stage with the T-step scan (S1b chunked
+    /// recurrence): conv steps and decay/beta prep stay per token in
+    /// ascending order (the conv history is shared state, so a barrier
+    /// separates consecutive tokens), the q/k norms run per token on each
+    /// slot's conv rows, one delta_gather packs the normed rows into the
+    /// contiguous [T, row] staging blocks, and a single T=n gated_delta_step
+    /// replaces the n per-token scans. The kernel's internal step loop
+    /// performs the same ascending-order arithmetic the per-token dispatches
+    /// did — state carried in f32 registers instead of a per-token f32
+    /// device round trip — so every y row and the final state are bitwise
+    /// identical. Ends on a barrier like the decode core.
+    private func encChunkDeltaRecurrence(
+        _ enc: MTLComputeCommandEncoder, fl: FastLayer, tokens n: Int
+    ) throws {
+        let valueDim = config.valueDim
+        for t in 0..<n {
+            let slot = prefillSlot(t)
+            try encConvStep(enc, fl: fl, slot: slot)
+            try encDeltaPre(enc, fl: fl, slot: slot)
+            barrier(enc)   // token t+1's conv reads the advanced history
+        }
+        for t in 0..<n { try encDeltaQKNorms(enc, slot: prefillSlot(t)) }
+        barrier(enc)
+        try engine.encodeDeltaGather(
+            enc, data: prefillScratchBuf!,
+            keyDim: config.keyDim, valueDim: valueDim, nv: config.linearNumValueHeads,
+            slotStride: reg.total, convOff: reg.conv, gbOff: reg.gb,
+            qOut: prefillStage.q, kOut: prefillStage.k, vOut: prefillStage.v,
+            gOut: prefillStage.g, bOut: prefillStage.b, tokens: n)
+        barrier(enc)
+        try encGatedDeltaScan(
+            enc, fl: fl, steps: n, data: prefillScratchBuf!,
+            qOff: prefillStage.q, kOff: prefillStage.k, vOff: prefillStage.v,
+            gOff: prefillStage.g, bOff: prefillStage.b, yOff: prefillStage.y)
+        barrier(enc)
+        for t in 0..<n {
+            try encGatedNormMul(
+                enc, fl: fl, data: prefillScratchBuf!,
+                yOff: prefillStage.y + t * valueDim,
+                zOff: t * reg.total + reg.z, outOff: t * reg.total + reg.dn)
+        }
         barrier(enc)
     }
 

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1189,6 +1189,26 @@ public final class QwenMetalModel {
 // dispatches (e.g. all expert GEMVs) actually run in parallel.
 extension QwenMetalModel {
 
+    /// Where one token's fast-path scratch and hidden row live. The decode
+    /// path uses the single legacy slot (sBuf/hBuf at offset zero); a chunked
+    /// prefill can give every token its own stride so tokens never collide
+    /// inside a shared command buffer. Encoding a token through a slot is
+    /// byte-for-byte the legacy schedule when the slot is the legacy one.
+    struct TokenSlot {
+        /// Scratch buffer holding this token's Regions layout.
+        var scratch: MTLBuffer
+        /// Float offset added to every Regions offset inside `scratch`.
+        var base: Int
+        /// Buffer holding this token's hidden-state row.
+        var hidden: MTLBuffer
+        /// Byte offset of the hidden row inside `hidden`.
+        var hiddenByteOffset: Int
+    }
+
+    var legacySlot: TokenSlot {
+        TokenSlot(scratch: sBuf!, base: 0, hidden: hBuf!, hiddenByteOffset: 0)
+    }
+
     private func setBytesParams<T>(_ enc: MTLComputeCommandEncoder, _ v: inout T, index: Int) {
         enc.setBytes(&v, length: MemoryLayout<T>.stride, index: index)
     }
@@ -1216,24 +1236,26 @@ extension QwenMetalModel {
         var off: UInt32
     }
 
-    private func encNormCopy(_ enc: MTLComputeCommandEncoder, w: MTLBuffer, dstOff: Int) throws {
+    private func encNormCopy(
+        _ enc: MTLComputeCommandEncoder, w: MTLBuffer, dstOff: Int, slot: TokenSlot
+    ) throws {
         enc.setComputePipelineState(try engine.pipeline("norm_copy"))
         var p = NormParams(rows: 1, dim: UInt32(config.hiddenSize), eps: Float(config.rmsNormEps),
-                           hasWeight: 1, scale: 1, off: UInt32(dstOff))
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
+                           hasWeight: 1, scale: 1, off: UInt32(slot.base + dstOff))
+        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
+        enc.setBuffer(slot.scratch, offset: 0, index: 1)
         enc.setBuffer(w, offset: 0, index: 2)
         setBytesParams(enc, &p, index: 3)
         dispatchRows(enc, rows: 1)
     }
 
     private func encRMSNorm(_ enc: MTLComputeCommandEncoder, off: Int, rows: Int, dim: Int,
-                            w: MTLBuffer?, scale: Float, eps: Float) throws {
+                            w: MTLBuffer?, scale: Float, eps: Float, slot: TokenSlot) throws {
         enc.setComputePipelineState(try engine.pipeline("rmsnorm_rows"))
         var p = NormParams(rows: UInt32(rows), dim: UInt32(dim), eps: eps,
-                           hasWeight: w != nil ? 1 : 0, scale: scale, off: UInt32(off))
-        enc.setBuffer(sBuf!, offset: 0, index: 0)
-        enc.setBuffer(w ?? sBuf!, offset: 0, index: 1)
+                           hasWeight: w != nil ? 1 : 0, scale: scale, off: UInt32(slot.base + off))
+        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+        enc.setBuffer(w ?? slot.scratch, offset: 0, index: 1)
         setBytesParams(enc, &p, index: 2)
         dispatchRows(enc, rows: rows)
     }
@@ -1242,15 +1264,16 @@ extension QwenMetalModel {
         enc.memoryBarrier(scope: .buffers)
     }
 
-    private func readS(_ off: Int, _ n: Int) -> [Float] {
+    private func readSlot(_ slot: TokenSlot, _ off: Int, _ n: Int) -> [Float] {
         Array(UnsafeBufferPointer(
-            start: sBuf!.contents().advanced(by: off * 4).bindMemory(to: Float.self, capacity: n),
+            start: slot.scratch.contents().advanced(by: (slot.base + off) * 4)
+                .bindMemory(to: Float.self, capacity: n),
             count: n))
     }
 
-    private func writeS(_ off: Int, _ v: [Float]) {
+    private func writeSlot(_ slot: TokenSlot, _ off: Int, _ v: [Float]) {
         v.withUnsafeBufferPointer {
-            sBuf!.contents().advanced(by: off * 4)
+            slot.scratch.contents().advanced(by: (slot.base + off) * 4)
                 .copyMemory(from: $0.baseAddress!, byteCount: v.count * 4)
         }
     }
@@ -1262,7 +1285,9 @@ extension QwenMetalModel {
         }
     }
 
-    private func encodePendingMoE(_ enc: MTLComputeCommandEncoder, _ pend: PendingMoE) throws {
+    private func encodePendingMoE(
+        _ enc: MTLComputeCommandEncoder, _ pend: PendingMoE, slot: TokenSlot
+    ) throws {
         let cfg = config
         let D = cfg.hiddenSize, inter = cfg.moeIntermediateSize
         let shInter = cfg.sharedExpertIntermediateSize
@@ -1273,39 +1298,44 @@ extension QwenMetalModel {
         for (ki, pick) in pend.picks.enumerated() {
             let gLin: GPULinear
             let uLin: GPULinear
-            let dLin: GPULinear
             var wE = 0, sE = 0
             if let projs, ki < pend.bufs.count {
                 let buf = pend.bufs[ki]
                 gLin = projs.gate.linear(on: buf)
                 uLin = projs.up.linear(on: buf)
-                dLin = projs.down.linear(on: buf)
             } else {
                 let st = moe.stacks!
-                gLin = st.gate.lin; uLin = st.up.lin; dLin = st.down.lin
+                gLin = st.gate.lin; uLin = st.up.lin
                 wE = pick.0; sE = pick.0
             }
             try engine.encodeGemv(enc, gLin, rows: inter,
                 wExtra: wE * (moe.stacks?.gate.wStride ?? 0), sExtra: sE * (moe.stacks?.gate.sStride ?? 0),
                 bExtra: sE * (moe.stacks?.gate.sStride ?? 0),
-                x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.exp + ki * inter)
+                x: slot.scratch, xOff: slot.base + reg.xmoe,
+                y: slot.scratch, yOff: slot.base + reg.exp + ki * inter)
             try engine.encodeGemv(enc, uLin, rows: inter,
                 wExtra: wE * (moe.stacks?.up.wStride ?? 0), sExtra: sE * (moe.stacks?.up.sStride ?? 0),
                 bExtra: sE * (moe.stacks?.up.sStride ?? 0),
-                x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.exp + pend.picks.count * inter + ki * inter)
+                x: slot.scratch, xOff: slot.base + reg.xmoe,
+                y: slot.scratch, yOff: slot.base + reg.exp + pend.picks.count * inter + ki * inter)
         }
-        try engine.encodeGemv(enc, moe.sharedGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.sh)
-        try engine.encodeGemv(enc, moe.sharedUp, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.sh + shInter)
-        try engine.encodeGemv(enc, fl.sharedGateLin, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.shg)
+        try engine.encodeGemv(enc, moe.sharedGate, x: slot.scratch, xOff: slot.base + reg.xmoe,
+            y: slot.scratch, yOff: slot.base + reg.sh)
+        try engine.encodeGemv(enc, moe.sharedUp, x: slot.scratch, xOff: slot.base + reg.xmoe,
+            y: slot.scratch, yOff: slot.base + reg.sh + shInter)
+        try engine.encodeGemv(enc, fl.sharedGateLin, x: slot.scratch, xOff: slot.base + reg.xmoe,
+            y: slot.scratch, yOff: slot.base + reg.shg)
         barrier(enc)
         let K = pend.picks.count
         for ki in 0..<K {
-            try engine.encodeSiluMul(enc, buf: sBuf!, count: inter,
-                gOff: reg.exp + ki * inter, uOff: reg.exp + K * inter + ki * inter,
-                dstOff: reg.exp + 2 * K * inter + ki * inter)
+            try engine.encodeSiluMul(enc, buf: slot.scratch, count: inter,
+                gOff: slot.base + reg.exp + ki * inter,
+                uOff: slot.base + reg.exp + K * inter + ki * inter,
+                dstOff: slot.base + reg.exp + 2 * K * inter + ki * inter)
         }
-        try engine.encodeSiluMul(enc, buf: sBuf!, count: shInter,
-            gOff: reg.sh, uOff: reg.sh + shInter, dstOff: reg.sh + 2 * shInter)
+        try engine.encodeSiluMul(enc, buf: slot.scratch, count: shInter,
+            gOff: slot.base + reg.sh, uOff: slot.base + reg.sh + shInter,
+            dstOff: slot.base + reg.sh + 2 * shInter)
         barrier(enc)
         for (ki, pick) in pend.picks.enumerated() {
             let dLin: GPULinear
@@ -1319,29 +1349,39 @@ extension QwenMetalModel {
             try engine.encodeGemv(enc, dLin, rows: D,
                 wExtra: wE * (moe.stacks?.down.wStride ?? 0), sExtra: sE * (moe.stacks?.down.sStride ?? 0),
                 bExtra: sE * (moe.stacks?.down.sStride ?? 0),
-                x: sBuf!, xOff: reg.exp + 2 * K * inter + ki * inter,
-                y: sBuf!, yOff: reg.dexp + ki * D)
+                x: slot.scratch, xOff: slot.base + reg.exp + 2 * K * inter + ki * inter,
+                y: slot.scratch, yOff: slot.base + reg.dexp + ki * D)
         }
-        try engine.encodeGemv(enc, moe.sharedDown, x: sBuf!, xOff: reg.sh + 2 * shInter,
-            y: sBuf!, yOff: reg.sh + 3 * shInter)
+        try engine.encodeGemv(enc, moe.sharedDown, x: slot.scratch, xOff: slot.base + reg.sh + 2 * shInter,
+            y: slot.scratch, yOff: slot.base + reg.sh + 3 * shInter)
         barrier(enc)
 
-        enc.setComputePipelineState(try engine.pipeline("weighted_accum"))
-        var ap = SIMD8<UInt32>(UInt32(D), UInt32(K), UInt32(reg.dexp),
-                               UInt32(reg.sh + 3 * shInter), UInt32(reg.shg), 0, 0, 0)
-        enc.setBuffer(hBuf!, offset: 0, index: 0)
-        enc.setBuffer(sBuf!, offset: 0, index: 1)
-        setBytesParams(enc, &ap, index: 2)
-        pend.weights.withUnsafeBufferPointer {
-            enc.setBytes($0.baseAddress!, length: max(1, $0.count) * 4, index: 3)
-        }
-        dispatchN(enc, D)
+        try encWeightedAccum(enc, weights: pend.weights, count: pend.picks.count, slot: slot)
         barrier(enc)
     }
 
-    private func routerPicks() -> ([(Int, Float)], [Float]) {
+    /// h[slot] += sum(weights[k] * expertDown[k]) + sigmoid(sharedGate) * sharedDown.
+    private func encWeightedAccum(
+        _ enc: MTLComputeCommandEncoder, weights: [Float], count: Int, slot: TokenSlot
+    ) throws {
         let cfg = config
-        var router = readS(reg.rout, cfg.numExperts)
+        let D = cfg.hiddenSize, shInter = cfg.sharedExpertIntermediateSize
+        enc.setComputePipelineState(try engine.pipeline("weighted_accum"))
+        var ap = SIMD8<UInt32>(UInt32(D), UInt32(count), UInt32(slot.base + reg.dexp),
+                               UInt32(slot.base + reg.sh + 3 * shInter),
+                               UInt32(slot.base + reg.shg), 0, 0, 0)
+        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
+        enc.setBuffer(slot.scratch, offset: 0, index: 1)
+        setBytesParams(enc, &ap, index: 2)
+        weights.withUnsafeBufferPointer {
+            enc.setBytes($0.baseAddress!, length: max(1, $0.count) * 4, index: 3)
+        }
+        dispatchN(enc, D)
+    }
+
+    private func routerPicks(slot: TokenSlot) -> ([(Int, Float)], [Float]) {
+        let cfg = config
+        var router = readSlot(slot, reg.rout, cfg.numExperts)
         QwenCPUModel.softmaxRow(&router, base: 0, count: cfg.numExperts)
         var picks: [(Int, Float)] = []
         for e in 0..<cfg.numExperts {
@@ -1356,6 +1396,62 @@ extension QwenMetalModel {
         for (_, p) in picks { sum += p }
         let weights = picks.map { cfg.normTopkProb ? $0.1 / sum : $0.1 }
         return (picks, weights)
+    }
+
+    /// Attention: input norm + q/k/v projections into the slot's regions.
+    private func encAttentionProjections(
+        _ enc: MTLComputeCommandEncoder, attn: AttnGPU, fl: FastLayer, slot: TokenSlot
+    ) throws {
+        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: slot)
+        barrier(enc)
+        try engine.encodeGemv(enc, attn.qProj, x: slot.scratch, xOff: slot.base + reg.x0,
+            y: slot.scratch, yOff: slot.base + reg.qout)
+        try engine.encodeGemv(enc, attn.kProj, x: slot.scratch, xOff: slot.base + reg.x0,
+            y: slot.scratch, yOff: slot.base + reg.knew)
+        try engine.encodeGemv(enc, attn.vProj, x: slot.scratch, xOff: slot.base + reg.x0,
+            y: slot.scratch, yOff: slot.base + reg.vnew)
+    }
+
+    /// Attention: output projection and residual add into the slot's hidden row.
+    private func encAttentionFinish(
+        _ enc: MTLComputeCommandEncoder, attn: AttnGPU, slot: TokenSlot
+    ) throws {
+        let D = config.hiddenSize
+        try engine.encodeGemv(enc, attn.oProj, x: slot.scratch, xOff: slot.base + reg.att,
+            y: slot.scratch, yOff: slot.base + reg.r)
+        barrier(enc)
+        var np = SIMD2<UInt32>(UInt32(D), UInt32(slot.base + reg.r))
+        enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
+        enc.setBuffer(slot.scratch, offset: 0, index: 1)
+        setBytesParams(enc, &np, index: 2)
+        dispatchN(enc, D)
+        barrier(enc)
+    }
+
+    /// Post-attention norm and router logits projection for one token.
+    private func encRouterProbe(
+        _ enc: MTLComputeCommandEncoder, moeGate: GPULinear, fl: FastLayer, slot: TokenSlot
+    ) throws {
+        try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe, slot: slot)
+        barrier(enc)
+        try engine.encodeGemv(enc, moeGate, x: slot.scratch, xOff: slot.base + reg.xmoe,
+            y: slot.scratch, yOff: slot.base + reg.rout)
+    }
+
+    /// Final norm + vocabulary projection for the slot's hidden row.
+    private func encFinalLMHead(_ enc: MTLComputeCommandEncoder, slot: TokenSlot) throws {
+        enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+        var np = NormParams(rows: 1, dim: UInt32(config.hiddenSize), eps: Float(config.rmsNormEps),
+                            hasWeight: 1, scale: 1, off: UInt32(slot.base + reg.x0))
+        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
+        enc.setBuffer(slot.scratch, offset: 0, index: 1)
+        enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
+        setBytesParams(enc, &np, index: 3)
+        dispatchRows(enc, rows: 1)
+        barrier(enc)
+        try engine.encodeGemv(enc, lmHead, x: slot.scratch, xOff: slot.base + reg.x0,
+            y: logitsBuf, yOff: 0)
     }
 
     func stepOneFast(
@@ -1373,6 +1469,7 @@ extension QwenMetalModel {
             hBuf!.contents().copyMemory(from: $0.baseAddress!, byteCount: D * 4)
         }
 
+        let slot = legacySlot
         var pending: PendingMoE? = nil
 
         for li in 0..<cfg.numHiddenLayers {
@@ -1382,55 +1479,49 @@ extension QwenMetalModel {
             if let delta = L.delta {
                 let (cb, enc) = beginStepCommandBuffer()
                 if let p = pending {
-                    try phase(.moe) { try encodePendingMoE(enc, p) }
+                    try phase(.moe) { try encodePendingMoE(enc, p, slot: slot) }
                     pending = nil
                 }
-                try encDeltaLayer(enc, delta: delta, fl: fl, moeGate: L.moe.gate)
+                try phase(.delta) {
+                    try encDeltaCore(enc, delta: delta, fl: fl, slot: slot)
+                }
+                try phase(.router) {
+                    try encRouterProbe(enc, moeGate: L.moe.gate, fl: fl, slot: slot)
+                }
                 enc.endEncoding()
                 commitAndWait(cb)
             } else {
                 // Attention: projections, CPU core, then out-proj + router.
                 let (cb1, e1) = beginStepCommandBuffer()
                 if let p = pending {
-                    try phase(.moe) { try encodePendingMoE(e1, p) }
+                    try phase(.moe) { try encodePendingMoE(e1, p, slot: slot) }
                     pending = nil
                 }
                 let attn = L.attn!
                 try phase(.attention) {
-                    try encNormCopy(e1, w: fl.inputNorm, dstOff: reg.x0)
-                    barrier(e1)
-                    try engine.encodeGemv(e1, attn.qProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qout)
-                    try engine.encodeGemv(e1, attn.kProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.knew)
-                    try engine.encodeGemv(e1, attn.vProj, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.vnew)
+                    try encAttentionProjections(e1, attn: attn, fl: fl, slot: slot)
                 }
                 e1.endEncoding()
                 commitAndWait(cb1)
 
-                let attnOut = attnCoreCPU(layerIndex: li, state: state, attn: attn)
-                writeS(reg.att, attnOut)
+                let attnOut = attnCoreCPU(
+                    layerIndex: li, state: state, attn: attn,
+                    position: state.position, slot: slot
+                )
+                writeSlot(slot, reg.att, attnOut)
 
                 let (cb2, e2) = beginStepCommandBuffer()
                 try phase(.attention) {
-                    try engine.encodeGemv(e2, attn.oProj, x: sBuf!, xOff: reg.att, y: sBuf!, yOff: reg.r)
-                    barrier(e2)
-                    var np = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-                    e2.setComputePipelineState(try engine.pipeline("add_inplace"))
-                    e2.setBuffer(hBuf!, offset: 0, index: 0)
-                    e2.setBuffer(sBuf!, offset: 0, index: 1)
-                    setBytesParams(e2, &np, index: 2)
-                    dispatchN(e2, D)
-                    barrier(e2)
+                    try encAttentionFinish(e2, attn: attn, slot: slot)
                 }
                 try phase(.router) {
-                    try encNormCopy(e2, w: fl.postNorm, dstOff: reg.xmoe)
-                    barrier(e2)
-                    try engine.encodeGemv(e2, L.moe.gate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
+                    try encRouterProbe(e2, moeGate: L.moe.gate, fl: fl, slot: slot)
                 }
                 e2.endEncoding()
                 commitAndWait(cb2)
             }
 
-            let (picks, weights) = routerPicks()
+            let (picks, weights) = routerPicks(slot: slot)
             routedExpertObserver?(li, picks.map { $0.0 })
             var bufs: [MTLBuffer] = []
             if let cache = expertCache {
@@ -1442,18 +1533,10 @@ extension QwenMetalModel {
         // Always apply the last layer's experts. Only the final token in a
         // multi-token call also needs final norm + vocabulary projection.
         let (cb, enc) = beginStepCommandBuffer()
-        if let p = pending { try phase(.moe) { try encodePendingMoE(enc, p) } }
+        if let p = pending { try phase(.moe) { try encodePendingMoE(enc, p, slot: slot) } }
         if projectLogits {
             try phase(.lmHead) {
-                enc.setComputePipelineState(try engine.pipeline("norm_copy"))
-                var np = NormParams(rows: 1, dim: UInt32(D), eps: Float(cfg.rmsNormEps), hasWeight: 1, scale: 1, off: UInt32(reg.x0))
-                enc.setBuffer(hBuf!, offset: 0, index: 0)
-                enc.setBuffer(sBuf!, offset: 0, index: 1)
-                enc.setBuffer(finalNormBuf!, offset: 0, index: 2)
-                setBytesParams(enc, &np, index: 3)
-                dispatchRows(enc, rows: 1)
-                barrier(enc)
-                try engine.encodeGemv(enc, lmHead, x: sBuf!, xOff: reg.x0, y: logitsBuf, yOff: 0)
+                try encFinalLMHead(enc, slot: slot)
             }
             activeStepCounters?.logitProjections += 1
         }
@@ -1466,118 +1549,132 @@ extension QwenMetalModel {
             count: cfg.vocabSize))
     }
 
-    private func encDeltaLayer(_ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, moeGate: GPULinear) throws {
+    /// DeltaNet mixer for one token, entirely on GPU: projections, conv step,
+    /// gated recurrence, gated norm, output projection, residual add.
+    private func encDeltaCore(
+        _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, slot: TokenSlot
+    ) throws {
         let cfg = config
         let D = cfg.hiddenSize
         let nk = cfg.linearNumKeyHeads, nv = cfg.linearNumValueHeads
         let dk = cfg.linearKeyHeadDim, dv = cfg.linearValueHeadDim
         let keyDim = cfg.keyDim, convDim = cfg.convDim
 
-        try phase(.delta) {
-            try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0)
+        try encNormCopy(enc, w: fl.inputNorm, dstOff: reg.x0, slot: slot)
+        barrier(enc)
+        switch config.deltaLayout {
+        case .split:
+            try engine.encodeGemv(enc, delta.qkv!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.qkv)
+            try engine.encodeGemv(enc, delta.zProj!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.z)
+            try engine.encodeGemv(enc, delta.bProj!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.b)
+            try engine.encodeGemv(enc, delta.aProj!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.a)
             barrier(enc)
-            switch config.deltaLayout {
-            case .split:
-                try engine.encodeGemv(enc, delta.qkv!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkv)
-                try engine.encodeGemv(enc, delta.zProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.z)
-                try engine.encodeGemv(enc, delta.bProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.b)
-                try engine.encodeGemv(enc, delta.aProj!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.a)
-                barrier(enc)
-            case .fusedInterleaved:
-                try engine.encodeGemv(enc, delta.qkvz!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.qkvzStage)
-                try engine.encodeGemv(enc, delta.ba!, x: sBuf!, xOff: reg.x0, y: sBuf!, yOff: reg.baStage)
-                barrier(enc)
-                enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
-                struct DeintParams {
-                    var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
-                    var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
-                    var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
-                }
-                var dip = DeintParams(
-                    nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
-                    keyDim: UInt32(keyDim), srcOff: UInt32(reg.qkvzStage), baOff: UInt32(reg.baStage),
-                    qkvOff: UInt32(reg.qkv), zOff: UInt32(reg.z), bOff: UInt32(reg.b), aOff: UInt32(reg.a)
-                )
-                enc.setBuffer(sBuf!, offset: 0, index: 0)
-                setBytesParams(enc, &dip, index: 1)
-                dispatchN(enc, nk)
-                barrier(enc)
+        case .fusedInterleaved:
+            try engine.encodeGemv(enc, delta.qkvz!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.qkvzStage)
+            try engine.encodeGemv(enc, delta.ba!, x: slot.scratch, xOff: slot.base + reg.x0,
+                y: slot.scratch, yOff: slot.base + reg.baStage)
+            barrier(enc)
+            enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
+            struct DeintParams {
+                var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
+                var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
+                var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
             }
-
-            enc.setComputePipelineState(try engine.pipeline("conv_step"))
-            var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim), UInt32(reg.qkv), UInt32(reg.conv))
-            enc.setBuffer(sBuf!, offset: 0, index: 0)
-            enc.setBuffer(fl.hist!, offset: 0, index: 1)
-            enc.setBuffer(fl.convW!, offset: 0, index: 2)
-            setBytesParams(enc, &cp, index: 3)
-            dispatchN(enc, convDim)
-
-            enc.setComputePipelineState(try engine.pipeline("delta_pre"))
-            var dp = SIMD4<UInt32>(UInt32(nv), UInt32(reg.a), UInt32(reg.b), UInt32(reg.gb))
-            enc.setBuffer(sBuf!, offset: 0, index: 0)
-            enc.setBuffer(fl.aLog!, offset: 0, index: 1)
-            enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
-            setBytesParams(enc, &dp, index: 3)
-            dispatchN(enc, nv)
-            barrier(enc)
-
-            let invScale = 1 / Float(dk).squareRoot()
-            try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil, scale: invScale * invScale, eps: 1e-6)
-            try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil, scale: invScale, eps: 1e-6)
-            barrier(enc)
-
-            enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
-            var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
-            enc.setBuffer(sBuf!, offset: reg.conv * 4, index: 0)                    // q
-            enc.setBuffer(sBuf!, offset: (reg.conv + keyDim) * 4, index: 1)         // k
-            enc.setBuffer(sBuf!, offset: (reg.conv + 2 * keyDim) * 4, index: 2)     // v
-            enc.setBuffer(sBuf!, offset: reg.gb * 4, index: 3)                      // g
-            enc.setBuffer(sBuf!, offset: (reg.gb + nv) * 4, index: 4)               // beta
-            enc.setBuffer(fl.state!, offset: 0, index: 5)
-            enc.setBuffer(sBuf!, offset: reg.dy * 4, index: 6)
-            enc.setBuffer(fl.state!, offset: 0, index: 7)
-            setBytesParams(enc, &delp, index: 8)
-            engine.dispatchThreads(
-                enc, threads: MTLSize(width: 32, height: dv, depth: nv),
-                threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
+            var dip = DeintParams(
+                nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(nv / nk), dv: UInt32(dv),
+                keyDim: UInt32(keyDim),
+                srcOff: UInt32(slot.base + reg.qkvzStage), baOff: UInt32(slot.base + reg.baStage),
+                qkvOff: UInt32(slot.base + reg.qkv), zOff: UInt32(slot.base + reg.z),
+                bOff: UInt32(slot.base + reg.b), aOff: UInt32(slot.base + reg.a)
             )
-            barrier(enc)
-
-            enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
-            struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
-            var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
-                         yOff: UInt32(reg.dy), zOff: UInt32(reg.z), outOff: UInt32(reg.dn))
-            enc.setBuffer(sBuf!, offset: 0, index: 0)
-            enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
-            setBytesParams(enc, &gp, index: 2)
-            dispatchRows(enc, rows: nv)
-            barrier(enc)
-
-            try engine.encodeGemv(enc, delta.outProj, x: sBuf!, xOff: reg.dn, y: sBuf!, yOff: reg.r)
-            barrier(enc)
-            var ap = SIMD2<UInt32>(UInt32(D), UInt32(reg.r))
-            enc.setComputePipelineState(try engine.pipeline("add_inplace"))
-            enc.setBuffer(hBuf!, offset: 0, index: 0)
-            enc.setBuffer(sBuf!, offset: 0, index: 1)
-            setBytesParams(enc, &ap, index: 2)
-            dispatchN(enc, D)
+            enc.setBuffer(slot.scratch, offset: 0, index: 0)
+            setBytesParams(enc, &dip, index: 1)
+            dispatchN(enc, nk)
             barrier(enc)
         }
-        try phase(.router) {
-            try encNormCopy(enc, w: fl.postNorm, dstOff: reg.xmoe)
-            barrier(enc)
-            try engine.encodeGemv(enc, moeGate, x: sBuf!, xOff: reg.xmoe, y: sBuf!, yOff: reg.rout)
-        }
+
+        enc.setComputePipelineState(try engine.pipeline("conv_step"))
+        var cp = SIMD4<UInt32>(UInt32(convDim), UInt32(cfg.linearConvKernelDim),
+                               UInt32(slot.base + reg.qkv), UInt32(slot.base + reg.conv))
+        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+        enc.setBuffer(fl.hist!, offset: 0, index: 1)
+        enc.setBuffer(fl.convW!, offset: 0, index: 2)
+        setBytesParams(enc, &cp, index: 3)
+        dispatchN(enc, convDim)
+
+        enc.setComputePipelineState(try engine.pipeline("delta_pre"))
+        var dp = SIMD4<UInt32>(UInt32(nv), UInt32(slot.base + reg.a),
+                               UInt32(slot.base + reg.b), UInt32(slot.base + reg.gb))
+        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+        enc.setBuffer(fl.aLog!, offset: 0, index: 1)
+        enc.setBuffer(fl.dtBias!, offset: 0, index: 2)
+        setBytesParams(enc, &dp, index: 3)
+        dispatchN(enc, nv)
+        barrier(enc)
+
+        let invScale = 1 / Float(dk).squareRoot()
+        try encRMSNorm(enc, off: reg.conv, rows: nk, dim: dk, w: nil,
+                       scale: invScale * invScale, eps: 1e-6, slot: slot)
+        try encRMSNorm(enc, off: reg.conv + keyDim, rows: nk, dim: dk, w: nil,
+                       scale: invScale, eps: 1e-6, slot: slot)
+        barrier(enc)
+
+        enc.setComputePipelineState(try engine.pipeline("gated_delta_step"))
+        var delp = MetalEngine.DeltaParams(T: 1, Hk: UInt32(nk), Hv: UInt32(nv), Dk: UInt32(dk), Dv: UInt32(dv))
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv) * 4, index: 0)            // q
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv + keyDim) * 4, index: 1)   // k
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.conv + 2 * keyDim) * 4, index: 2) // v
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.gb) * 4, index: 3)              // g
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.gb + nv) * 4, index: 4)         // beta
+        enc.setBuffer(fl.state!, offset: 0, index: 5)
+        enc.setBuffer(slot.scratch, offset: (slot.base + reg.dy) * 4, index: 6)
+        enc.setBuffer(fl.state!, offset: 0, index: 7)
+        setBytesParams(enc, &delp, index: 8)
+        engine.dispatchThreads(
+            enc, threads: MTLSize(width: 32, height: dv, depth: nv),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1)
+        )
+        barrier(enc)
+
+        enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
+        struct GNP { var nv: UInt32; var dv: UInt32; var eps: Float; var yOff: UInt32; var zOff: UInt32; var outOff: UInt32 }
+        var gp = GNP(nv: UInt32(nv), dv: UInt32(dv), eps: Float(cfg.rmsNormEps),
+                     yOff: UInt32(slot.base + reg.dy), zOff: UInt32(slot.base + reg.z),
+                     outOff: UInt32(slot.base + reg.dn))
+        enc.setBuffer(slot.scratch, offset: 0, index: 0)
+        enc.setBuffer(fl.deltaNormW!, offset: 0, index: 1)
+        setBytesParams(enc, &gp, index: 2)
+        dispatchRows(enc, rows: nv)
+        barrier(enc)
+
+        try engine.encodeGemv(enc, delta.outProj, x: slot.scratch, xOff: slot.base + reg.dn,
+            y: slot.scratch, yOff: slot.base + reg.r)
+        barrier(enc)
+        var ap = SIMD2<UInt32>(UInt32(D), UInt32(slot.base + reg.r))
+        enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+        enc.setBuffer(slot.hidden, offset: slot.hiddenByteOffset, index: 0)
+        enc.setBuffer(slot.scratch, offset: 0, index: 1)
+        setBytesParams(enc, &ap, index: 2)
+        dispatchN(enc, D)
+        barrier(enc)
     }
 
-    private func attnCoreCPU(layerIndex: Int, state: QwenCPUModel.DecodeState, attn: AttnGPU) -> [Float] {
+    private func attnCoreCPU(
+        layerIndex: Int, state: QwenCPUModel.DecodeState, attn: AttnGPU,
+        position: Int, slot: TokenSlot
+    ) -> [Float] {
         let cfg = config
         let H = cfg.numAttentionHeads, KVH = cfg.numKeyValueHeads, hd = cfg.headDim
         let eps = Float(cfg.rmsNormEps)
-        let past = state.position
-        let qOut = readS(reg.qout, H * hd * 2)
-        var k = readS(reg.knew, KVH * hd)
-        let v = readS(reg.vnew, KVH * hd)
+        let past = position
+        let qOut = readSlot(slot, reg.qout, H * hd * 2)
+        var k = readSlot(slot, reg.knew, KVH * hd)
+        let v = readSlot(slot, reg.vnew, KVH * hd)
 
         var q = [Float](repeating: 0, count: H * hd)
         var gate = [Float](repeating: 0, count: H * hd)

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -1674,10 +1674,11 @@ extension QwenMetalModel {
     /// slot's projection regions and advances the layer's shared conv
     /// history and recurrent state, so chunked callers must encode tokens in
     /// ascending order (the decode core encodes exactly one). Assembled
-    /// from the stage helpers below; the chunked prefill keeps only the
-    /// conv steps per token, batches decay/beta prep, the q/k norms, and
-    /// the gated norm through their stride twins, and runs the gated scan
-    /// once per chunk with T = chunk length (S1b chunked recurrence).
+    /// from the stage helpers below; the chunked prefill batches decay/beta
+    /// prep, the q/k norms, and the gated norm through their stride twins
+    /// and runs each order-sensitive stage as one cross-token scan per
+    /// chunk (conv_scan, and the gated scan with T = chunk length; S1b
+    /// chunked recurrence).
     private func encDeltaRecurrence(
         _ enc: MTLComputeCommandEncoder, fl: FastLayer, slot: TokenSlot
     ) throws {
@@ -1923,9 +1924,9 @@ extension QwenMetalModel {
 // kernels (norms, deinterleave, silu, residual adds, weighted accumulation,
 // attention q prep / KV append) via their batch twins. Every batched row is
 // the single-token kernel's arithmetic verbatim; the order-sensitive
-// recurrent stages keep ascending token order (conv history per token, the
-// gated recurrence as one T=chunk in-dispatch scan), so numerics match the
-// token-major schedule exactly. S2 batches the attention core across the
+// recurrent stages keep ascending token order inside cross-token scans (the
+// conv history and the gated recurrence each advance in one T=chunk
+// in-dispatch scan), so numerics match the token-major schedule exactly. S2 batches the attention core across the
 // chunk's tokens on GPU, including the causal attend: its batch twin derives
 // each token's kvLen from the token grid, and every KV append lands behind a
 // barrier before any token attends.
@@ -2259,12 +2260,11 @@ extension QwenMetalModel {
     /// One DeltaNet layer over the whole chunk (S1b token batching): one
     /// batched input norm, then one batched dispatch per in_proj tensor
     /// covering all tokens, one batched deinterleave, then the chunked
-    /// recurrence (per-token conv steps in ascending order, batched
-    /// decay/beta prep and q/k norms, one T=n gated scan, one batched gated
-    /// norm), then one batched output projection and one batched
-    /// residual add. One token degenerates to exactly the decode core's
-    /// encode stream, keeping the per-token scan alive as the chunked
-    /// path's oracle.
+    /// recurrence (one cross-token conv scan, batched decay/beta prep and
+    /// q/k norms, one T=n gated scan, one batched gated norm), then one
+    /// batched output projection and one batched residual add. One token
+    /// degenerates to exactly the decode core's encode stream, keeping the
+    /// per-token scan alive as the chunked path's oracle.
     private func encChunkDelta(
         _ enc: MTLComputeCommandEncoder, delta: DeltaGPU, fl: FastLayer, tokens n: Int
     ) throws {
@@ -2293,29 +2293,33 @@ extension QwenMetalModel {
         barrier(enc)
     }
 
-    /// The chunk's recurrence stage with the T-step scan (S1b chunked
-    /// recurrence): only the conv steps stay per token in ascending order
-    /// (the conv history is shared state, so a barrier separates consecutive
-    /// tokens); decay/beta prep and the weightless q/k norms are independent
+    /// The chunk's recurrence stage as pure cross-token dispatches (S1b
+    /// chunked recurrence): one conv_scan advances the layer's shared conv
+    /// history through all n tokens in-dispatch — its step loop is the
+    /// chained per-token conv_steps' arithmetic verbatim, history carried
+    /// in registers instead of a barrier-fenced device round trip per
+    /// token; decay/beta prep and the weightless q/k norms are independent
     /// per token and encode once per chunk through their stride twins; one
     /// delta_gather packs the normed rows into the contiguous [T, row]
     /// staging blocks, a single T=n gated_delta_step replaces the n
     /// per-token scans, and one batched gated norm reads the scan's staged y
     /// rows. Every batched row is the single-token kernel's arithmetic
-    /// verbatim and the scan's internal step loop performs the same
+    /// verbatim and both scans' internal step loops perform the same
     /// ascending-order arithmetic the per-token dispatches did — state
     /// carried in f32 registers instead of a per-token f32 device round trip
-    /// — so every y row and the final state are bitwise identical. Ends on a
+    /// — so every conv row, y row, and both final states are bitwise
+    /// identical. Nothing here dispatches per token any more. Ends on a
     /// barrier like the decode core.
     private func encChunkDeltaRecurrence(
         _ enc: MTLComputeCommandEncoder, fl: FastLayer, tokens n: Int
     ) throws {
         let cfg = config
         let valueDim = cfg.valueDim
-        for t in 0..<n {
-            try encConvStep(enc, fl: fl, slot: prefillSlot(t))
-            barrier(enc)   // token t+1's conv reads the advanced history
-        }
+        try engine.encodeConvScan(
+            enc, data: prefillScratchBuf!, hist: fl.hist!, weight: fl.convW!,
+            convDim: cfg.convDim, K: cfg.linearConvKernelDim,
+            inOff: reg.qkv, outOff: reg.conv, slotStride: reg.total, tokens: n)
+        barrier(enc)   // the in-place q/k norms read the scan's conv rows
         // Reads the slots' a/b projection rows (behind encChunkDelta's
         // barrier) and writes gb, disjoint from the conv rows the norms
         // touch in place — one barrier below covers both for the gather.

--- a/Sources/SwiftletCore/SwiftletSession.swift
+++ b/Sources/SwiftletCore/SwiftletSession.swift
@@ -81,6 +81,7 @@ public final class SwiftletSession: @unchecked Sendable {
         print("[SwiftletSession] tokenizer ok; building Metal model...")
         if let gpu = try? QwenMetalModel(modelDir: modelDir, cacheBudgetGB: cacheBudgetGB) {
             model = gpu
+            config = gpu.config
             usesGPU = true
             print("[SwiftletSession] Metal model ready")
         } else {
@@ -88,9 +89,10 @@ public final class SwiftletSession: @unchecked Sendable {
             let cpu = try QwenCPUModel(modelDir: modelDir)
             cpu.retainAllLayers = retainAllLayers
             model = cpu
+            config = cpu.config
             usesGPU = false
         }
-        config = model.config
+        convState = model.makeContext()
         generator = TextGenerator(model: model)
         // Special tokens (think tags, chat markup, FIM markers, vision and
         // tool tags) are never legitimate chat output, but a model pushed off
@@ -133,14 +135,14 @@ public final class SwiftletSession: @unchecked Sendable {
     // extend the cached conversation is decided by comparing message content,
     // not template tokens: the re-rendered template drops the think block from
     // past assistant turns, so token-prefix comparison always diverges.
-    private var convState = QwenCPUModel.DecodeState()
+    private let convState: any InferenceContext
     private var lastMessages: [[String: String]] = []
     private var lastReplyText = ""
     private var statePrimed = false
 
     /// Drops the cached conversation (e.g. when the user starts a new chat).
     public func resetConversation() {
-        convState = QwenCPUModel.DecodeState()
+        convState.reset()
         lastMessages = []
         lastReplyText = ""
         statePrimed = false
@@ -354,7 +356,7 @@ public final class SwiftletSession: @unchecked Sendable {
                     var printed = ""
                     var cleanEnd = false
 
-                    var logits = try self.model.step(suffix, state: self.convState)
+                    var logits = try self.model.step(suffix, context: self.convState)
                     let prefillDone = Date()
 
                     var decodeSeconds = 0.0
@@ -407,7 +409,7 @@ public final class SwiftletSession: @unchecked Sendable {
                             printed = newPrinted
                         }
                         let t0 = Date()
-                        logits = try self.model.step([best], state: self.convState)
+                        logits = try self.model.step([best], context: self.convState)
                         decodeSeconds += -t0.timeIntervalSinceNow
                         if terminated { cleanEnd = true; stopReason = "consumer-cancelled"; break }
                     }

--- a/Sources/SwiftletCore/TextGenerator.swift
+++ b/Sources/SwiftletCore/TextGenerator.swift
@@ -1,21 +1,8 @@
 import Foundation
 
-/// A model that can decode incrementally: CPU reference or Metal runtime.
-public protocol InferenceModel: AnyObject {
-    var config: QwenConfig { get }
-    var modelDir: URL { get }
-    func step(_ tokens: [Int], state: QwenCPUModel.DecodeState) throws -> [Float]
-}
-
-extension QwenCPUModel: InferenceModel {
-    public var modelDir: URL { ckpt.dir }
-}
-
-extension QwenMetalModel: InferenceModel {
-    public var modelDir: URL { ckpt.dir }
-}
-
 /// Engine-agnostic greedy generation loop shared by the CLI and server.
+/// Talks to the model only through InferenceModel: it never sees what the
+/// context holds.
 public final class TextGenerator {
     public let model: any InferenceModel
     public let eosTokens: Set<Int>
@@ -78,20 +65,20 @@ public final class TextGenerator {
     public func generate(promptIds: [Int], maxNew: Int, onToken: (Int) -> Bool) throws -> Stats {
         var stats = Stats()
         stats.promptTokens = promptIds.count
-        let state = QwenCPUModel.DecodeState()
+        let context = model.makeContext()
 
         let prefillStart = Date()
-        var logits = try model.step(promptIds, state: state)
+        var logits = try model.step(promptIds, context: context)
         stats.prefillSeconds = -prefillStart.timeIntervalSinceNow
 
         let decodeStart = Date()
         for _ in 0..<maxNew {
             var best = 0
-            for v in 1..<model.config.vocabSize where logits[v] > logits[best] { best = v }
+            for v in 1..<model.vocabSize where logits[v] > logits[best] { best = v }
             if eosTokens.contains(best) { break }
             stats.generatedTokens += 1
             if !onToken(best) { break }
-            logits = try model.step([best], state: state)
+            logits = try model.step([best], context: context)
         }
         stats.decodeSeconds = -decodeStart.timeIntervalSinceNow
         return stats

--- a/Tests/SwiftletCoreTests/AttentionKernelTests.swift
+++ b/Tests/SwiftletCoreTests/AttentionKernelTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Metal
+import Testing
+@testable import SwiftletCore
+
+/// S2 attention kernels vs the exact CPU math they replace (the fast path's
+/// CPU attention core): query extraction + RMSNorm + partial RoPE, KV append
+/// into position-indexed cache rows (K normed + roped, V verbatim), and gated
+/// GQA softmax attention over the cached rows.
+@Suite struct AttentionKernelTests {
+    struct Geometry {
+        let H: Int      // query heads
+        let KVH: Int    // kv heads
+        let hd: Int     // head dim
+        let rot: Int    // rotary dims
+    }
+
+    /// Test-local copy of the reference partial-RoPE (QwenCPUModel.applyRope
+    /// math with an explicit position per call).
+    static func rope(
+        _ x: inout [Float], heads: Int, hd: Int, rot: Int, theta: Float, position: Int
+    ) {
+        let half = rot / 2
+        for head in 0..<heads {
+            let base = head * hd
+            for j in 0..<half {
+                let invFreq = powf(theta, -Float(2 * j) / Float(rot))
+                let angle = Float(position) * invFreq
+                let c = cosf(angle), sn = sinf(angle)
+                let a = x[base + j]
+                let b = x[base + half + j]
+                x[base + j] = a * c - b * sn
+                x[base + half + j] = b * c + a * sn
+            }
+        }
+    }
+
+    static func maxAbsDiff(_ a: [Float], _ b: [Float]) -> Float {
+        precondition(a.count == b.count)
+        var m: Float = 0
+        for i in a.indices { m = max(m, abs(a[i] - b[i])) }
+        return m
+    }
+
+    /// Runs the three kernels in one command buffer against a scratch layout
+    /// shaped like the fast path's regions, then compares every artifact —
+    /// prepped q, the appended cache rows, and the gated context — to the CPU
+    /// reference. `past` cache rows already hold earlier positions, so the
+    /// softmax really spans history, not just the new token.
+    static func compare(_ geo: Geometry, seed: UInt64) throws {
+        let engine = try MetalEngine()
+        let H = geo.H, KVH = geo.KVH, hd = geo.hd, rot = geo.rot
+        let past = 3
+        let position = past
+        let theta: Float = 10_000_000
+        let eps: Float = 1e-6
+        var rng = MetalKernelTests.Rand(seed)
+
+        // Raw projection outputs for the new token, plus norm weights and a
+        // cache history of already-processed rows.
+        let qout = (0..<H * 2 * hd).map { _ in rng.float() }
+        let knew = (0..<KVH * hd).map { _ in rng.float() }
+        let vnew = (0..<KVH * hd).map { _ in rng.float() }
+        let qNorm = (0..<hd).map { _ in 1 + 0.25 * rng.float() }
+        let kNorm = (0..<hd).map { _ in 1 + 0.25 * rng.float() }
+        let kPast = (0..<past * KVH * hd).map { _ in rng.float() }
+        let vPast = (0..<past * KVH * hd).map { _ in rng.float() }
+
+        // CPU reference: the former attnCoreCPU math, op for op.
+        var qRef = [Float](repeating: 0, count: H * hd)
+        var gate = [Float](repeating: 0, count: H * hd)
+        for head in 0..<H {
+            for i in 0..<hd {
+                qRef[head * hd + i] = qout[head * 2 * hd + i]
+                gate[head * hd + i] = qout[head * 2 * hd + hd + i]
+            }
+        }
+        QwenCPUModel.rmsNorm(&qRef, rows: H, dim: hd, weight: qNorm, eps: eps)
+        var kRef = knew
+        QwenCPUModel.rmsNorm(&kRef, rows: KVH, dim: hd, weight: kNorm, eps: eps)
+        Self.rope(&qRef, heads: H, hd: hd, rot: rot, theta: theta, position: position)
+        Self.rope(&kRef, heads: KVH, hd: hd, rot: rot, theta: theta, position: position)
+        let kAll = kPast + kRef
+        let vAll = vPast + vnew
+        let kvLen = past + 1
+        let scale = 1 / Float(hd).squareRoot()
+        let group = H / KVH
+        var outRef = [Float](repeating: 0, count: H * hd)
+        var scores = [Float](repeating: 0, count: kvLen)
+        for head in 0..<H {
+            let kvHead = head / group
+            for sj in 0..<kvLen {
+                var dot: Float = 0
+                for i in 0..<hd { dot += qRef[head * hd + i] * kAll[(sj * KVH + kvHead) * hd + i] }
+                scores[sj] = dot * scale
+            }
+            QwenCPUModel.softmaxRow(&scores, base: 0, count: kvLen)
+            for sj in 0..<kvLen {
+                let p = scores[sj]
+                let vBase = (sj * KVH + kvHead) * hd
+                for i in 0..<hd { outRef[head * hd + i] += p * vAll[vBase + i] }
+            }
+        }
+        for i in 0..<outRef.count { outRef[i] *= QwenCPUModel.sigmoid(gate[i]) }
+
+        // GPU: fast-path-shaped scratch regions in one shared buffer.
+        let qoutOff = 0
+        let kOff = qoutOff + H * 2 * hd
+        let vOff = kOff + KVH * hd
+        let qprepOff = vOff + KVH * hd
+        let outOff = qprepOff + H * hd
+        let total = outOff + H * hd
+        var scratchInit = [Float](repeating: 0, count: total)
+        scratchInit.replaceSubrange(qoutOff..<qoutOff + qout.count, with: qout)
+        scratchInit.replaceSubrange(kOff..<kOff + knew.count, with: knew)
+        scratchInit.replaceSubrange(vOff..<vOff + vnew.count, with: vnew)
+        let scratch = engine.makeBuffer(scratchInit)
+        let qNormBuf = engine.makeBuffer(qNorm)
+        let kNormBuf = engine.makeBuffer(kNorm)
+        let kCache = engine.makeBuffer(kPast + [Float](repeating: 0, count: KVH * hd))
+        let vCache = engine.makeBuffer(vPast + [Float](repeating: 0, count: KVH * hd))
+
+        let cb = engine.queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+        try engine.encodeAttnQPrep(
+            enc, data: scratch, weight: qNormBuf,
+            heads: H, headDim: hd, rotaryDims: rot, eps: eps, ropeTheta: theta,
+            position: position, srcOff: qoutOff, dstOff: qprepOff
+        )
+        try engine.encodeAttnKVAppend(
+            enc, data: scratch, weight: kNormBuf, kCache: kCache, vCache: vCache,
+            kvHeads: KVH, headDim: hd, rotaryDims: rot, eps: eps, ropeTheta: theta,
+            position: position, kSrcOff: kOff, vSrcOff: vOff
+        )
+        enc.memoryBarrier(scope: .buffers)
+        try engine.encodeAttnDecode(
+            enc, data: scratch, kCache: kCache, vCache: vCache,
+            heads: H, kvHeads: KVH, headDim: hd, kvLen: kvLen,
+            qOff: qprepOff, qoutOff: qoutOff, outOff: outOff
+        )
+        enc.endEncoding()
+        cb.commit()
+        cb.waitUntilCompleted()
+        #expect(cb.status == .completed, "attention kernel command buffer failed")
+
+        func read(_ off: Int, _ n: Int) -> [Float] {
+            Array(UnsafeBufferPointer(
+                start: scratch.contents().advanced(by: off * 4)
+                    .bindMemory(to: Float.self, capacity: n),
+                count: n))
+        }
+        func readCache(_ buf: MTLBuffer, _ row: Int, _ n: Int) -> [Float] {
+            Array(UnsafeBufferPointer(
+                start: buf.contents().advanced(by: row * n * 4)
+                    .bindMemory(to: Float.self, capacity: n),
+                count: n))
+        }
+
+        let label = "H=\(H) KVH=\(KVH) hd=\(hd) rot=\(rot)"
+        let qDiff = Self.maxAbsDiff(read(qprepOff, H * hd), qRef)
+        #expect(qDiff < 1e-5, "\(label): prepped q maxAbsDiff \(qDiff)")
+        let kDiff = Self.maxAbsDiff(readCache(kCache, past, KVH * hd), kRef)
+        #expect(kDiff < 1e-5, "\(label): appended K row maxAbsDiff \(kDiff)")
+        let vDiff = Self.maxAbsDiff(readCache(vCache, past, KVH * hd), vnew)
+        #expect(vDiff == 0, "\(label): appended V row must copy verbatim, diff \(vDiff)")
+        let pastKDiff = Self.maxAbsDiff(readCache(kCache, 0, past * KVH * hd), kPast)
+        #expect(pastKDiff == 0, "\(label): append disturbed earlier K rows")
+        let outDiff = Self.maxAbsDiff(read(outOff, H * hd), outRef)
+        #expect(outDiff < 1e-5, "\(label): gated attention output maxAbsDiff \(outDiff)")
+    }
+
+    /// Tiny-fixture geometry: exercises head dims below one SIMD width.
+    @Test func attentionKernelsMatchCPUCoreTinyHeads() throws {
+        try Self.compare(Geometry(H: 4, KVH: 2, hd: 16, rot: 4), seed: 11)
+    }
+
+    /// 80B-class geometry: multi-register accumulators (hd > 32) and a
+    /// deeper GQA group.
+    @Test func attentionKernelsMatchCPUCoreWideHeads() throws {
+        try Self.compare(Geometry(H: 8, KVH: 2, hd: 128, rot: 32), seed: 23)
+    }
+}

--- a/Tests/SwiftletCoreTests/AttentionKernelTests.swift
+++ b/Tests/SwiftletCoreTests/AttentionKernelTests.swift
@@ -47,10 +47,9 @@ import Testing
     /// prepped q, the appended cache rows, and the gated context — to the CPU
     /// reference. `past` cache rows already hold earlier positions, so the
     /// softmax really spans history, not just the new token.
-    static func compare(_ geo: Geometry, seed: UInt64) throws {
+    static func compare(_ geo: Geometry, seed: UInt64, past: Int = 3) throws {
         let engine = try MetalEngine()
         let H = geo.H, KVH = geo.KVH, hd = geo.hd, rot = geo.rot
-        let past = 3
         let position = past
         let theta: Float = 10_000_000
         let eps: Float = 1e-6
@@ -178,5 +177,18 @@ import Testing
     /// deeper GQA group.
     @Test func attentionKernelsMatchCPUCoreWideHeads() throws {
         try Self.compare(Geometry(H: 8, KVH: 2, hd: 128, rot: 32), seed: 23)
+    }
+
+    /// A KV history long enough that every cooperating simdgroup in the
+    /// attend owns many cache rows, with a row count off every power-of-two
+    /// grid so the tail is uneven — the softmax must span all of it.
+    @Test func attentionKernelsMatchCPUCoreLongHistory() throws {
+        try Self.compare(Geometry(H: 4, KVH: 2, hd: 128, rot: 32), seed: 31, past: 133)
+    }
+
+    /// A head dim off the float4 grid (18 % 4 != 0) keeps the lane-strided
+    /// scalar reads honest for any vectorized-load fast path.
+    @Test func attentionKernelsMatchCPUCoreOddHeadDim() throws {
+        try Self.compare(Geometry(H: 4, KVH: 2, hd: 18, rot: 6), seed: 37, past: 9)
     }
 }

--- a/Tests/SwiftletCoreTests/ConversationStateTests.swift
+++ b/Tests/SwiftletCoreTests/ConversationStateTests.swift
@@ -1,0 +1,356 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S6: a context can be written to a versioned binary snapshot and restored
+/// into a fresh model instance, continuing bitwise; anything that does not
+/// belong to this model, version, geometry, or dtype is refused.
+@Suite struct ConversationStateTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+    static let q4 = fixturesDir.appendingPathComponent("tiny-model-q4")
+    static let f32 = fixturesDir.appendingPathComponent("tiny-model")
+
+    static let prompt = [1, 5, 9, 42, 7]
+    static let savedAfter = 4      // greedy tokens decoded before the snapshot
+    static let continued = 5       // greedy tokens decoded after it
+
+    static func argmax(_ v: [Float]) -> Int {
+        var b = 0
+        for i in 1..<v.count where v[i] > v[b] { b = i }
+        return b
+    }
+
+    struct Trace: Equatable {
+        var tokens: [Int] = []
+        var logits: [[Float]] = []
+    }
+
+    /// Greedy-decodes `count` tokens from `logits`, recording every logits
+    /// vector and pick.
+    static func decode(_ model: any InferenceModel, _ ctx: any InferenceContext,
+                       from logits: [Float], count: Int) throws -> (Trace, [Float]) {
+        var trace = Trace()
+        var logits = logits
+        for _ in 0..<count {
+            let t = argmax(logits)
+            trace.tokens.append(t)
+            logits = try model.step([t], context: ctx)
+            trace.logits.append(logits)
+        }
+        return (trace, logits)
+    }
+
+    /// The uninterrupted reference: prompt, then savedAfter + continued
+    /// greedy tokens on one context.
+    static func uninterrupted(_ model: any InferenceModel) throws -> Trace {
+        let ctx = model.makeContext()
+        let first = try model.step(prompt, context: ctx)
+        let (a, mid) = try decode(model, ctx, from: first, count: savedAfter)
+        let (b, _) = try decode(model, ctx, from: mid, count: continued)
+        return Trace(tokens: a.tokens + b.tokens, logits: a.logits + b.logits)
+    }
+
+    /// Same run, snapshotting after savedAfter tokens and finishing on a
+    /// fresh model instance restored from the bytes.
+    static func interrupted(
+        _ model: any PersistableInferenceModel, fresh: () throws -> any PersistableInferenceModel
+    ) throws -> (Trace, Data) {
+        let ctx = model.makeContext()
+        let first = try model.step(prompt, context: ctx)
+        let (a, mid) = try decode(model, ctx, from: first, count: savedAfter)
+        let data = try model.snapshot(of: ctx)
+        let reopened = try fresh()
+        let restored = try reopened.restoreContext(from: data)
+        #expect(restored.position == ctx.position)
+        let (b, _) = try decode(reopened, restored, from: mid, count: continued)
+        return (Trace(tokens: a.tokens + b.tokens, logits: a.logits + b.logits), data)
+    }
+
+    // MARK: - Round trips
+
+    @Test func cpuRoundTripIsBitwise() throws {
+        let cpu = try QwenCPUModel(modelDir: Self.q4)
+        cpu.retainAllLayers = true
+        let reference = try Self.uninterrupted(cpu)
+        let (resumed, _) = try Self.interrupted(cpu) {
+            let m = try QwenCPUModel(modelDir: Self.q4)
+            m.retainAllLayers = true
+            return m
+        }
+        #expect(resumed.tokens == reference.tokens, "CPU: greedy tokens diverge after restore")
+        #expect(resumed.logits == reference.logits, "CPU: logits diverge after restore")
+        #expect(reference.tokens.count == Self.savedAfter + Self.continued)
+    }
+
+    @Test func metalRoundTripIsBitwise() throws {
+        let gpu = try QwenMetalModel(modelDir: Self.q4)
+        let reference = try Self.uninterrupted(gpu)
+        let (resumed, _) = try Self.interrupted(gpu) { try QwenMetalModel(modelDir: Self.q4) }
+        #expect(resumed.tokens == reference.tokens, "Metal: greedy tokens diverge after restore")
+        #expect(resumed.logits == reference.logits, "Metal: logits diverge after restore")
+    }
+
+    /// The layer-major chunked prefill and a snapshot taken mid-prompt (no
+    /// decode yet) must restore the same as the decode-time snapshot.
+    @Test func metalSnapshotAfterChunkedPrefillRestoresBitwise() throws {
+        let long = Array(repeating: Self.prompt, count: 3).flatMap { $0 }   // 15 tokens
+        let gpu = try QwenMetalModel(modelDir: Self.q4)
+        gpu.prefillMode = .layerMajor(chunkTokens: 4)                      // crosses chunks
+        let ctx = gpu.makeContext()
+        let first = try gpu.step(long, context: ctx)
+        let (reference, _) = try Self.decode(gpu, ctx, from: first, count: 4)
+
+        let ctx2 = gpu.makeContext()
+        let first2 = try gpu.step(long, context: ctx2)
+        let data = try gpu.snapshot(of: ctx2)
+        let reopened = try QwenMetalModel(modelDir: Self.q4)
+        let restored = try reopened.restoreContext(from: data)
+        let (resumed, _) = try Self.decode(reopened, restored, from: first2, count: 4)
+        #expect(resumed == reference, "Metal: chunked-prefill snapshot diverges after restore")
+    }
+
+    /// Which bytes the Metal snapshot holds, proven against the GPU: the KV
+    /// sections equal a direct readback of the GPU KV rows (the mirror is a
+    /// memcpy of them), and the conv tail / delta state sections equal a
+    /// direct readback of the per-layer GPU buffers.
+    @Test func metalSnapshotMatchesDirectGPUReadback() throws {
+        let gpu = try QwenMetalModel(modelDir: Self.q4)
+        let ctx = gpu.makeQwenContext()
+        let first = try gpu.step(Self.prompt, context: ctx)
+        _ = try Self.decode(gpu, ctx, from: first, count: 3)
+        let position = ctx.position
+        #expect(gpu.boundContext === ctx, "context is not the bound one")
+
+        let snapshot = try ConversationState.decode(try gpu.snapshot(of: ctx))
+        #expect(snapshot.position == position)
+        var kvLayers = 0, deltaLayers = 0
+        for li in 0..<gpu.config.numHiddenLayers {
+            if gpu.config.isLinearLayer(li) {
+                deltaLayers += 1
+                let hist = try #require(gpu.fastLayers[li].hist)
+                let state = try #require(gpu.fastLayers[li].state)
+                let histFloats = Array(UnsafeBufferPointer(
+                    start: hist.contents().bindMemory(to: Float.self, capacity: hist.length / 4),
+                    count: hist.length / 4))
+                let stateFloats = Array(UnsafeBufferPointer(
+                    start: state.contents().bindMemory(to: Float.self, capacity: state.length / 4),
+                    count: state.length / 4))
+                #expect(snapshot.section(layer: li, kind: .convTail)?.values == histFloats,
+                        "layer \(li): conv tail section is not the GPU history")
+                #expect(snapshot.section(layer: li, kind: .deltaState)?.values == stateFloats,
+                        "layer \(li): delta state section is not the GPU recurrence")
+            } else {
+                kvLayers += 1
+                let rows = try #require(gpu.attentionKVCacheRows(layer: li, count: position))
+                #expect(snapshot.section(layer: li, kind: .k)?.values == rows.k,
+                        "layer \(li): K section is not the GPU KV rows")
+                #expect(snapshot.section(layer: li, kind: .v)?.values == rows.v,
+                        "layer \(li): V section is not the GPU KV rows")
+            }
+        }
+        #expect(kvLayers > 0 && deltaLayers > 0)
+        #expect(snapshot.sections.count == 2 * kvLayers + 2 * deltaLayers)
+        // Snapshotting did not disturb the live context: the next step still
+        // matches a never-snapshotted twin.
+        let twin = gpu.makeQwenContext()
+        let twinFirst = try gpu.step(Self.prompt, context: twin)
+        let (twinTrace, _) = try Self.decode(gpu, twin, from: twinFirst, count: 3)
+        let next = try gpu.step([twinTrace.tokens.last!], context: ctx)
+        let twinNext = try gpu.step([twinTrace.tokens.last!], context: twin)
+        #expect(next == twinNext, "snapshot disturbed the bound context")
+    }
+
+    /// The format is engine-neutral: a Metal snapshot restores into the CPU
+    /// reference (same checkpoint) and continues within the engines' usual
+    /// parity band. Not bitwise: the state itself carries GPU-vs-CPU
+    /// accumulation noise.
+    @Test func metalSnapshotRestoresIntoCPUReference() throws {
+        let gpu = try QwenMetalModel(modelDir: Self.q4)
+        let ctx = gpu.makeContext()
+        let first = try gpu.step(Self.prompt, context: ctx)
+        let (_, gpuLogits) = try Self.decode(gpu, ctx, from: first, count: 2)
+        let data = try gpu.snapshot(of: ctx)
+
+        let cpu = try QwenCPUModel(modelDir: Self.q4)
+        cpu.retainAllLayers = true
+        let restored = try cpu.restoreContext(from: data)
+        let next = Self.argmax(gpuLogits)
+        let cpuNext = try cpu.step([next], context: restored)
+        let gpuNext = try gpu.step([next], context: ctx)
+        let diff = MetalModelTests.maxAbsDiff(cpuNext, gpuNext)
+        #expect(diff < 2e-3, "CPU continuation of a Metal snapshot maxAbsDiff \(diff)")
+        #expect(Self.argmax(cpuNext) == Self.argmax(gpuNext))
+    }
+
+    // MARK: - Format pins
+
+    @Test func headerLayoutIsPinned() throws {
+        let cpu = try QwenCPUModel(modelDir: Self.q4)
+        let ctx = cpu.makeContext()
+        _ = try cpu.step(Self.prompt, context: ctx)
+        let data = try cpu.snapshot(of: ctx)
+        func u32(_ off: Int) -> UInt32 {
+            data.subdata(in: off..<off + 4).withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+        }
+        func u64(_ off: Int) -> UInt64 {
+            data.subdata(in: off..<off + 8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
+        }
+        #expect(Array(data.prefix(8)) == Array("SWLSTATE".utf8))
+        #expect(u32(8) == 1, "format version")
+        #expect(u32(12) == 128, "header length")
+        #expect(u32(16) == 1, "dtype float32")
+        #expect(u32(20) == 2, "identity scheme: safetensors checkpoint")
+        let cfg = cpu.config
+        let geometry: [Int] = [
+            cfg.numHiddenLayers, cfg.fullAttentionInterval, cfg.numKeyValueHeads, cfg.headDim,
+            cfg.linearNumValueHeads, cfg.linearNumKeyHeads, cfg.linearKeyHeadDim,
+            cfg.linearValueHeadDim, cfg.linearConvKernelDim, cfg.hiddenSize, cfg.vocabSize,
+        ]
+        for (i, g) in geometry.enumerated() {
+            #expect(u32(56 + 4 * i) == UInt32(g), "geometry field \(i)")
+        }
+        #expect(u64(100) == UInt64(Self.prompt.count), "position")
+        let attention = (0..<cfg.numHiddenLayers).filter { !cfg.isLinearLayer($0) }.count
+        let linear = cfg.numHiddenLayers - attention
+        #expect(u32(108) == UInt32(2 * attention + 2 * linear), "section count")
+        #expect(u64(112) == UInt64(data.count), "total byte length")
+        #expect(data.count > 128 + 32)
+        // Same context, same bytes: the snapshot is deterministic.
+        #expect(try cpu.snapshot(of: ctx) == data)
+        // An identity that does not depend on which engine wrote it.
+        let gpu = try QwenMetalModel(modelDir: Self.q4)
+        let gctx = gpu.makeContext()
+        _ = try gpu.step(Self.prompt, context: gctx)
+        let gdata = try gpu.snapshot(of: gctx)
+        #expect(gdata.subdata(in: 0..<100) == data.subdata(in: 0..<100),
+                "CPU and Metal snapshots of one checkpoint disagree on identity or geometry")
+    }
+
+    @Test func emptyContextRoundTrips() throws {
+        let cpu = try QwenCPUModel(modelDir: Self.q4)
+        let data = try cpu.snapshot(of: cpu.makeContext())
+        let restored = try cpu.restoreContext(from: data)
+        #expect(restored.position == 0)
+        let fresh = try cpu.step(Self.prompt, context: cpu.makeContext())
+        #expect(try cpu.step(Self.prompt, context: restored) == fresh)
+    }
+
+    // MARK: - Refusals
+
+    static func snapshotBytes() throws -> (QwenCPUModel, Data) {
+        let cpu = try QwenCPUModel(modelDir: Self.q4)
+        let ctx = cpu.makeContext()
+        _ = try cpu.step(Self.prompt, context: ctx)
+        return (cpu, try cpu.snapshot(of: ctx))
+    }
+
+    /// Rewrites bytes in the header and re-signs the trailer, so the refusal
+    /// under test is the semantic one, not the digest.
+    static func forged(_ data: Data, at offset: Int, u32 value: UInt32) -> Data {
+        var body = data.subdata(in: 0..<data.count - 32)
+        var le = value.littleEndian
+        withUnsafeBytes(of: &le) { body.replaceSubrange(offset..<offset + 4, with: $0) }
+        return ConversationState.signed(body)
+    }
+
+    @Test func refusesBadMagic() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        var bad = data
+        bad.replaceSubrange(0..<8, with: Array("NOTSTATE".utf8))
+        #expect(throws: ConversationStateError.badMagic) {
+            _ = try cpu.restoreContext(from: bad)
+        }
+        #expect(throws: ConversationStateError.badMagic) {
+            _ = try cpu.restoreContext(from: Data([1, 2, 3]))
+        }
+    }
+
+    @Test func refusesUnsupportedVersion() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        let bad = Self.forged(data, at: 8, u32: 2)
+        #expect(throws: ConversationStateError.unsupportedVersion(found: 2, supported: 1)) {
+            _ = try cpu.restoreContext(from: bad)
+        }
+    }
+
+    @Test func refusesTruncatedAndCorruptBytes() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        #expect(throws: ConversationStateError.truncated) {
+            _ = try cpu.restoreContext(from: data.prefix(data.count - 1))
+        }
+        #expect(throws: ConversationStateError.truncated) {
+            _ = try cpu.restoreContext(from: data.prefix(200))
+        }
+        var flipped = data
+        flipped[200] ^= 0x40
+        #expect(throws: ConversationStateError.corrupt("digest mismatch")) {
+            _ = try cpu.restoreContext(from: flipped)
+        }
+    }
+
+    @Test func refusesAnotherModel() throws {
+        let (_, data) = try Self.snapshotBytes()
+        // Same geometry, different checkpoint bytes (f32 vs int4).
+        let other = try QwenCPUModel(modelDir: Self.f32)
+        #expect(throws: ConversationStateError.self) {
+            _ = try other.restoreContext(from: data)
+        }
+        do {
+            _ = try other.restoreContext(from: data)
+            Issue.record("restore into another checkpoint succeeded")
+        } catch let error as ConversationStateError {
+            guard case .modelMismatch = error else {
+                Issue.record("expected modelMismatch, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test func refusesGeometryMismatch() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        // vocabSize shapes no section, so this reaches the geometry compare.
+        let vocab = cpu.config.vocabSize
+        let bad = Self.forged(data, at: 56 + 4 * 10, u32: UInt32(vocab + 1))
+        #expect(throws: ConversationStateError.geometryMismatch(
+            field: "vocabSize", expected: vocab, found: vocab + 1)
+        ) {
+            _ = try cpu.restoreContext(from: bad)
+        }
+        // A layer count the sections cannot satisfy is refused structurally,
+        // before any model is consulted.
+        let layers = Self.forged(data, at: 56, u32: UInt32(cpu.config.numHiddenLayers + 1))
+        #expect(throws: ConversationStateError.corrupt("layer 8 missing convTail")) {
+            _ = try cpu.restoreContext(from: layers)
+        }
+    }
+
+    @Test func refusesDtypeMismatch() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        let bad = Self.forged(data, at: 16, u32: 2)
+        #expect(throws: ConversationStateError.dtypeMismatch(found: 2)) {
+            _ = try cpu.restoreContext(from: bad)
+        }
+    }
+
+    @Test func refusesSectionThatDoesNotFitPosition() throws {
+        let (cpu, data) = try Self.snapshotBytes()
+        // Claim one more position than the KV sections hold.
+        let bad = Self.forged(data, at: 100, u32: UInt32(Self.prompt.count + 1))
+        #expect(throws: ConversationStateError.self) {
+            _ = try cpu.restoreContext(from: bad)
+        }
+    }
+
+    @Test func refusesSnapshotOfForeignContext() throws {
+        let a = try QwenCPUModel(modelDir: Self.q4)
+        let b = try QwenCPUModel(modelDir: Self.q4)
+        let ctx = a.makeContext()
+        #expect(throws: InferenceContextError.foreignContext) {
+            _ = try b.snapshot(of: ctx)
+        }
+    }
+}

--- a/Tests/SwiftletCoreTests/IncrementalDecodeTests.swift
+++ b/Tests/SwiftletCoreTests/IncrementalDecodeTests.swift
@@ -21,9 +21,9 @@ import Testing
         let fullLast = Array(full.logits[(tokens.count - 1) * V..<tokens.count * V])
 
         // Prefill 6, then decode 4 one at a time.
-        let state = QwenCPUModel.DecodeState()
-        var logits = try model.step(Array(tokens[0..<6]), state: state)
-        for t in tokens[6...] { logits = try model.step([t], state: state) }
+        let state = model.makeQwenContext()
+        var logits = try model.step(Array(tokens[0..<6]), context: state)
+        for t in tokens[6...] { logits = try model.step([t], context: state) }
         #expect(state.position == tokens.count)
 
         var maxDiff: Float = 0
@@ -31,9 +31,9 @@ import Testing
         #expect(maxDiff < 1e-4, "incremental vs whole-sequence logits maxAbsDiff \(maxDiff)")
 
         // Pure token-by-token from scratch too.
-        let s2 = QwenCPUModel.DecodeState()
+        let s2 = model.makeQwenContext()
         var logits2 = [Float]()
-        for t in tokens { logits2 = try model.step([t], state: s2) }
+        for t in tokens { logits2 = try model.step([t], context: s2) }
         maxDiff = 0
         for i in 0..<V { maxDiff = max(maxDiff, abs(logits2[i] - fullLast[i])) }
         #expect(maxDiff < 1e-4, "token-by-token vs whole-sequence logits maxAbsDiff \(maxDiff)")
@@ -45,14 +45,14 @@ import Testing
         let V = model.config.vocabSize
 
         func generate() throws -> [Int] {
-            let state = QwenCPUModel.DecodeState()
-            var logits = try model.step([1, 5, 9], state: state)
+            let state = model.makeQwenContext()
+            var logits = try model.step([1, 5, 9], context: state)
             var out: [Int] = []
             for _ in 0..<8 {
                 var best = 0
                 for v in 1..<V where logits[v] > logits[best] { best = v }
                 out.append(best)
-                logits = try model.step([best], state: state)
+                logits = try model.step([best], context: state)
             }
             return out
         }

--- a/Tests/SwiftletCoreTests/InferenceContextTests.swift
+++ b/Tests/SwiftletCoreTests/InferenceContextTests.swift
@@ -134,4 +134,60 @@ import Testing
         let gpuRuns = try run(gpu)
         #expect(gpuRuns.fresh == gpuRuns.reused, "Metal: reset context diverges from fresh")
     }
+
+    /// One model, two live contexts, stepped alternately, must produce the
+    /// same logits and KV rows as each sequence run alone on that model.
+    /// On the Metal fast path the bound context's conv history and delta
+    /// recurrence live in GPU buffers, so a switch has to capture them into
+    /// the outgoing context and restore the incoming one's (plus its KV
+    /// rows, which the other context overwrote at the same positions).
+    @Test func interleavedContextsMatchIsolatedRuns() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let a = [1, 5, 9, 42, 7, 99]
+        let b = [3, 17, 64, 2, 11, 5]
+
+        func isolated(_ model: any InferenceModel, _ seq: [Int]) throws
+            -> (logits: [[Float]], context: QwenInferenceContext) {
+            let ctx = model.makeContext()
+            // Multi-token prefill then single-token decode: both step shapes.
+            var out = [try model.step(Array(seq[0..<3]), context: ctx)]
+            for t in seq[3...] { out.append(try model.step([t], context: ctx)) }
+            return (out, ctx as! QwenInferenceContext)
+        }
+
+        func interleaved(_ model: any InferenceModel) throws
+            -> (a: [[Float]], b: [[Float]], ctxA: QwenInferenceContext, ctxB: QwenInferenceContext) {
+            let ctxA = model.makeContext()
+            let ctxB = model.makeContext()
+            var outA = [try model.step(Array(a[0..<3]), context: ctxA)]
+            var outB = [try model.step(Array(b[0..<3]), context: ctxB)]
+            for i in 3..<a.count {
+                outA.append(try model.step([a[i]], context: ctxA))
+                outB.append(try model.step([b[i]], context: ctxB))
+            }
+            return (outA, outB, ctxA as! QwenInferenceContext, ctxB as! QwenInferenceContext)
+        }
+
+        func check(_ model: any InferenceModel, label: String) throws {
+            let refA = try isolated(model, a)
+            let refB = try isolated(model, b)
+            let mixed = try interleaved(model)
+            #expect(mixed.a == refA.logits, "\(label): sequence A diverges when interleaved")
+            #expect(mixed.b == refB.logits, "\(label): sequence B diverges when interleaved")
+            #expect(mixed.ctxA.position == a.count && mixed.ctxB.position == b.count)
+            for (layer, ref) in refA.context.kv {
+                let got = try #require(mixed.ctxA.kv[layer], "\(label): A lost KV layer \(layer)")
+                #expect(got.k == ref.k && got.v == ref.v, "\(label): A KV layer \(layer) diverged")
+            }
+            for (layer, ref) in refB.context.kv {
+                let got = try #require(mixed.ctxB.kv[layer], "\(label): B lost KV layer \(layer)")
+                #expect(got.k == ref.k && got.v == ref.v, "\(label): B KV layer \(layer) diverged")
+            }
+        }
+
+        let cpu = try QwenCPUModel(modelDir: dir)
+        cpu.retainAllLayers = true
+        try check(cpu, label: "CPU")
+        try check(try QwenMetalModel(modelDir: dir), label: "Metal")
+    }
 }

--- a/Tests/SwiftletCoreTests/InferenceContextTests.swift
+++ b/Tests/SwiftletCoreTests/InferenceContextTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S7a: the public model protocol hands callers an opaque, model-owned
+/// context instead of Qwen's decode state. These tests pin the seam from
+/// both sides — a non-Qwen model can implement the protocol and drive the
+/// shared generator, and the Qwen models honour the context lifecycle
+/// bitwise.
+@Suite struct InferenceContextTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    // MARK: - Protocol leak checks
+
+    /// A stand-in backend that names no Qwen type anywhere. Its context is a
+    /// plain counter and its "logits" are a deterministic function of the
+    /// tokens fed so far, so the generator's output is predictable.
+    final class CounterContext: InferenceContext {
+        private(set) var position = 0
+        var fed: [Int] = []
+        func reset() { position = 0; fed = [] }
+        func advance(_ tokens: [Int]) { fed += tokens; position += tokens.count }
+    }
+
+    final class CounterModel: InferenceModel {
+        let vocabSize = 16
+        // A directory that holds no generation_config.json, so the
+        // generator's EOS lookup finds nothing (no stop tokens).
+        let modelDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swiftlet-counter-model-\(UUID().uuidString)")
+        func makeContext() -> any InferenceContext { CounterContext() }
+        func step(_ tokens: [Int], context: any InferenceContext) throws -> [Float] {
+            guard let ctx = context as? CounterContext else {
+                throw InferenceContextError.foreignContext
+            }
+            ctx.advance(tokens)
+            // Next token = (sum of everything fed so far) mod vocab, as a
+            // one-hot logit vector.
+            var logits = [Float](repeating: 0, count: vocabSize)
+            logits[ctx.fed.reduce(0, +) % vocabSize] = 1
+            return logits
+        }
+    }
+
+    /// Compile-level proof that the protocol is implementable without any
+    /// Qwen type, plus a runtime check that the engine-agnostic generator
+    /// really only uses the protocol: it must drive the stand-in end to end.
+    @Test func protocolIsImplementableWithoutQwenTypes() throws {
+        let model = CounterModel()
+        let generator = TextGenerator(model: model)
+        var out: [Int] = []
+        try generator.generate(promptIds: [3, 4], maxNew: 4) { out.append($0); return true }
+        // fed=[3,4] -> 7; fed+=[7] -> 14; fed+=[14] -> 28%16=12; fed+=[12] -> 40%16=8
+        #expect(out == [7, 14, 12, 8])
+    }
+
+    /// The protocol declarations themselves must not mention a Qwen type.
+    /// Reads the source because Swift has no reflection over protocol
+    /// requirements; the file is small and holds nothing else.
+    @Test func protocolDeclarationsNameNoQwenType() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/SwiftletCore/InferenceModel.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+        #expect(text.contains("protocol InferenceModel"), "protocol file moved?")
+        #expect(text.contains("protocol InferenceContext"), "protocol file moved?")
+        #expect(!text.contains("Qwen"), "InferenceModel.swift names a Qwen type")
+        #expect(!text.contains("DecodeState"), "InferenceModel.swift names the old decode state")
+    }
+
+    /// A context belongs to the model instance that made it. Handing it to
+    /// another instance is refused rather than silently mixing state.
+    @Test func foreignContextIsRefused() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let a = try QwenCPUModel(modelDir: dir)
+        let b = try QwenCPUModel(modelDir: dir)
+        let ctx = a.makeContext()
+        _ = try a.step([1], context: ctx)
+        #expect(throws: InferenceContextError.self) {
+            _ = try b.step([5], context: ctx)
+        }
+        let gpuA = try QwenMetalModel(modelDir: dir)
+        let gpuB = try QwenMetalModel(modelDir: dir)
+        let gpuCtx = gpuA.makeContext()
+        _ = try gpuA.step([1], context: gpuCtx)
+        #expect(throws: InferenceContextError.self) {
+            _ = try gpuB.step([5], context: gpuCtx)
+        }
+        // And a CPU context is not a Metal context.
+        #expect(throws: InferenceContextError.self) {
+            _ = try gpuA.step([5], context: ctx)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// create -> step -> reset -> step must reproduce a fresh context's
+    /// logits bitwise on both engines: reset really discards KV rows, conv
+    /// history, recurrence, and position.
+    @Test func resetReproducesFreshContextBitwise() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let prompt = [1, 5, 9, 42]
+        let follow = [7, 99]
+
+        func run(_ model: any InferenceModel) throws -> (fresh: [[Float]], reused: [[Float]]) {
+            let fresh = model.makeContext()
+            var freshLogits = [try model.step(prompt, context: fresh)]
+            for t in follow { freshLogits.append(try model.step([t], context: fresh)) }
+
+            let reused = model.makeContext()
+            _ = try model.step([3, 17, 64], context: reused)
+            _ = try model.step([2], context: reused)
+            #expect(reused.position == 4)
+            reused.reset()
+            #expect(reused.position == 0)
+            var reusedLogits = [try model.step(prompt, context: reused)]
+            for t in follow { reusedLogits.append(try model.step([t], context: reused)) }
+            #expect(reused.position == prompt.count + follow.count)
+            return (freshLogits, reusedLogits)
+        }
+
+        let cpu = try QwenCPUModel(modelDir: dir)
+        cpu.retainAllLayers = true
+        let cpuRuns = try run(cpu)
+        #expect(cpuRuns.fresh == cpuRuns.reused, "CPU: reset context diverges from fresh")
+
+        let gpu = try QwenMetalModel(modelDir: dir)
+        let gpuRuns = try run(gpu)
+        #expect(gpuRuns.fresh == gpuRuns.reused, "Metal: reset context diverges from fresh")
+    }
+}

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -17,22 +17,34 @@ import Testing
 
     /// Layer-major token-batched baseline: one decode-token-shaped buffer
     /// sequence per chunk (the S2 9-buffer shape), with the dispatch cost
-    /// decomposed into per-token kernels (norms, deinterleave, recurrence,
-    /// attention core, silu, residual adds, weighted accumulation), per-chunk
-    /// token-batched projections (each dense/shared/router GEMV encodes once
-    /// per chunk regardless of chunk size), and per-union-expert batched
-    /// GEMVs (gate/up/down encode once per (expert, projection) per chunk).
-    /// Exact assertions, S3a style.
+    /// decomposed into per-token kernels (the order-sensitive DeltaNet
+    /// recurrence chain and the per-token causal attends), per-chunk batched
+    /// dispatches (each dense/shared/router GEMV plus each glue twin — norm
+    /// copies, deinterleave, silu, residual adds, weighted accumulation,
+    /// attention q prep / KV append — encodes once per chunk regardless of
+    /// chunk size), and per-union-expert batched GEMVs (gate/up/down encode
+    /// once per (expert, projection) per chunk). A single-token chunk
+    /// delegates every batch encode to the legacy per-token path and lands
+    /// exactly on the pre-batching decomposition. Exact assertions, S3a
+    /// style.
     struct LayerMajorBaseline {
         let commandBuffersPerChunk: Int
+        /// Dispatches that stay per token inside a multi-token chunk.
         let perTokenDispatches: Int
+        /// Batched dispatches paid once per multi-token chunk.
         let perChunkDispatches: Int
         let perUnionExpertDispatches: Int
         let lmHeadDispatches: Int
-        /// The pre-batching per-token pin (the flat cost the S1b schedule
-        /// paid before token batching); chunk=1 must still land exactly on
-        /// it, larger chunks strictly below it.
+        /// The pre-batching decomposition (what a single-token chunk pays).
+        let legacyPerTokenDispatches: Int
+        let legacyPerChunkDispatches: Int
+        /// The flat per-token cost of the unbatched schedule; chunk=1 must
+        /// land exactly on it, larger chunks strictly below it.
         let unbatchedDispatchesPerToken: Int
+
+        func chunkSizes(tokens: Int, chunkTokens: Int) -> [Int] {
+            stride(from: 0, to: tokens, by: chunkTokens).map { min(chunkTokens, tokens - $0) }
+        }
 
         func chunkCount(tokens: Int, chunkTokens: Int) -> Int {
             (tokens + chunkTokens - 1) / chunkTokens
@@ -43,36 +55,48 @@ import Testing
         }
 
         func dispatches(tokens: Int, chunkTokens: Int, unionSizes: [Int]) -> Int {
-            perTokenDispatches * tokens
-                + perChunkDispatches * chunkCount(tokens: tokens, chunkTokens: chunkTokens)
-                + perUnionExpertDispatches * unionSizes.reduce(0, +)
-                + lmHeadDispatches
+            chunkSizes(tokens: tokens, chunkTokens: chunkTokens).reduce(lmHeadDispatches) {
+                $0 + ($1 == 1
+                    ? legacyPerTokenDispatches + legacyPerChunkDispatches
+                    : perTokenDispatches * $1 + perChunkDispatches)
+            } + perUnionExpertDispatches * unionSizes.reduce(0, +)
         }
     }
 
-    /// S1b token batching re-pins the prefill dispatch baselines. Old: a
-    /// flat 218 (q4) / 224 (q35) per token — the decode schedule's cost.
-    /// New: per token only the unbatchable kernels remain (q4 104 = 6 delta
-    /// layers x 10 + 2 attention layers x 6 + 8 MoE layers x 4; q35 has one
-    /// fewer batched in_proj stage per delta layer but no deinterleave, so
-    /// 98); per chunk the token-batched projection GEMVs (q4 66 = 6x4 + 2x5
-    /// + 8x4; q35 78 = 6x6 + 2x5 + 8x4); per union expert 3 (gate/up/down).
-    /// A single-token chunk lands exactly on the old pin: 104 + 66 + 3x16
-    /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
+    /// Batching the non-GEMV glue re-pins the prefill dispatch baselines.
+    /// Old (GEMV batching only): per token 104 (q4) = 6 delta layers x 10 +
+    /// 2 attention layers x 6 + 8 MoE layers x 4 (q35: 98, no deinterleave);
+    /// per chunk the token-batched projection GEMVs, 66 (q4) = 6x4 + 2x5 +
+    /// 8x4 (q35: 78 = 6x6 + 2x5 + 8x4).
+    /// New: per token only the order-sensitive kernels remain — the DeltaNet
+    /// recurrence chain (conv, decay/beta prep, q/k norms, gated step, gated
+    /// norm; 6 per delta layer) and the causal attend (1 per attention
+    /// layer): q4/q35 38 = 6x6 + 2x1. Per chunk the GEMVs plus the glue
+    /// twins: q4 132 = 66 + 6x4 (input norm, deinterleave, residual, post
+    /// norm) + 2x5 (input norm, q prep, KV append, residual, post norm) +
+    /// 8x4 (top-2 silus, shared silu, weighted accum); q35 138 = 78 + 6x3 +
+    /// 2x5 + 8x4. Per union expert 3 (gate/up/down). A single-token chunk
+    /// delegates to the legacy path and lands exactly on the old pin:
+    /// 104 + 66 + 3x16 = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x
+    /// top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 104,
-        perChunkDispatches: 66,
+        perTokenDispatches: 38,
+        perChunkDispatches: 132,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
+        legacyPerTokenDispatches: 104,
+        legacyPerChunkDispatches: 66,
         unbatchedDispatchesPerToken: 218
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 98,
-        perChunkDispatches: 78,
+        perTokenDispatches: 38,
+        perChunkDispatches: 138,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
+        legacyPerTokenDispatches: 98,
+        legacyPerChunkDispatches: 78,
         unbatchedDispatchesPerToken: 224
     )
 

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -63,28 +63,28 @@ import Testing
         }
     }
 
-    /// Batching the non-GEMV glue and chunking the DeltaNet recurrence
-    /// re-pin the prefill dispatch baselines.
-    /// Old (GEMV batching only): per token 104 (q4) = 6 delta layers x 10 +
-    /// 2 attention layers x 6 + 8 MoE layers x 4 (q35: 98, no deinterleave);
-    /// per chunk the token-batched projection GEMVs, 66 (q4) = 6x4 + 2x5 +
-    /// 8x4 (q35: 78 = 6x6 + 2x5 + 8x4).
-    /// New: per token only the order-sensitive kernels remain — the DeltaNet
+    /// Batching the causal attend re-pins the prefill dispatch baselines.
+    /// Old (glue twins + chunked scan): per token the DeltaNet
     /// conv/prep/norm chain (conv, decay/beta prep, q/k norms, gated norm;
-    /// 5 per delta layer — the gated scan itself is now one T=chunk dispatch
-    /// per layer) and the causal attend (1 per attention layer): q4/q35
-    /// 32 = 6x5 + 2x1. Per chunk the GEMVs plus the glue twins and the
-    /// chunked scan: q4 144 = 66 + 6x6 (input norm, deinterleave, gather,
-    /// T-step scan, residual, post norm) + 2x5 (input norm, q prep, KV
-    /// append, residual, post norm) + 8x4 (top-2 silus, shared silu,
-    /// weighted accum); q35 150 = 78 + 6x5 (no deinterleave) + 2x5 + 8x4.
+    /// 5 per delta layer) plus the causal attend (1 per attention layer):
+    /// q4/q35 32 = 6x5 + 2x1; per chunk q4 144 = 66 GEMVs + 6x6 + 2x5 +
+    /// 8x4 (q35: 150 = 78 + 6x5 + 2x5 + 8x4).
+    /// New: attn_decode_gqa_batch derives each token's kvLen from the token
+    /// grid, so the attend moves to the per-chunk column — per token only
+    /// the order-sensitive DeltaNet chain remains: q4/q35 30 = 6x5. Per
+    /// chunk the GEMVs plus the glue twins, the chunked scan, and the
+    /// batched attend: q4 146 = 66 + 6x6 (input norm, deinterleave, gather,
+    /// T-step scan, residual, post norm) + 2x6 (input norm, q prep, KV
+    /// append, attend, residual, post norm) + 8x4 (top-2 silus, shared
+    /// silu, weighted accum); q35 152 = 78 + 6x5 (no deinterleave) + 2x6 +
+    /// 8x4.
     /// Per union expert 3 (gate/up/down). A single-token chunk delegates to
     /// the legacy path and lands exactly on the old pin: 104 + 66 + 3x16
     /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 32,
-        perChunkDispatches: 144,
+        perTokenDispatches: 30,
+        perChunkDispatches: 146,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 104,
@@ -93,8 +93,8 @@ import Testing
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 32,
-        perChunkDispatches: 150,
+        perTokenDispatches: 30,
+        perChunkDispatches: 152,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 98,

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -17,14 +17,15 @@ import Testing
 
     /// Layer-major token-batched baseline: one decode-token-shaped buffer
     /// sequence per chunk (the S2 9-buffer shape), with the dispatch cost
-    /// decomposed into per-token kernels (only the order-sensitive DeltaNet
-    /// conv step, whose history each token advances for the next), per-chunk
-    /// batched dispatches (each dense/shared/router GEMV plus each batch
-    /// twin — norm copies, deinterleave, silu, residual adds, weighted
-    /// accumulation, attention q prep / KV append / causal attend, decay/
-    /// beta prep, q/k norms, gated norm — encodes once per chunk regardless
-    /// of chunk size), and per-union-expert batched GEMVs (gate/up/down
-    /// encode once per (expert, projection) per chunk). A single-token chunk
+    /// decomposed into per-chunk batched dispatches (each dense/shared/
+    /// router GEMV plus each batch twin or cross-token scan — norm copies,
+    /// deinterleave, silu, residual adds, weighted accumulation, attention
+    /// q prep / KV append / causal attend, conv scan, decay/beta prep, q/k
+    /// norms, gated scan, gated norm — encodes once per chunk regardless of
+    /// chunk size) and per-union-expert batched GEMVs (gate/up/down encode
+    /// once per (expert, projection) per chunk). No dispatch scales with
+    /// chunk size any more; the perTokenDispatches term is kept at zero as
+    /// the regression tripwire for that property. A single-token chunk
     /// delegates every batch encode to the legacy per-token path and lands
     /// exactly on the pre-batching decomposition. Exact assertions, S3a
     /// style.
@@ -64,29 +65,29 @@ import Testing
         }
     }
 
-    /// Batching the DeltaNet prep chain (after the causal attend) re-pins
-    /// the prefill dispatch baselines.
-    /// Old (glue twins + chunked scan + batched attend): per token the
-    /// DeltaNet conv/prep/norm chain — conv, decay/beta prep, q/k norms,
-    /// gated norm; q4/q35 30 = 6x5 — with per chunk q4 146 = 66 GEMVs +
-    /// 6x6 + 2x6 + 8x4 (q35: 152 = 78 + 6x5 + 2x6 + 8x4).
-    /// New: decay/beta prep, the weightless q/k norms, and the gated norm
-    /// are independent per token, so they encode once per chunk through
-    /// their stride twins — per token only the genuinely order-sensitive
-    /// kernel remains, the depthwise conv step advancing the layer's shared
-    /// history: q4/q35 6 = 6x1. Per chunk the GEMVs plus every batched
-    /// stage: q4 170 = 66 + 6x10 (input norm, deinterleave, decay/beta
-    /// prep, q norm, k norm, gather, T-step scan, gated norm, residual,
-    /// post norm) + 2x6 (input norm, q prep, KV append, attend, residual,
-    /// post norm) + 8x4 (top-2 silus, shared silu, weighted accum);
-    /// q35 176 = 78 + 6x9 (no deinterleave) + 2x6 + 8x4.
+    /// Scanning the conv steps across the chunk erases the last per-token
+    /// dispatches from the layer-major decomposition.
+    /// Old (glue twins + chunked scan + batched attend + batched prep
+    /// chain): per token only the depthwise conv step advancing the layer's
+    /// shared history — q4/q35 6 = 6x1 — with per chunk q4 170 = 66 GEMVs
+    /// + 6x10 + 2x6 + 8x4 (q35: 176 = 78 + 6x9 + 2x6 + 8x4).
+    /// New: the conv history rides across the chunk inside one conv_scan
+    /// per delta layer (the kernel's step loop is the chained per-token
+    /// steps' arithmetic verbatim, so the chunk-size bitwise pins hold
+    /// unchanged) — per token 0; no dispatch scales with chunk size. Per
+    /// chunk the GEMVs plus every batched stage: q4 176 = 66 + 6x11 (conv
+    /// scan, input norm, deinterleave, decay/beta prep, q norm, k norm,
+    /// gather, T-step scan, gated norm, residual, post norm) + 2x6 (input
+    /// norm, q prep, KV append, attend, residual, post norm) + 8x4 (top-2
+    /// silus, shared silu, weighted accum); q35 182 = 78 + 6x10 (no
+    /// deinterleave) + 2x6 + 8x4.
     /// Per union expert 3 (gate/up/down). A single-token chunk delegates to
     /// the legacy path and lands exactly on the old pin: 104 + 66 + 3x16
     /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 6,
-        perChunkDispatches: 170,
+        perTokenDispatches: 0,
+        perChunkDispatches: 176,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 104,
@@ -95,8 +96,8 @@ import Testing
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 6,
-        perChunkDispatches: 176,
+        perTokenDispatches: 0,
+        perChunkDispatches: 182,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 98,

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -1,0 +1,320 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S1b: layer-major, chunked prefill with expert-union routing. The bar:
+/// final logits, greedy continuation, and KV/recurrent state must match the
+/// legacy token-major path under the S1a tolerance discipline; the experts
+/// touched per layer must be exactly the S1b-a oracle's planned unions; and
+/// the new schedule's buffer/dispatch shape is pinned as exactly as the S3a
+/// baselines pin the old one. Decode steps never take this path.
+@Suite struct LayerMajorPrefillTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    /// Layer-major fast-path baseline: one legacy-token-shaped buffer
+    /// sequence per chunk (the S3a 11-buffer shape), per-token dispatch cost
+    /// unchanged from the old schedule, and the LM head only after the final
+    /// chunk. Exact assertions, S3a style.
+    struct LayerMajorBaseline {
+        let commandBuffersPerChunk: Int
+        let dispatchesPerToken: Int
+        let lmHeadDispatches: Int
+
+        func chunkCount(tokens: Int, chunkTokens: Int) -> Int {
+            (tokens + chunkTokens - 1) / chunkTokens
+        }
+
+        func commandBuffers(tokens: Int, chunkTokens: Int) -> Int {
+            commandBuffersPerChunk * chunkCount(tokens: tokens, chunkTokens: chunkTokens)
+        }
+
+        func dispatches(tokens: Int) -> Int {
+            dispatchesPerToken * tokens + lmHeadDispatches
+        }
+    }
+
+    static let q4Baseline = LayerMajorBaseline(
+        commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
+        dispatchesPerToken: 212,
+        lmHeadDispatches: 2
+    )
+    static let q35Baseline = LayerMajorBaseline(
+        commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
+        dispatchesPerToken: 218,
+        lmHeadDispatches: 2
+    )
+
+    static func argmax(_ v: [Float]) -> Int {
+        var b = 0
+        for i in 1..<v.count where v[i] > v[b] { b = i }
+        return b
+    }
+
+    /// The shipped default is the S1b schedule with a bounded chunk.
+    @Test func defaultPrefillModeIsLayerMajor() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        #expect(model.prefillMode == .layerMajor(chunkTokens: 32))
+    }
+
+    static func compare(
+        _ modelName: String,
+        chunkTokens: Int,
+        baseline: LayerMajorBaseline,
+        decodeBaseline: MetalModelTests.FastPathBaseline
+    ) throws {
+        let dir = fixturesDir.appendingPathComponent(modelName)
+        let label = "\(modelName) chunk=\(chunkTokens)"
+        let tokens = [1, 5, 9, 42, 7]
+
+        let cpu = try QwenCPUModel(modelDir: dir)
+        cpu.retainAllLayers = true
+        let cpuState = QwenCPUModel.DecodeState()
+        var cpuLogits: [Float] = []
+        for t in tokens { cpuLogits = try cpu.step([t], state: cpuState) }
+
+        // Reference: the decode loop, token at a time (never layer-major).
+        let sequentialGPU = try QwenMetalModel(modelDir: dir)
+        let sequentialState = QwenCPUModel.DecodeState()
+        var sequentialLogits: [Float] = []
+        for t in tokens { sequentialLogits = try sequentialGPU.step([t], state: sequentialState) }
+
+        let layerMajorGPU = try QwenMetalModel(modelDir: dir)
+        layerMajorGPU.prefillMode = .layerMajor(chunkTokens: chunkTokens)
+        let layerMajorState = QwenCPUModel.DecodeState()
+        let layerMajorLogits = try layerMajorGPU.step(tokens, state: layerMajorState)
+        let metrics = layerMajorGPU.lastStepMetrics
+
+        // Correctness bar: same logits, same greedy pick, same KV state.
+        let cpuDiff = MetalModelTests.maxAbsDiff(cpuLogits, layerMajorLogits)
+        #expect(cpuDiff < 2e-3, "\(label): CPU vs layer-major maxAbsDiff \(cpuDiff)")
+        let seqDiff = MetalModelTests.maxAbsDiff(sequentialLogits, layerMajorLogits)
+        #expect(seqDiff < 2e-3, "\(label): sequential vs layer-major maxAbsDiff \(seqDiff)")
+        MetalModelTests.expectMatchingKV(
+            sequentialState, layerMajorState, label: "\(label) prompt")
+        #expect(argmax(cpuLogits) == argmax(layerMajorLogits), "\(label): greedy diverged")
+
+        // S1a property preserved: one LM head, intermediates elided.
+        #expect(metrics.tokensProcessed == tokens.count, "\(label): token count")
+        #expect(metrics.logitProjections == 1, "\(label): LM-head count")
+        #expect(metrics.avoidedLogitProjections == tokens.count - 1, "\(label): elision count")
+        MetalModelTests.expectInstrumentation(metrics, tokens: tokens.count, label: label)
+
+        // S1b baselines, pinned exactly: buffers per chunk, dispatches per
+        // token, and the chunk-shaped phase timeline.
+        let chunks = baseline.chunkCount(tokens: tokens.count, chunkTokens: chunkTokens)
+        #expect(metrics.commandBuffersCommitted
+                == baseline.commandBuffers(tokens: tokens.count, chunkTokens: chunkTokens),
+                "\(label): layer-major command-buffer baseline changed")
+        #expect(metrics.computeDispatchesEncoded == baseline.dispatches(tokens: tokens.count),
+                "\(label): layer-major dispatch baseline changed")
+        MetalModelTests.expectPhaseTimeline(
+            metrics,
+            expectedPhases: MetalModelTests.expectedTimelinePhases(
+                config: layerMajorGPU.config, tokens: chunks),
+            label: label
+        )
+
+        // Continuation decode after the layer-major prompt: same next logits
+        // as the sequential state, and the decode baselines untouched.
+        let continuation = 11
+        let seqCont = try sequentialGPU.step([continuation], state: sequentialState)
+        let lmCont = try layerMajorGPU.step([continuation], state: layerMajorState)
+        let contDiff = MetalModelTests.maxAbsDiff(seqCont, lmCont)
+        #expect(contDiff < 2e-3, "\(label): continuation maxAbsDiff \(contDiff)")
+        #expect(argmax(seqCont) == argmax(lmCont), "\(label): continuation greedy diverged")
+        MetalModelTests.expectMatchingKV(
+            sequentialState, layerMajorState, label: "\(label) continuation")
+        MetalModelTests.expectFastPathBaseline(
+            layerMajorGPU.lastStepMetrics, tokens: 1,
+            baseline: decodeBaseline, label: "\(label) continuation"
+        )
+    }
+
+    @Test func layerMajorMatchesSequentialOnQuantizedTiny() throws {
+        try Self.compare("tiny-model-q4", chunkTokens: 32,
+                         baseline: Self.q4Baseline, decodeBaseline: MetalModelTests.q4Baseline)
+    }
+
+    @Test func layerMajorMatchesSequentialOnQwen35Tiny() throws {
+        try Self.compare("tiny-model-q35", chunkTokens: 32,
+                         baseline: Self.q35Baseline, decodeBaseline: MetalModelTests.q35Baseline)
+    }
+
+    /// A prompt longer than the chunk crosses chunk boundaries with the same
+    /// math: chunks of 2/2/1 must reproduce the sequential state exactly.
+    @Test func chunkedPrefillSpansThePrompt() throws {
+        try Self.compare("tiny-model-q4", chunkTokens: 2,
+                         baseline: Self.q4Baseline, decodeBaseline: MetalModelTests.q4Baseline)
+    }
+
+    /// chunkTokens=1 degenerates to token order — the boundary case where
+    /// layer-major and token-major visit (token, layer) identically.
+    @Test func singleTokenChunksDegenerateToTokenOrder() throws {
+        try Self.compare("tiny-model-q4", chunkTokens: 1,
+                         baseline: Self.q4Baseline, decodeBaseline: MetalModelTests.q4Baseline)
+    }
+
+    // MARK: - Expert unions vs the S1b-a oracle
+
+    /// The layer-major path must route every (token, layer) exactly as the
+    /// token loop does, and fetch per layer exactly the union the
+    /// PrefillExpertUnionPlan oracle computes from those routes — per chunk.
+    static func expectUnionsMatchPlan(_ modelName: String, chunkTokens: Int) throws {
+        let dir = fixturesDir.appendingPathComponent(modelName)
+        let label = "\(modelName) chunk=\(chunkTokens)"
+        let tokens = [1, 5, 9, 42, 7]
+
+        // Oracle input: token-major routes recorded from the decode loop.
+        let loopModel = try QwenMetalModel(modelDir: dir)
+        let layerCount = loopModel.config.numHiddenLayers
+        var loopFlat: [(layer: Int, experts: [Int])] = []
+        loopModel.routedExpertObserver = { loopFlat.append(($0, $1)) }
+        let loopState = QwenCPUModel.DecodeState()
+        for t in tokens { _ = try loopModel.step([t], state: loopState) }
+        loopModel.routedExpertObserver = nil
+        #expect(loopFlat.count == tokens.count * layerCount, "\(label): observation shape")
+        var loopRoutes: [[[Int]]] = []
+        for t in 0..<tokens.count {
+            var perLayer: [[Int]] = []
+            for l in 0..<layerCount {
+                let entry = loopFlat[t * layerCount + l]
+                #expect(entry.layer == l, "\(label): loop layer order")
+                perLayer.append(entry.experts)
+            }
+            loopRoutes.append(perLayer)
+        }
+
+        // The layer-major prefill records what it routed and what it fetched.
+        let model = try QwenMetalModel(modelDir: dir)
+        model.prefillMode = .layerMajor(chunkTokens: chunkTokens)
+        var routed: [(layer: Int, experts: [Int])] = []
+        var unions: [(layer: Int, experts: [Int])] = []
+        model.routedExpertObserver = { routed.append(($0, $1)) }
+        model.prefillExpertUnionObserver = { unions.append(($0, $1)) }
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step(tokens, state: state)
+        model.routedExpertObserver = nil
+        model.prefillExpertUnionObserver = nil
+
+        // Expected order: per chunk, per layer — every token's route (in
+        // token order), then that layer's planned union.
+        var expectedRouted: [(Int, [Int])] = []
+        var expectedUnions: [(Int, [Int])] = []
+        var start = 0
+        while start < tokens.count {
+            let end = min(start + chunkTokens, tokens.count)
+            let chunkPlan = try PrefillExpertUnionPlan(
+                tokenRoutes: Array(loopRoutes[start..<end]),
+                expertCount: model.config.numExperts
+            )
+            for l in 0..<layerCount {
+                for t in start..<end { expectedRouted.append((l, loopRoutes[t][l])) }
+                expectedUnions.append((l, chunkPlan.layers[l].experts))
+            }
+            start = end
+        }
+        #expect(routed.map(\.layer) == expectedRouted.map(\.0),
+                "\(label): layer-major routing order diverged")
+        #expect(routed.map(\.experts) == expectedRouted.map(\.1),
+                "\(label): layer-major routing diverged from the token loop")
+        #expect(unions.map(\.layer) == expectedUnions.map(\.0),
+                "\(label): union layer order diverged")
+        #expect(unions.map(\.experts) == expectedUnions.map(\.1),
+                "\(label): fetched unions diverge from the oracle plan")
+
+        // Single chunk: the fetched unions are exactly the whole-prompt plan
+        // replayed layer-major (the S1b-a equivalence pattern, now consumed
+        // by the real schedule).
+        if chunkTokens >= tokens.count {
+            let plan = try PrefillExpertUnionPlan(
+                tokenRoutes: loopRoutes, expertCount: model.config.numExperts)
+            var replayed: [(Int, [Int])] = []
+            plan.replayLayerMajor { replayed.append(($0, $1)) }
+            #expect(unions.map(\.layer) == replayed.map(\.0)
+                    && unions.map(\.experts) == replayed.map(\.1),
+                    "\(label): schedule does not consume the plan verbatim")
+        }
+    }
+
+    @Test func unionsMatchThePlanOnQuantizedTiny() throws {
+        try Self.expectUnionsMatchPlan("tiny-model-q4", chunkTokens: 32)
+    }
+
+    @Test func unionsMatchThePlanOnQwen35Tiny() throws {
+        try Self.expectUnionsMatchPlan("tiny-model-q35", chunkTokens: 32)
+    }
+
+    @Test func chunkedUnionsMatchPerChunkPlans() throws {
+        try Self.expectUnionsMatchPlan("tiny-model-q4", chunkTokens: 2)
+    }
+
+    // MARK: - Streaming (qpack) path
+
+    /// On the streaming container the layer-major prefill must stay exact and
+    /// its expert-cache traffic must be exactly one union fetch per layer:
+    /// the cache sees sum(union sizes) requests for the whole prompt, not
+    /// tokens x top-k.
+    @Test func layerMajorQpackStreamingMatchesSequential() throws {
+        let src = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let out = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tiny-q4-s1b-\(UUID().uuidString).qpack")
+        defer { try? FileManager.default.removeItem(at: out) }
+        var repacker = QpackRepacker(checkpointDir: src, outputDir: out)
+        repacker.log = { _ in }
+        try repacker.repack()
+
+        let tokens = [1, 5, 9, 42, 7, 99]
+        let sequentialGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        let layerMajorGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        #expect(sequentialGPU.expertCache != nil, "qpack mode not engaged")
+        #expect(layerMajorGPU.expertCache != nil, "qpack mode not engaged")
+
+        let sequentialState = QwenCPUModel.DecodeState()
+        var sequentialLogits: [Float] = []
+        for t in tokens { sequentialLogits = try sequentialGPU.step([t], state: sequentialState) }
+
+        var unionSizes: [Int] = []
+        layerMajorGPU.prefillExpertUnionObserver = { unionSizes.append($1.count) }
+        let cache = layerMajorGPU.expertCache!
+        let requestsBefore = cache.hits + cache.misses
+        let layerMajorState = QwenCPUModel.DecodeState()
+        let layerMajorLogits = try layerMajorGPU.step(tokens, state: layerMajorState)
+        layerMajorGPU.prefillExpertUnionObserver = nil
+        let requests = cache.hits + cache.misses - requestsBefore
+
+        let diff = MetalModelTests.maxAbsDiff(sequentialLogits, layerMajorLogits)
+        #expect(diff < 2e-3, "qpack layer-major maxAbsDiff \(diff)")
+        MetalModelTests.expectMatchingKV(
+            sequentialState, layerMajorState, label: "qpack layer-major prompt")
+        #expect(layerMajorGPU.lastStepMetrics.logitProjections == 1)
+        #expect(layerMajorGPU.lastStepMetrics.commandBuffersCommitted
+                == Self.q4Baseline.commandBuffers(tokens: tokens.count, chunkTokens: 32),
+                "qpack layer-major command-buffer baseline changed")
+        #expect(layerMajorGPU.lastStepMetrics.computeDispatchesEncoded
+                == Self.q4Baseline.dispatches(tokens: tokens.count),
+                "qpack layer-major dispatch baseline changed")
+
+        #expect(unionSizes.count == layerMajorGPU.config.numHiddenLayers,
+                "one union fetch per layer expected")
+        #expect(requests == unionSizes.reduce(0, +),
+                "expert-cache traffic is not one union fetch per layer")
+        let tokenMajorRequests = tokens.count
+            * layerMajorGPU.config.numHiddenLayers
+            * layerMajorGPU.config.numExpertsPerTok
+        #expect(requests <= tokenMajorRequests,
+                "union fetches exceed token-major traffic")
+
+        let continuation = 11
+        let seqCont = try sequentialGPU.step([continuation], state: sequentialState)
+        let lmCont = try layerMajorGPU.step([continuation], state: layerMajorState)
+        let contDiff = MetalModelTests.maxAbsDiff(seqCont, lmCont)
+        #expect(contDiff < 2e-3, "qpack layer-major continuation maxAbsDiff \(contDiff)")
+        MetalModelTests.expectMatchingKV(
+            sequentialState, layerMajorState, label: "qpack layer-major continuation")
+    }
+}

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -15,10 +15,10 @@ import Testing
         .deletingLastPathComponent()
         .appendingPathComponent("fixtures")
 
-    /// Layer-major fast-path baseline: one legacy-token-shaped buffer
-    /// sequence per chunk (the S3a 11-buffer shape), per-token dispatch cost
-    /// unchanged from the old schedule, and the LM head only after the final
-    /// chunk. Exact assertions, S3a style.
+    /// Layer-major fast-path baseline: one decode-token-shaped buffer
+    /// sequence per chunk (the S2 9-buffer shape), per-token dispatch cost
+    /// identical to the decode schedule, and the LM head only after the
+    /// final chunk. Exact assertions, S3a style.
     struct LayerMajorBaseline {
         let commandBuffersPerChunk: Int
         let dispatchesPerToken: Int
@@ -37,14 +37,18 @@ import Testing
         }
     }
 
+    /// S2: the chunk keeps the decode shape — 9 buffers per chunk (was 11
+    /// around the CPU attention core) and +3 dispatches per attention layer
+    /// per token (q prep, KV append, causal attention), so 212 -> 218 (q4)
+    /// and 218 -> 224 (q35) dispatches per token.
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        dispatchesPerToken: 212,
+        dispatchesPerToken: 218,
         lmHeadDispatches: 2
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        dispatchesPerToken: 218,
+        dispatchesPerToken: 224,
         lmHeadDispatches: 2
     )
 

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -63,26 +63,28 @@ import Testing
         }
     }
 
-    /// Batching the non-GEMV glue re-pins the prefill dispatch baselines.
+    /// Batching the non-GEMV glue and chunking the DeltaNet recurrence
+    /// re-pin the prefill dispatch baselines.
     /// Old (GEMV batching only): per token 104 (q4) = 6 delta layers x 10 +
     /// 2 attention layers x 6 + 8 MoE layers x 4 (q35: 98, no deinterleave);
     /// per chunk the token-batched projection GEMVs, 66 (q4) = 6x4 + 2x5 +
     /// 8x4 (q35: 78 = 6x6 + 2x5 + 8x4).
     /// New: per token only the order-sensitive kernels remain — the DeltaNet
-    /// recurrence chain (conv, decay/beta prep, q/k norms, gated step, gated
-    /// norm; 6 per delta layer) and the causal attend (1 per attention
-    /// layer): q4/q35 38 = 6x6 + 2x1. Per chunk the GEMVs plus the glue
-    /// twins: q4 132 = 66 + 6x4 (input norm, deinterleave, residual, post
-    /// norm) + 2x5 (input norm, q prep, KV append, residual, post norm) +
-    /// 8x4 (top-2 silus, shared silu, weighted accum); q35 138 = 78 + 6x3 +
-    /// 2x5 + 8x4. Per union expert 3 (gate/up/down). A single-token chunk
-    /// delegates to the legacy path and lands exactly on the old pin:
-    /// 104 + 66 + 3x16 = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x
-    /// top-2 picks).
+    /// conv/prep/norm chain (conv, decay/beta prep, q/k norms, gated norm;
+    /// 5 per delta layer — the gated scan itself is now one T=chunk dispatch
+    /// per layer) and the causal attend (1 per attention layer): q4/q35
+    /// 32 = 6x5 + 2x1. Per chunk the GEMVs plus the glue twins and the
+    /// chunked scan: q4 144 = 66 + 6x6 (input norm, deinterleave, gather,
+    /// T-step scan, residual, post norm) + 2x5 (input norm, q prep, KV
+    /// append, residual, post norm) + 8x4 (top-2 silus, shared silu,
+    /// weighted accum); q35 150 = 78 + 6x5 (no deinterleave) + 2x5 + 8x4.
+    /// Per union expert 3 (gate/up/down). A single-token chunk delegates to
+    /// the legacy path and lands exactly on the old pin: 104 + 66 + 3x16
+    /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 38,
-        perChunkDispatches: 132,
+        perTokenDispatches: 32,
+        perChunkDispatches: 144,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 104,
@@ -91,8 +93,8 @@ import Testing
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 38,
-        perChunkDispatches: 138,
+        perTokenDispatches: 32,
+        perChunkDispatches: 150,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 98,

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -130,22 +130,22 @@ import Testing
 
         let cpu = try QwenCPUModel(modelDir: dir)
         cpu.retainAllLayers = true
-        let cpuState = QwenCPUModel.DecodeState()
+        let cpuState = cpu.makeQwenContext()
         var cpuLogits: [Float] = []
-        for t in tokens { cpuLogits = try cpu.step([t], state: cpuState) }
+        for t in tokens { cpuLogits = try cpu.step([t], context: cpuState) }
 
         // Reference: the decode loop, token at a time (never layer-major).
         let sequentialGPU = try QwenMetalModel(modelDir: dir)
-        let sequentialState = QwenCPUModel.DecodeState()
+        let sequentialState = sequentialGPU.makeQwenContext()
         var sequentialLogits: [Float] = []
-        for t in tokens { sequentialLogits = try sequentialGPU.step([t], state: sequentialState) }
+        for t in tokens { sequentialLogits = try sequentialGPU.step([t], context: sequentialState) }
 
         let layerMajorGPU = try QwenMetalModel(modelDir: dir)
         layerMajorGPU.prefillMode = .layerMajor(chunkTokens: chunkTokens)
-        let layerMajorState = QwenCPUModel.DecodeState()
+        let layerMajorState = layerMajorGPU.makeQwenContext()
         var unionSizes: [Int] = []
         layerMajorGPU.prefillExpertUnionObserver = { unionSizes.append($1.count) }
-        let layerMajorLogits = try layerMajorGPU.step(tokens, state: layerMajorState)
+        let layerMajorLogits = try layerMajorGPU.step(tokens, context: layerMajorState)
         layerMajorGPU.prefillExpertUnionObserver = nil
         let metrics = layerMajorGPU.lastStepMetrics
 
@@ -194,8 +194,8 @@ import Testing
         // Continuation decode after the layer-major prompt: same next logits
         // as the sequential state, and the decode baselines untouched.
         let continuation = 11
-        let seqCont = try sequentialGPU.step([continuation], state: sequentialState)
-        let lmCont = try layerMajorGPU.step([continuation], state: layerMajorState)
+        let seqCont = try sequentialGPU.step([continuation], context: sequentialState)
+        let lmCont = try layerMajorGPU.step([continuation], context: layerMajorState)
         let contDiff = MetalModelTests.maxAbsDiff(seqCont, lmCont)
         #expect(contDiff < 2e-3, "\(label): continuation maxAbsDiff \(contDiff)")
         #expect(argmax(seqCont) == argmax(lmCont), "\(label): continuation greedy diverged")
@@ -250,8 +250,8 @@ import Testing
         for chunk in [1, 2, 5] {
             let model = try QwenMetalModel(modelDir: dir)
             model.prefillMode = .layerMajor(chunkTokens: chunk)
-            let state = QwenCPUModel.DecodeState()
-            let logits = try model.step(tokens, state: state)
+            let state = model.makeQwenContext()
+            let logits = try model.step(tokens, context: state)
             if reference.isEmpty {
                 reference = logits
             } else {
@@ -276,8 +276,8 @@ import Testing
         let layerCount = loopModel.config.numHiddenLayers
         var loopFlat: [(layer: Int, experts: [Int])] = []
         loopModel.routedExpertObserver = { loopFlat.append(($0, $1)) }
-        let loopState = QwenCPUModel.DecodeState()
-        for t in tokens { _ = try loopModel.step([t], state: loopState) }
+        let loopState = loopModel.makeQwenContext()
+        for t in tokens { _ = try loopModel.step([t], context: loopState) }
         loopModel.routedExpertObserver = nil
         #expect(loopFlat.count == tokens.count * layerCount, "\(label): observation shape")
         var loopRoutes: [[[Int]]] = []
@@ -298,8 +298,8 @@ import Testing
         var unions: [(layer: Int, experts: [Int])] = []
         model.routedExpertObserver = { routed.append(($0, $1)) }
         model.prefillExpertUnionObserver = { unions.append(($0, $1)) }
-        let state = QwenCPUModel.DecodeState()
-        _ = try model.step(tokens, state: state)
+        let state = model.makeQwenContext()
+        _ = try model.step(tokens, context: state)
         model.routedExpertObserver = nil
         model.prefillExpertUnionObserver = nil
 
@@ -376,16 +376,16 @@ import Testing
         #expect(sequentialGPU.expertCache != nil, "qpack mode not engaged")
         #expect(layerMajorGPU.expertCache != nil, "qpack mode not engaged")
 
-        let sequentialState = QwenCPUModel.DecodeState()
+        let sequentialState = sequentialGPU.makeQwenContext()
         var sequentialLogits: [Float] = []
-        for t in tokens { sequentialLogits = try sequentialGPU.step([t], state: sequentialState) }
+        for t in tokens { sequentialLogits = try sequentialGPU.step([t], context: sequentialState) }
 
         var unionSizes: [Int] = []
         layerMajorGPU.prefillExpertUnionObserver = { unionSizes.append($1.count) }
         let cache = layerMajorGPU.expertCache!
         let requestsBefore = cache.hits + cache.misses
-        let layerMajorState = QwenCPUModel.DecodeState()
-        let layerMajorLogits = try layerMajorGPU.step(tokens, state: layerMajorState)
+        let layerMajorState = layerMajorGPU.makeQwenContext()
+        let layerMajorLogits = try layerMajorGPU.step(tokens, context: layerMajorState)
         layerMajorGPU.prefillExpertUnionObserver = nil
         let requests = cache.hits + cache.misses - requestsBefore
 
@@ -413,8 +413,8 @@ import Testing
                 "union fetches exceed token-major traffic")
 
         let continuation = 11
-        let seqCont = try sequentialGPU.step([continuation], state: sequentialState)
-        let lmCont = try layerMajorGPU.step([continuation], state: layerMajorState)
+        let seqCont = try sequentialGPU.step([continuation], context: sequentialState)
+        let lmCont = try layerMajorGPU.step([continuation], context: layerMajorState)
         let contDiff = MetalModelTests.maxAbsDiff(seqCont, lmCont)
         #expect(contDiff < 2e-3, "qpack layer-major continuation maxAbsDiff \(contDiff)")
         MetalModelTests.expectMatchingKV(

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -15,14 +15,24 @@ import Testing
         .deletingLastPathComponent()
         .appendingPathComponent("fixtures")
 
-    /// Layer-major fast-path baseline: one decode-token-shaped buffer
-    /// sequence per chunk (the S2 9-buffer shape), per-token dispatch cost
-    /// identical to the decode schedule, and the LM head only after the
-    /// final chunk. Exact assertions, S3a style.
+    /// Layer-major token-batched baseline: one decode-token-shaped buffer
+    /// sequence per chunk (the S2 9-buffer shape), with the dispatch cost
+    /// decomposed into per-token kernels (norms, deinterleave, recurrence,
+    /// attention core, silu, residual adds, weighted accumulation), per-chunk
+    /// token-batched projections (each dense/shared/router GEMV encodes once
+    /// per chunk regardless of chunk size), and per-union-expert batched
+    /// GEMVs (gate/up/down encode once per (expert, projection) per chunk).
+    /// Exact assertions, S3a style.
     struct LayerMajorBaseline {
         let commandBuffersPerChunk: Int
-        let dispatchesPerToken: Int
+        let perTokenDispatches: Int
+        let perChunkDispatches: Int
+        let perUnionExpertDispatches: Int
         let lmHeadDispatches: Int
+        /// The pre-batching per-token pin (the flat cost the S1b schedule
+        /// paid before token batching); chunk=1 must still land exactly on
+        /// it, larger chunks strictly below it.
+        let unbatchedDispatchesPerToken: Int
 
         func chunkCount(tokens: Int, chunkTokens: Int) -> Int {
             (tokens + chunkTokens - 1) / chunkTokens
@@ -32,24 +42,38 @@ import Testing
             commandBuffersPerChunk * chunkCount(tokens: tokens, chunkTokens: chunkTokens)
         }
 
-        func dispatches(tokens: Int) -> Int {
-            dispatchesPerToken * tokens + lmHeadDispatches
+        func dispatches(tokens: Int, chunkTokens: Int, unionSizes: [Int]) -> Int {
+            perTokenDispatches * tokens
+                + perChunkDispatches * chunkCount(tokens: tokens, chunkTokens: chunkTokens)
+                + perUnionExpertDispatches * unionSizes.reduce(0, +)
+                + lmHeadDispatches
         }
     }
 
-    /// S2: the chunk keeps the decode shape — 9 buffers per chunk (was 11
-    /// around the CPU attention core) and +3 dispatches per attention layer
-    /// per token (q prep, KV append, causal attention), so 212 -> 218 (q4)
-    /// and 218 -> 224 (q35) dispatches per token.
+    /// S1b token batching re-pins the prefill dispatch baselines. Old: a
+    /// flat 218 (q4) / 224 (q35) per token — the decode schedule's cost.
+    /// New: per token only the unbatchable kernels remain (q4 104 = 6 delta
+    /// layers x 10 + 2 attention layers x 6 + 8 MoE layers x 4; q35 has one
+    /// fewer batched in_proj stage per delta layer but no deinterleave, so
+    /// 98); per chunk the token-batched projection GEMVs (q4 66 = 6x4 + 2x5
+    /// + 8x4; q35 78 = 6x6 + 2x5 + 8x4); per union expert 3 (gate/up/down).
+    /// A single-token chunk lands exactly on the old pin: 104 + 66 + 3x16
+    /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        dispatchesPerToken: 218,
-        lmHeadDispatches: 2
+        perTokenDispatches: 104,
+        perChunkDispatches: 66,
+        perUnionExpertDispatches: 3,
+        lmHeadDispatches: 2,
+        unbatchedDispatchesPerToken: 218
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        dispatchesPerToken: 224,
-        lmHeadDispatches: 2
+        perTokenDispatches: 98,
+        perChunkDispatches: 78,
+        perUnionExpertDispatches: 3,
+        lmHeadDispatches: 2,
+        unbatchedDispatchesPerToken: 224
     )
 
     static func argmax(_ v: [Float]) -> Int {
@@ -90,7 +114,10 @@ import Testing
         let layerMajorGPU = try QwenMetalModel(modelDir: dir)
         layerMajorGPU.prefillMode = .layerMajor(chunkTokens: chunkTokens)
         let layerMajorState = QwenCPUModel.DecodeState()
+        var unionSizes: [Int] = []
+        layerMajorGPU.prefillExpertUnionObserver = { unionSizes.append($1.count) }
         let layerMajorLogits = try layerMajorGPU.step(tokens, state: layerMajorState)
+        layerMajorGPU.prefillExpertUnionObserver = nil
         let metrics = layerMajorGPU.lastStepMetrics
 
         // Correctness bar: same logits, same greedy pick, same KV state.
@@ -108,14 +135,26 @@ import Testing
         #expect(metrics.avoidedLogitProjections == tokens.count - 1, "\(label): elision count")
         MetalModelTests.expectInstrumentation(metrics, tokens: tokens.count, label: label)
 
-        // S1b baselines, pinned exactly: buffers per chunk, dispatches per
-        // token, and the chunk-shaped phase timeline.
+        // S1b token-batched baselines, pinned exactly: buffers per chunk,
+        // the dispatch decomposition, and the chunk-shaped phase timeline.
         let chunks = baseline.chunkCount(tokens: tokens.count, chunkTokens: chunkTokens)
         #expect(metrics.commandBuffersCommitted
                 == baseline.commandBuffers(tokens: tokens.count, chunkTokens: chunkTokens),
                 "\(label): layer-major command-buffer baseline changed")
-        #expect(metrics.computeDispatchesEncoded == baseline.dispatches(tokens: tokens.count),
+        #expect(metrics.computeDispatchesEncoded == baseline.dispatches(
+                    tokens: tokens.count, chunkTokens: chunkTokens, unionSizes: unionSizes),
                 "\(label): layer-major dispatch baseline changed")
+        // The point of token batching: never above the unbatched schedule,
+        // strictly below it whenever a chunk holds more than one token.
+        let unbatched = baseline.unbatchedDispatchesPerToken * tokens.count
+            + baseline.lmHeadDispatches
+        if chunkTokens > 1 {
+            #expect(metrics.computeDispatchesEncoded < unbatched,
+                    "\(label): token batching did not reduce dispatches")
+        } else {
+            #expect(metrics.computeDispatchesEncoded == unbatched,
+                    "\(label): single-token chunks moved off the decode-shaped cost")
+        }
         MetalModelTests.expectPhaseTimeline(
             metrics,
             expectedPhases: MetalModelTests.expectedTimelinePhases(
@@ -161,6 +200,36 @@ import Testing
     @Test func singleTokenChunksDegenerateToTokenOrder() throws {
         try Self.compare("tiny-model-q4", chunkTokens: 1,
                          baseline: Self.q4Baseline, decodeBaseline: MetalModelTests.q4Baseline)
+    }
+
+    /// The split DeltaNet layout (q35) must batch across chunk boundaries
+    /// too: 4 in_proj dispatches per chunk instead of per token.
+    @Test func chunkedPrefillSpansThePromptOnQwen35() throws {
+        try Self.compare("tiny-model-q35", chunkTokens: 2,
+                         baseline: Self.q35Baseline, decodeBaseline: MetalModelTests.q35Baseline)
+    }
+
+    /// Token batching is pure reordering: chunk sizes 1, 2, and 5 must
+    /// produce bitwise-identical final logits, because each batched GEMV row
+    /// computes exactly the unbatched kernel's arithmetic and the recurrent
+    /// stages keep ascending token order.
+    @Test(arguments: ["tiny-model-q4", "tiny-model-q35"])
+    func chunkSizeIsBitwiseIrrelevant(modelName: String) throws {
+        let dir = Self.fixturesDir.appendingPathComponent(modelName)
+        let tokens = [1, 5, 9, 42, 7]
+        var reference: [Float] = []
+        for chunk in [1, 2, 5] {
+            let model = try QwenMetalModel(modelDir: dir)
+            model.prefillMode = .layerMajor(chunkTokens: chunk)
+            let state = QwenCPUModel.DecodeState()
+            let logits = try model.step(tokens, state: state)
+            if reference.isEmpty {
+                reference = logits
+            } else {
+                #expect(logits.map(\.bitPattern) == reference.map(\.bitPattern),
+                        "\(modelName): chunk=\(chunk) logits diverge bitwise from chunk=1")
+            }
+        }
     }
 
     // MARK: - Expert unions vs the S1b-a oracle
@@ -300,7 +369,8 @@ import Testing
                 == Self.q4Baseline.commandBuffers(tokens: tokens.count, chunkTokens: 32),
                 "qpack layer-major command-buffer baseline changed")
         #expect(layerMajorGPU.lastStepMetrics.computeDispatchesEncoded
-                == Self.q4Baseline.dispatches(tokens: tokens.count),
+                == Self.q4Baseline.dispatches(
+                    tokens: tokens.count, chunkTokens: 32, unionSizes: unionSizes),
                 "qpack layer-major dispatch baseline changed")
 
         #expect(unionSizes.count == layerMajorGPU.config.numHiddenLayers,

--- a/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
+++ b/Tests/SwiftletCoreTests/LayerMajorPrefillTests.swift
@@ -17,13 +17,14 @@ import Testing
 
     /// Layer-major token-batched baseline: one decode-token-shaped buffer
     /// sequence per chunk (the S2 9-buffer shape), with the dispatch cost
-    /// decomposed into per-token kernels (the order-sensitive DeltaNet
-    /// recurrence chain and the per-token causal attends), per-chunk batched
-    /// dispatches (each dense/shared/router GEMV plus each glue twin — norm
-    /// copies, deinterleave, silu, residual adds, weighted accumulation,
-    /// attention q prep / KV append — encodes once per chunk regardless of
-    /// chunk size), and per-union-expert batched GEMVs (gate/up/down encode
-    /// once per (expert, projection) per chunk). A single-token chunk
+    /// decomposed into per-token kernels (only the order-sensitive DeltaNet
+    /// conv step, whose history each token advances for the next), per-chunk
+    /// batched dispatches (each dense/shared/router GEMV plus each batch
+    /// twin — norm copies, deinterleave, silu, residual adds, weighted
+    /// accumulation, attention q prep / KV append / causal attend, decay/
+    /// beta prep, q/k norms, gated norm — encodes once per chunk regardless
+    /// of chunk size), and per-union-expert batched GEMVs (gate/up/down
+    /// encode once per (expert, projection) per chunk). A single-token chunk
     /// delegates every batch encode to the legacy per-token path and lands
     /// exactly on the pre-batching decomposition. Exact assertions, S3a
     /// style.
@@ -63,28 +64,29 @@ import Testing
         }
     }
 
-    /// Batching the causal attend re-pins the prefill dispatch baselines.
-    /// Old (glue twins + chunked scan): per token the DeltaNet
-    /// conv/prep/norm chain (conv, decay/beta prep, q/k norms, gated norm;
-    /// 5 per delta layer) plus the causal attend (1 per attention layer):
-    /// q4/q35 32 = 6x5 + 2x1; per chunk q4 144 = 66 GEMVs + 6x6 + 2x5 +
-    /// 8x4 (q35: 150 = 78 + 6x5 + 2x5 + 8x4).
-    /// New: attn_decode_gqa_batch derives each token's kvLen from the token
-    /// grid, so the attend moves to the per-chunk column — per token only
-    /// the order-sensitive DeltaNet chain remains: q4/q35 30 = 6x5. Per
-    /// chunk the GEMVs plus the glue twins, the chunked scan, and the
-    /// batched attend: q4 146 = 66 + 6x6 (input norm, deinterleave, gather,
-    /// T-step scan, residual, post norm) + 2x6 (input norm, q prep, KV
-    /// append, attend, residual, post norm) + 8x4 (top-2 silus, shared
-    /// silu, weighted accum); q35 152 = 78 + 6x5 (no deinterleave) + 2x6 +
-    /// 8x4.
+    /// Batching the DeltaNet prep chain (after the causal attend) re-pins
+    /// the prefill dispatch baselines.
+    /// Old (glue twins + chunked scan + batched attend): per token the
+    /// DeltaNet conv/prep/norm chain — conv, decay/beta prep, q/k norms,
+    /// gated norm; q4/q35 30 = 6x5 — with per chunk q4 146 = 66 GEMVs +
+    /// 6x6 + 2x6 + 8x4 (q35: 152 = 78 + 6x5 + 2x6 + 8x4).
+    /// New: decay/beta prep, the weightless q/k norms, and the gated norm
+    /// are independent per token, so they encode once per chunk through
+    /// their stride twins — per token only the genuinely order-sensitive
+    /// kernel remains, the depthwise conv step advancing the layer's shared
+    /// history: q4/q35 6 = 6x1. Per chunk the GEMVs plus every batched
+    /// stage: q4 170 = 66 + 6x10 (input norm, deinterleave, decay/beta
+    /// prep, q norm, k norm, gather, T-step scan, gated norm, residual,
+    /// post norm) + 2x6 (input norm, q prep, KV append, attend, residual,
+    /// post norm) + 8x4 (top-2 silus, shared silu, weighted accum);
+    /// q35 176 = 78 + 6x9 (no deinterleave) + 2x6 + 8x4.
     /// Per union expert 3 (gate/up/down). A single-token chunk delegates to
     /// the legacy path and lands exactly on the old pin: 104 + 66 + 3x16
     /// = 218 and 98 + 78 + 3x16 = 224 (16 = 8 layers x top-2 picks).
     static let q4Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 30,
-        perChunkDispatches: 146,
+        perTokenDispatches: 6,
+        perChunkDispatches: 170,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 104,
@@ -93,8 +95,8 @@ import Testing
     )
     static let q35Baseline = LayerMajorBaseline(
         commandBuffersPerChunk: MetalModelTests.commandBuffersPerToken,
-        perTokenDispatches: 30,
-        perChunkDispatches: 152,
+        perTokenDispatches: 6,
+        perChunkDispatches: 176,
         perUnionExpertDispatches: 3,
         lmHeadDispatches: 2,
         legacyPerTokenDispatches: 98,

--- a/Tests/SwiftletCoreTests/MetalAttentionTests.swift
+++ b/Tests/SwiftletCoreTests/MetalAttentionTests.swift
@@ -26,11 +26,11 @@ import Testing
         cpu.retainAllLayers = true
         let gpu = try QwenMetalModel(modelDir: dir)
         let tokens = [1, 5, 9, 42, 7]
-        let cpuState = QwenCPUModel.DecodeState()
-        let gpuState = QwenCPUModel.DecodeState()
+        let cpuState = cpu.makeQwenContext()
+        let gpuState = gpu.makeQwenContext()
         for t in tokens {
-            _ = try cpu.step([t], state: cpuState)
-            _ = try gpu.step([t], state: gpuState)
+            _ = try cpu.step([t], context: cpuState)
+            _ = try gpu.step([t], context: gpuState)
         }
 
         var attentionLayers = 0
@@ -67,13 +67,13 @@ import Testing
         let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
         let tokens = [1, 5, 9, 42, 7]
         let sequential = try QwenMetalModel(modelDir: dir)
-        let seqState = QwenCPUModel.DecodeState()
-        for t in tokens { _ = try sequential.step([t], state: seqState) }
+        let seqState = sequential.makeQwenContext()
+        for t in tokens { _ = try sequential.step([t], context: seqState) }
 
         let chunked = try QwenMetalModel(modelDir: dir)
         chunked.prefillMode = .layerMajor(chunkTokens: 2) // crosses chunk boundaries
-        let chunkState = QwenCPUModel.DecodeState()
-        _ = try chunked.step(tokens, state: chunkState)
+        let chunkState = chunked.makeQwenContext()
+        _ = try chunked.step(tokens, context: chunkState)
 
         for li in 0..<chunked.config.numHiddenLayers where !chunked.config.isLinearLayer(li) {
             let seqRows = try #require(
@@ -96,8 +96,8 @@ import Testing
     @Test func attentionDecodeEncodesOneBufferPerLayer() throws {
         let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
         let model = try QwenMetalModel(modelDir: dir)
-        let state = QwenCPUModel.DecodeState()
-        _ = try model.step([1], state: state)
+        let state = model.makeQwenContext()
+        _ = try model.step([1], context: state)
         let timeline = model.lastStepMetrics.commandBufferTimeline
         #expect(timeline.count == model.config.numHiddenLayers + 1,
                 "decode is not one buffer per layer plus the tail")

--- a/Tests/SwiftletCoreTests/MetalAttentionTests.swift
+++ b/Tests/SwiftletCoreTests/MetalAttentionTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S2: full-attention decode runs on Metal against a GPU-resident KV cache.
+/// state.kv stays the observable KV state — a CPU-side mirror copied from the
+/// GPU rows after each attention layer — so the existing KV parity
+/// assertions keep their meaning instead of trivially comparing empties.
+@Suite struct MetalAttentionTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    /// After a decode loop, every attention layer must hold its KV rows on
+    /// the GPU, the state.kv mirror must equal those rows bitwise (it is
+    /// copied from them), and the mirror must match the CPU reference
+    /// model's KV within accumulation noise. That noise is dominated by the
+    /// k projection itself — quantized affine GEMV on GPU vs dequantized
+    /// BLAS on CPU — not by the attention kernels; measured 1.2e-5 on
+    /// M4 Max, pinned at 5e-5.
+    @Test func decodeKVCacheIsGPUResidentAndMatchesCPU() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let cpu = try QwenCPUModel(modelDir: dir)
+        cpu.retainAllLayers = true
+        let gpu = try QwenMetalModel(modelDir: dir)
+        let tokens = [1, 5, 9, 42, 7]
+        let cpuState = QwenCPUModel.DecodeState()
+        let gpuState = QwenCPUModel.DecodeState()
+        for t in tokens {
+            _ = try cpu.step([t], state: cpuState)
+            _ = try gpu.step([t], state: gpuState)
+        }
+
+        var attentionLayers = 0
+        for li in 0..<gpu.config.numHiddenLayers where !gpu.config.isLinearLayer(li) {
+            attentionLayers += 1
+            let rows = try #require(
+                gpu.attentionKVCacheRows(layer: li, count: tokens.count),
+                "layer \(li): no GPU-resident KV cache after decode"
+            )
+            let mirror = try #require(gpuState.kv[li], "layer \(li): KV mirror missing")
+            #expect(rows.k == mirror.k, "layer \(li): GPU K rows diverge from the mirror")
+            #expect(rows.v == mirror.v, "layer \(li): GPU V rows diverge from the mirror")
+
+            let cpuKV = try #require(cpuState.kv[li], "layer \(li): CPU reference KV missing")
+            let kDiff = MetalModelTests.maxAbsDiff(mirror.k, cpuKV.k)
+            let vDiff = MetalModelTests.maxAbsDiff(mirror.v, cpuKV.v)
+            #expect(kDiff < 5e-5, "layer \(li): K vs CPU reference maxAbsDiff \(kDiff)")
+            #expect(vDiff < 5e-5, "layer \(li): V vs CPU reference maxAbsDiff \(vDiff)")
+        }
+        #expect(attentionLayers > 0, "fixture has no attention layers")
+
+        // DeltaNet layers never grow a KV cache.
+        for li in 0..<gpu.config.numHiddenLayers where gpu.config.isLinearLayer(li) {
+            #expect(gpu.attentionKVCacheRows(layer: li, count: 1) == nil,
+                    "layer \(li): DeltaNet layer grew a KV cache")
+        }
+    }
+
+    /// Batched attention prefill must land the same GPU KV rows as the
+    /// sequential decode loop — same kernels at the same absolute positions,
+    /// so the rows match bitwise even across chunk boundaries — and the
+    /// state.kv mirror must track the GPU rows through those boundaries.
+    @Test func batchedPrefillKVMatchesSequentialDecode() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let tokens = [1, 5, 9, 42, 7]
+        let sequential = try QwenMetalModel(modelDir: dir)
+        let seqState = QwenCPUModel.DecodeState()
+        for t in tokens { _ = try sequential.step([t], state: seqState) }
+
+        let chunked = try QwenMetalModel(modelDir: dir)
+        chunked.prefillMode = .layerMajor(chunkTokens: 2) // crosses chunk boundaries
+        let chunkState = QwenCPUModel.DecodeState()
+        _ = try chunked.step(tokens, state: chunkState)
+
+        for li in 0..<chunked.config.numHiddenLayers where !chunked.config.isLinearLayer(li) {
+            let seqRows = try #require(
+                sequential.attentionKVCacheRows(layer: li, count: tokens.count),
+                "layer \(li): sequential decode kept no GPU KV")
+            let chunkRows = try #require(
+                chunked.attentionKVCacheRows(layer: li, count: tokens.count),
+                "layer \(li): batched prefill kept no GPU KV")
+            #expect(seqRows.k == chunkRows.k, "layer \(li): batched K rows diverge from decode")
+            #expect(seqRows.v == chunkRows.v, "layer \(li): batched V rows diverge from decode")
+            let mirror = try #require(chunkState.kv[li], "layer \(li): chunk KV mirror missing")
+            #expect(chunkRows.k == mirror.k, "layer \(li): chunk mirror diverges from GPU K rows")
+            #expect(chunkRows.v == mirror.v, "layer \(li): chunk mirror diverges from GPU V rows")
+        }
+    }
+
+    /// The decode schedule encodes each attention layer in one command
+    /// buffer — projections, KV append, attention, out-proj, and the router
+    /// probe together. The CPU round trip's second buffer is gone.
+    @Test func attentionDecodeEncodesOneBufferPerLayer() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1], state: state)
+        let timeline = model.lastStepMetrics.commandBufferTimeline
+        #expect(timeline.count == model.config.numHiddenLayers + 1,
+                "decode is not one buffer per layer plus the tail")
+
+        let attentionLayerCount = (0..<model.config.numHiddenLayers)
+            .filter { !model.config.isLinearLayer($0) }.count
+        let attentionBuffers = timeline.filter { $0.phases.contains(.attention) }
+        #expect(attentionBuffers.count == attentionLayerCount,
+                "attention layers must encode exactly one buffer each")
+        for sample in attentionBuffers {
+            #expect(sample.phases.contains(.router),
+                    "attention buffer no longer carries its router probe")
+        }
+    }
+}

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -780,6 +780,54 @@ import Testing
                 "T-step scan state diverges bitwise from chained T=1 steps")
     }
 
+    /// conv_scan is the same kind of sequential in-dispatch scan for the
+    /// depthwise conv: one T=3 dispatch must reproduce three chained
+    /// conv_step dispatches bitwise (every token's conv+silu row and the
+    /// final shifted history), because each iteration performs the
+    /// single-step kernel's arithmetic verbatim with the history carried
+    /// across tokens in registers instead of a barrier-fenced device round
+    /// trip per token.
+    @Test func convScanMatchesChainedStepsBitwise() throws {
+        let engine = try MetalEngine()
+        let convDim = 48, K = 4, tokens = 3
+        let inOff = 5
+        let outOff = inOff + convDim + 3
+        let stride = outOff + convDim + 7
+        var rng = Rand(151)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+        let hist0 = (0..<(K - 1) * convDim).map { _ in rng.float() }
+        let wgt = engine.makeBuffer((0..<convDim * K).map { _ in rng.float() })
+
+        let dataA = engine.makeBuffer(src)
+        let histA = engine.makeBuffer(hist0)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("conv_step"))
+                var p = SIMD4<UInt32>(UInt32(convDim), UInt32(K),
+                                      UInt32(inOff + t * stride), UInt32(outOff + t * stride))
+                enc.setBuffer(dataA, offset: 0, index: 0)
+                enc.setBuffer(histA, offset: 0, index: 1)
+                enc.setBuffer(wgt, offset: 0, index: 2)
+                enc.setBytes(&p, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: convDim, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, convDim), height: 1, depth: 1))
+                enc.memoryBarrier(scope: .buffers) // token t+1 reads the advanced history
+            }
+        }
+        let dataB = engine.makeBuffer(src)
+        let histB = engine.makeBuffer(hist0)
+        let scanned = try Self.runEncoded(engine) { enc in
+            try engine.encodeConvScan(
+                enc, data: dataB, hist: histB, weight: wgt, convDim: convDim, K: K,
+                inOff: inOff, outOff: outOff, slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "conv_step: per-token dispatch count")
+        #expect(scanned == 1, "conv_scan: scan dispatch count")
+        Self.expectBitwise(dataA, dataB, tokens * stride, "conv_scan data")
+        Self.expectBitwise(histA, histB, (K - 1) * convDim, "conv_scan history")
+    }
+
     /// delta_gather packs slot-strided q/k/v/g/beta into the contiguous
     /// [T, row] staging blocks as pure copies — bitwise against a CPU
     /// reference, one dispatch, sources untouched.

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -250,4 +250,318 @@ import Testing
         try Self.expectBatchMatches(
             engine, lin, label: "split table", tokens: 513, expectedBatchDispatches: 2)
     }
+
+    // MARK: - S1b non-GEMV batch twins
+
+    /// Encodes `body` into one command buffer, waits, and returns how many
+    /// compute dispatches it encoded (via the engine's dispatch observer).
+    static func runEncoded(
+        _ engine: MetalEngine, _ body: (MTLComputeCommandEncoder) throws -> Void
+    ) throws -> Int {
+        var dispatches = 0
+        engine.computeDispatchObserver = { dispatches += 1 }
+        defer { engine.computeDispatchObserver = nil }
+        let cb = engine.queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+        do {
+            try body(enc)
+        } catch {
+            enc.endEncoding() // Metal aborts on encoders released mid-encode.
+            throw error
+        }
+        enc.endEncoding()
+        cb.commit()
+        cb.waitUntilCompleted()
+        return dispatches
+    }
+
+    static func floats(_ buf: MTLBuffer, _ n: Int) -> [Float] {
+        Array(UnsafeBufferPointer(
+            start: buf.contents().bindMemory(to: Float.self, capacity: n), count: n))
+    }
+
+    static func expectBitwise(_ a: MTLBuffer, _ b: MTLBuffer, _ n: Int, _ label: String) {
+        #expect(floats(a, n).map(\.bitPattern) == floats(b, n).map(\.bitPattern),
+                "\(label): batched kernel diverges bitwise from per-token dispatches")
+    }
+
+    /// norm_copy_batch: per-token norm_copy dispatches vs one batched
+    /// dispatch over strided hidden rows and destinations, bitwise.
+    @Test func normCopyBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let dim = 64, tokens = 3, hStride = dim + 9, dstStride = dim + 21, dstOff = 5
+        var rng = Rand(11)
+        let h = (0..<tokens * hStride).map { _ in rng.float() }
+        let wgt = (0..<dim).map { _ in rng.float() }
+        let hBuf = engine.makeBuffer(h)
+        let wBuf = engine.makeBuffer(wgt)
+        let dstFloats = dstOff + tokens * dstStride
+
+        struct NormParams {
+            var rows: UInt32; var dim: UInt32; var eps: Float
+            var hasWeight: UInt32; var scale: Float; var off: UInt32
+        }
+        let dstA = engine.device.makeBuffer(length: dstFloats * 4)!
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("norm_copy"))
+                var p = NormParams(rows: 1, dim: UInt32(dim), eps: 1e-6, hasWeight: 1,
+                                   scale: 1, off: UInt32(dstOff + t * dstStride))
+                enc.setBuffer(hBuf, offset: t * hStride * 4, index: 0)
+                enc.setBuffer(dstA, offset: 0, index: 1)
+                enc.setBuffer(wBuf, offset: 0, index: 2)
+                enc.setBytes(&p, length: MemoryLayout<NormParams>.stride, index: 3)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: 32, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+            }
+        }
+        let dstB = engine.device.makeBuffer(length: dstFloats * 4)!
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeNormCopyBatch(
+                enc, h: hBuf, hByteOffset: 0, hStride: hStride,
+                dst: dstB, weight: wBuf, dim: dim, eps: 1e-6,
+                dstOff: dstOff, dstStride: dstStride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "norm_copy: per-token dispatch count")
+        #expect(batched == 1, "norm_copy: batched dispatch count")
+        Self.expectBitwise(dstA, dstB, dstFloats, "norm_copy")
+    }
+
+    /// silu_mul_batch: per-token encodeSiluMul vs one strided batch, bitwise.
+    @Test func siluMulBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let count = 48, tokens = 4, stride = 200
+        let gOff = 3, uOff = 61, dstOff = 119
+        var rng = Rand(23)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+
+        func run(_ body: (MTLComputeCommandEncoder, MTLBuffer) throws -> Void)
+            throws -> (buf: MTLBuffer, dispatches: Int)
+        {
+            let buf = engine.makeBuffer(src)
+            let n = try Self.runEncoded(engine) { try body($0, buf) }
+            return (buf, n)
+        }
+        let perToken = try run { enc, buf in
+            for t in 0..<tokens {
+                try engine.encodeSiluMul(
+                    enc, buf: buf, count: count, gOff: gOff + t * stride,
+                    uOff: uOff + t * stride, dstOff: dstOff + t * stride)
+            }
+        }
+        let batched = try run { enc, buf in
+            try engine.encodeSiluMulBatch(
+                enc, buf: buf, count: count, gOff: gOff, uOff: uOff,
+                dstOff: dstOff, stride: stride, tokens: tokens)
+        }
+        #expect(perToken.dispatches == tokens, "silu_mul: per-token dispatch count")
+        #expect(batched.dispatches == 1, "silu_mul: batched dispatch count")
+        Self.expectBitwise(perToken.buf, batched.buf, tokens * stride, "silu_mul")
+    }
+
+    /// add_inplace_batch: per-token add_inplace dispatches vs one strided
+    /// batch over hidden rows, bitwise.
+    @Test func addInplaceBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let count = 64, tokens = 3, hStride = count + 5, rStride = 150, rOff = 7
+        var rng = Rand(31)
+        let h = (0..<tokens * hStride).map { _ in rng.float() }
+        let r = (0..<tokens * rStride).map { _ in rng.float() }
+        let rBuf = engine.makeBuffer(r)
+
+        let hA = engine.makeBuffer(h)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("add_inplace"))
+                var p = SIMD2<UInt32>(UInt32(count), UInt32(rOff + t * rStride))
+                enc.setBuffer(hA, offset: t * hStride * 4, index: 0)
+                enc.setBuffer(rBuf, offset: 0, index: 1)
+                enc.setBytes(&p, length: MemoryLayout<SIMD2<UInt32>>.stride, index: 2)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: count, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, count), height: 1, depth: 1))
+            }
+        }
+        let hB = engine.makeBuffer(h)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeAddInplaceBatch(
+                enc, h: hB, hStride: hStride, r: rBuf, rOff: rOff, rStride: rStride,
+                count: count, tokens: tokens)
+        }
+        #expect(perToken == tokens, "add_inplace: per-token dispatch count")
+        #expect(batched == 1, "add_inplace: batched dispatch count")
+        Self.expectBitwise(hA, hB, tokens * hStride, "add_inplace")
+    }
+
+    /// weighted_accum_batch: per-token weighted_accum (own weights each) vs
+    /// one batched dispatch with a token-major weights table, bitwise.
+    @Test func weightedAccumBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let d = 64, k = 2, tokens = 3, hStride = d + 3, stride = 400
+        let dBase = 11, shOff = 11 + k * d + 9, gateOff = shOff + d + 17
+        var rng = Rand(47)
+        let h = (0..<tokens * hStride).map { _ in rng.float() }
+        let data = (0..<tokens * stride).map { _ in rng.float() }
+        let weights = (0..<tokens * k).map { _ in rng.float() }
+        let dataBuf = engine.makeBuffer(data)
+
+        let hA = engine.makeBuffer(h)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("weighted_accum"))
+                var p = SIMD8<UInt32>(
+                    UInt32(d), UInt32(k), UInt32(dBase + t * stride),
+                    UInt32(shOff + t * stride), UInt32(gateOff + t * stride), 0, 0, 0)
+                enc.setBuffer(hA, offset: t * hStride * 4, index: 0)
+                enc.setBuffer(dataBuf, offset: 0, index: 1)
+                enc.setBytes(&p, length: MemoryLayout<SIMD8<UInt32>>.stride, index: 2)
+                let wk = Array(weights[t * k..<(t + 1) * k])
+                wk.withUnsafeBufferPointer {
+                    enc.setBytes($0.baseAddress!, length: $0.count * 4, index: 3)
+                }
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: d, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, d), height: 1, depth: 1))
+            }
+        }
+        let hB = engine.makeBuffer(h)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeWeightedAccumBatch(
+                enc, h: hB, hStride: hStride, data: dataBuf,
+                count: d, k: k, dBase: dBase, shOff: shOff, gateOff: gateOff,
+                stride: stride, weights: weights, tokens: tokens)
+        }
+        #expect(perToken == tokens, "weighted_accum: per-token dispatch count")
+        #expect(batched == 1, "weighted_accum: batched dispatch count")
+        Self.expectBitwise(hA, hB, tokens * hStride, "weighted_accum")
+    }
+
+    /// deinterleave_qkvz_batch: per-token deinterleaves vs one strided
+    /// batch, bitwise across the whole slotted scratch buffer.
+    @Test func deinterleaveBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let nk = 2, dk = 8, rep = 2, dv = 8, tokens = 3
+        let keyDim = nk * dk
+        let srcOff = 0, baOff = 96, qkvOff = 120, zOff = 190, bOff = 230, aOff = 240
+        let stride = 260
+        var rng = Rand(53)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+
+        struct DeintParams {
+            var nk: UInt32; var dk: UInt32; var rep: UInt32; var dv: UInt32
+            var keyDim: UInt32; var srcOff: UInt32; var baOff: UInt32
+            var qkvOff: UInt32; var zOff: UInt32; var bOff: UInt32; var aOff: UInt32
+        }
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("deinterleave_qkvz"))
+                let b = t * stride
+                var p = DeintParams(
+                    nk: UInt32(nk), dk: UInt32(dk), rep: UInt32(rep), dv: UInt32(dv),
+                    keyDim: UInt32(keyDim), srcOff: UInt32(srcOff + b),
+                    baOff: UInt32(baOff + b), qkvOff: UInt32(qkvOff + b),
+                    zOff: UInt32(zOff + b), bOff: UInt32(bOff + b), aOff: UInt32(aOff + b))
+                enc.setBuffer(bufA, offset: 0, index: 0)
+                enc.setBytes(&p, length: MemoryLayout<DeintParams>.stride, index: 1)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: nk, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, nk), height: 1, depth: 1))
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeDeinterleaveBatch(
+                enc, data: bufB, nk: nk, dk: dk, rep: rep, dv: dv, keyDim: keyDim,
+                srcOff: srcOff, baOff: baOff, qkvOff: qkvOff, zOff: zOff,
+                bOff: bOff, aOff: aOff, stride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "deinterleave: per-token dispatch count")
+        #expect(batched == 1, "deinterleave: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, tokens * stride, "deinterleave")
+    }
+
+    /// attn_q_prep_batch: per-token preps at ascending positions vs one
+    /// batched dispatch (position derived from the token grid slot), bitwise.
+    @Test func attnQPrepBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let heads = 4, headDim = 16, rot = 4, tokens = 3, basePosition = 9
+        let srcOff = 0
+        let dstOff = heads * 2 * headDim + 7
+        let stride = dstOff + heads * headDim + 5
+        var rng = Rand(61)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+        let wgt = (0..<headDim).map { _ in rng.float() }
+        let wBuf = engine.makeBuffer(wgt)
+
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                try engine.encodeAttnQPrep(
+                    enc, data: bufA, weight: wBuf, heads: heads, headDim: headDim,
+                    rotaryDims: rot, eps: 1e-6, ropeTheta: 1e7,
+                    position: basePosition + t,
+                    srcOff: srcOff + t * stride, dstOff: dstOff + t * stride)
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeAttnQPrepBatch(
+                enc, data: bufB, weight: wBuf, heads: heads, headDim: headDim,
+                rotaryDims: rot, eps: 1e-6, ropeTheta: 1e7,
+                basePosition: basePosition, srcOff: srcOff, dstOff: dstOff,
+                slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "attn_q_prep: per-token dispatch count")
+        #expect(batched == 1, "attn_q_prep: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, tokens * stride, "attn_q_prep")
+    }
+
+    /// attn_kv_append_batch: per-token appends at ascending positions vs one
+    /// batched dispatch, bitwise over both caches and the scratch.
+    @Test func attnKVAppendBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let kvHeads = 2, headDim = 16, rot = 4, tokens = 3, basePosition = 5
+        let kSrcOff = 3
+        let vSrcOff = kSrcOff + kvHeads * headDim + 9
+        let stride = vSrcOff + kvHeads * headDim + 11
+        let cacheFloats = (basePosition + tokens) * kvHeads * headDim
+        var rng = Rand(71)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+        let wgt = (0..<headDim).map { _ in rng.float() }
+        let seed = (0..<cacheFloats).map { _ in rng.float() }
+        let wBuf = engine.makeBuffer(wgt)
+
+        func run(_ body: (MTLComputeCommandEncoder, MTLBuffer, MTLBuffer, MTLBuffer) throws -> Void)
+            throws -> (data: MTLBuffer, k: MTLBuffer, v: MTLBuffer, dispatches: Int)
+        {
+            let data = engine.makeBuffer(src)
+            let k = engine.makeBuffer(seed)
+            let v = engine.makeBuffer(seed)
+            let n = try Self.runEncoded(engine) { try body($0, data, k, v) }
+            return (data, k, v, n)
+        }
+        let perToken = try run { enc, data, k, v in
+            for t in 0..<tokens {
+                try engine.encodeAttnKVAppend(
+                    enc, data: data, weight: wBuf, kCache: k, vCache: v,
+                    kvHeads: kvHeads, headDim: headDim, rotaryDims: rot,
+                    eps: 1e-6, ropeTheta: 1e7, position: basePosition + t,
+                    kSrcOff: kSrcOff + t * stride, vSrcOff: vSrcOff + t * stride)
+            }
+        }
+        let batched = try run { enc, data, k, v in
+            try engine.encodeAttnKVAppendBatch(
+                enc, data: data, weight: wBuf, kCache: k, vCache: v,
+                kvHeads: kvHeads, headDim: headDim, rotaryDims: rot,
+                eps: 1e-6, ropeTheta: 1e7, basePosition: basePosition,
+                kSrcOff: kSrcOff, vSrcOff: vSrcOff, slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken.dispatches == tokens, "attn_kv_append: per-token dispatch count")
+        #expect(batched.dispatches == 1, "attn_kv_append: batched dispatch count")
+        Self.expectBitwise(perToken.k, batched.k, cacheFloats, "attn_kv_append k cache")
+        Self.expectBitwise(perToken.v, batched.v, cacheFloats, "attn_kv_append v cache")
+        Self.expectBitwise(perToken.data, batched.data, tokens * stride, "attn_kv_append data")
+    }
 }

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -606,6 +606,136 @@ import Testing
         Self.expectBitwise(bufA, bufB, tokens * stride, "attn_decode")
     }
 
+    /// delta_pre_batch: per-token delta_pre dispatches vs one strided batch
+    /// over the slots' a/b rows, bitwise (g and beta both land at outOff).
+    @Test func deltaPreBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let nv = 6, tokens = 3
+        let aOff = 5, bOff = aOff + nv + 3, outOff = bOff + nv + 7
+        let stride = outOff + 2 * nv + 9
+        var rng = Rand(113)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+        let aLog = engine.makeBuffer((0..<nv).map { _ in rng.float() })
+        let dtBias = engine.makeBuffer((0..<nv).map { _ in rng.float() })
+
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("delta_pre"))
+                var p = SIMD4<UInt32>(
+                    UInt32(nv), UInt32(aOff + t * stride),
+                    UInt32(bOff + t * stride), UInt32(outOff + t * stride))
+                enc.setBuffer(bufA, offset: 0, index: 0)
+                enc.setBuffer(aLog, offset: 0, index: 1)
+                enc.setBuffer(dtBias, offset: 0, index: 2)
+                enc.setBytes(&p, length: MemoryLayout<SIMD4<UInt32>>.stride, index: 3)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: nv, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: min(64, nv), height: 1, depth: 1))
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeDeltaPreBatch(
+                enc, data: bufB, aLog: aLog, dtBias: dtBias,
+                nv: nv, aOff: aOff, bOff: bOff, outOff: outOff,
+                slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "delta_pre: per-token dispatch count")
+        #expect(batched == 1, "delta_pre: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, tokens * stride, "delta_pre")
+    }
+
+    /// rmsnorm_rows_batch: per-token in-place rmsnorm_rows dispatches vs one
+    /// strided batch, bitwise — in the weightless scaled shape the DeltaNet
+    /// q/k norms use.
+    @Test func rmsnormRowsBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let rows = 2, dim = 32, tokens = 3, off = 5
+        let stride = rows * dim + 11
+        let scale: Float = 0.25
+        let total = off + (tokens - 1) * stride + rows * dim
+        var rng = Rand(127)
+        let src = (0..<total).map { _ in rng.float() }
+
+        struct NormParams {
+            var rows: UInt32; var dim: UInt32; var eps: Float
+            var hasWeight: UInt32; var scale: Float; var off: UInt32
+        }
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("rmsnorm_rows"))
+                var p = NormParams(rows: UInt32(rows), dim: UInt32(dim), eps: 1e-6,
+                                   hasWeight: 0, scale: scale, off: UInt32(off + t * stride))
+                enc.setBuffer(bufA, offset: 0, index: 0)
+                enc.setBuffer(bufA, offset: 0, index: 1)
+                enc.setBytes(&p, length: MemoryLayout<NormParams>.stride, index: 2)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: 32, height: rows, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeRMSNormRowsBatch(
+                enc, data: bufB, weight: nil, off: off, rows: rows, dim: dim,
+                scale: scale, eps: 1e-6, slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "rmsnorm_rows: per-token dispatch count")
+        #expect(batched == 1, "rmsnorm_rows: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, total, "rmsnorm_rows")
+    }
+
+    /// gated_norm_mul_batch: per-token gated_norm_mul dispatches vs one
+    /// batched dispatch with per-stream strides — y rows in a contiguous
+    /// staging block (the chunked recurrence's layout), z and the output
+    /// slot-strided — bitwise.
+    @Test func gatedNormMulBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let nv = 4, dv = 8, tokens = 3
+        let zOff = 3
+        let outOff = zOff + nv * dv + 5
+        let slotStride = outOff + nv * dv + 7
+        let yOff = tokens * slotStride
+        let yStride = nv * dv
+        let total = yOff + tokens * yStride
+        var rng = Rand(137)
+        let src = (0..<total).map { _ in rng.float() }
+        let wgt = engine.makeBuffer((0..<dv).map { _ in rng.float() })
+
+        struct GatedNormParams {
+            var nv: UInt32; var dv: UInt32; var eps: Float
+            var yOff: UInt32; var zOff: UInt32; var outOff: UInt32
+        }
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                enc.setComputePipelineState(try engine.pipeline("gated_norm_mul"))
+                var p = GatedNormParams(
+                    nv: UInt32(nv), dv: UInt32(dv), eps: 1e-6,
+                    yOff: UInt32(yOff + t * yStride), zOff: UInt32(zOff + t * slotStride),
+                    outOff: UInt32(outOff + t * slotStride))
+                enc.setBuffer(bufA, offset: 0, index: 0)
+                enc.setBuffer(wgt, offset: 0, index: 1)
+                enc.setBytes(&p, length: MemoryLayout<GatedNormParams>.stride, index: 2)
+                engine.dispatchThreads(
+                    enc, threads: MTLSize(width: 32, height: nv, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeGatedNormMulBatch(
+                enc, data: bufB, weight: wgt, nv: nv, dv: dv, eps: 1e-6,
+                yOff: yOff, yStride: yStride, zOff: zOff, zStride: slotStride,
+                outOff: outOff, outStride: slotStride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "gated_norm_mul: per-token dispatch count")
+        #expect(batched == 1, "gated_norm_mul: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, total, "gated_norm_mul")
+    }
+
     // MARK: - S1b chunked DeltaNet recurrence (T-step scan)
 
     /// gated_delta_step's T parameter is a sequential in-dispatch scan: one

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -565,6 +565,47 @@ import Testing
         Self.expectBitwise(perToken.data, batched.data, tokens * stride, "attn_kv_append data")
     }
 
+    /// attn_decode_gqa_batch: per-token causal attends at ascending kvLens
+    /// vs one batched dispatch whose kernel derives token t's kvLen from
+    /// basePosition + the token grid slot, bitwise over the whole slotted
+    /// scratch. headDim 64 exercises multi-register accumulators.
+    @Test func attnDecodeBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        let heads = 4, kvHeads = 2, headDim = 64, tokens = 3, basePosition = 5
+        let qoutOff = 3
+        let qOff = qoutOff + heads * 2 * headDim + 7
+        let outOff = qOff + heads * headDim + 5
+        let stride = outOff + heads * headDim + 9
+        let cacheFloats = (basePosition + tokens) * kvHeads * headDim
+        var rng = Rand(83)
+        let src = (0..<tokens * stride).map { _ in rng.float() }
+        let kBuf = engine.makeBuffer((0..<cacheFloats).map { _ in rng.float() })
+        let vBuf = engine.makeBuffer((0..<cacheFloats).map { _ in rng.float() })
+
+        let bufA = engine.makeBuffer(src)
+        let perToken = try Self.runEncoded(engine) { enc in
+            for t in 0..<tokens {
+                try engine.encodeAttnDecode(
+                    enc, data: bufA, kCache: kBuf, vCache: vBuf,
+                    heads: heads, kvHeads: kvHeads, headDim: headDim,
+                    kvLen: basePosition + t + 1,
+                    qOff: qOff + t * stride, qoutOff: qoutOff + t * stride,
+                    outOff: outOff + t * stride)
+            }
+        }
+        let bufB = engine.makeBuffer(src)
+        let batched = try Self.runEncoded(engine) { enc in
+            try engine.encodeAttnDecodeBatch(
+                enc, data: bufB, kCache: kBuf, vCache: vBuf,
+                heads: heads, kvHeads: kvHeads, headDim: headDim,
+                basePosition: basePosition, qOff: qOff, qoutOff: qoutOff,
+                outOff: outOff, slotStride: stride, tokens: tokens)
+        }
+        #expect(perToken == tokens, "attn_decode: per-token dispatch count")
+        #expect(batched == 1, "attn_decode: batched dispatch count")
+        Self.expectBitwise(bufA, bufB, tokens * stride, "attn_decode")
+    }
+
     // MARK: - S1b chunked DeltaNet recurrence (T-step scan)
 
     /// gated_delta_step's T parameter is a sequential in-dispatch scan: one

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 import Testing
 @testable import SwiftletCore
 
@@ -125,5 +126,128 @@ import Testing
         for i in 0..<refState.count { maxS = max(maxS, abs(state[i] - refState[i])) }
         #expect(maxY < 1e-4, "delta y maxAbsDiff \(maxY)")
         #expect(maxS < 1e-4, "delta state maxAbsDiff \(maxS)")
+    }
+
+    // MARK: - S1b token-batched GEMV
+
+    static func quantizedLinear(
+        _ engine: MetalEngine, bits: Int, pad: Int, outDim O: Int = 48, inDim I: Int = 128
+    ) -> MetalShardStore.GPULinear {
+        let group = 32
+        let perWord = 32 / bits
+        var rng = Rand(UInt64(bits * 100 + pad + 7))
+        let packed = (0..<O * I / perWord).map { _ in rng.next32() }
+        let scales = (0..<O * I / group).map { _ in rng.float() * 0.1 }
+        let biases = (0..<O * I / group).map { _ in rng.float() * 0.05 }
+        // One blob: [pad] weights | scales | biases. pad = 2 yields weight
+        // rows that are only 2-byte aligned, forcing the scalar kernel.
+        var blob = Data(repeating: 0, count: pad)
+        packed.withUnsafeBytes { blob.append(contentsOf: $0) }
+        let sOff = blob.count
+        scales.withUnsafeBytes { blob.append(contentsOf: $0) }
+        let bOff = blob.count
+        biases.withUnsafeBytes { blob.append(contentsOf: $0) }
+        let buf = engine.makeBuffer(blob)
+        return MetalShardStore.GPULinear(
+            wBuffer: buf, sBuffer: buf, bBuffer: buf, outDim: O, inDim: I,
+            isQuantized: true, groupSize: group, bits: bits, scalesType: 0,
+            wOff: pad, sOff: sOff, bOff: bOff
+        )
+    }
+
+    static func plainLinear(
+        _ engine: MetalEngine, dtype: UInt32, outDim O: Int = 48, inDim I: Int = 128
+    ) -> MetalShardStore.GPULinear {
+        var rng = Rand(UInt64(900 + dtype))
+        let rows = (0..<O * I).map { _ in rng.float() }
+        var blob = Data()
+        switch dtype {
+        case 0: rows.withUnsafeBytes { blob.append(contentsOf: $0) }
+        case 1:
+            let h = rows.map { Float16($0) }
+            h.withUnsafeBytes { blob.append(contentsOf: $0) }
+        default:
+            let b = rows.map { Self.bf16($0) }
+            b.withUnsafeBytes { blob.append(contentsOf: $0) }
+        }
+        let buf = engine.makeBuffer(blob)
+        return MetalShardStore.GPULinear(
+            wBuffer: buf, sBuffer: buf, bBuffer: buf, outDim: O, inDim: I,
+            isQuantized: false, plainDtype: dtype
+        )
+    }
+
+    /// Applies `lin` to `tokens` slots (distinct x/y offsets in shared
+    /// buffers) once through per-token encodeGemv dispatches and once through
+    /// encodeGemvBatch, requiring bitwise-identical output buffers plus the
+    /// mechanical dispatch reduction.
+    static func expectBatchMatches(
+        _ engine: MetalEngine, _ lin: MetalShardStore.GPULinear, label: String,
+        tokens: Int = 3, expectedBatchDispatches: Int = 1
+    ) throws {
+        let O = lin.outDim, I = lin.inDim
+        let xStride = I + 7, yStride = O + 5
+        var rng = Rand(4242)
+        let x = (0..<tokens * xStride).map { _ in rng.float() }
+        let xBuf = engine.makeBuffer(x)
+        let slots = (0..<tokens).map { (xOff: $0 * xStride, yOff: $0 * yStride + 3) }
+        let yFloats = tokens * yStride + 3
+
+        func run(_ body: (MTLComputeCommandEncoder, MTLBuffer) throws -> Void)
+            throws -> (y: [Float], dispatches: Int)
+        {
+            let yBuf = engine.device.makeBuffer(length: yFloats * 4)!
+            memset(yBuf.contents(), 0, yFloats * 4)
+            var dispatches = 0
+            engine.computeDispatchObserver = { dispatches += 1 }
+            defer { engine.computeDispatchObserver = nil }
+            let cb = engine.queue.makeCommandBuffer()!
+            let enc = cb.makeComputeCommandEncoder()!
+            try body(enc, yBuf)
+            enc.endEncoding()
+            cb.commit()
+            cb.waitUntilCompleted()
+            let y = Array(UnsafeBufferPointer(
+                start: yBuf.contents().bindMemory(to: Float.self, capacity: yFloats),
+                count: yFloats))
+            return (y, dispatches)
+        }
+
+        let perToken = try run { enc, yBuf in
+            for s in slots {
+                try engine.encodeGemv(enc, lin, x: xBuf, xOff: s.xOff, y: yBuf, yOff: s.yOff)
+            }
+        }
+        let batched = try run { enc, yBuf in
+            try engine.encodeGemvBatch(enc, lin, x: xBuf, y: yBuf, slots: slots)
+        }
+        #expect(perToken.dispatches == tokens, "\(label): per-token dispatch count")
+        #expect(batched.dispatches == expectedBatchDispatches, "\(label): batched dispatch count")
+        #expect(perToken.y.map(\.bitPattern) == batched.y.map(\.bitPattern),
+                "\(label): batched GEMV diverges bitwise from per-token dispatches")
+    }
+
+    /// Every kernel variant the runtime selects — fast 4/8-bit, the scalar
+    /// fallback (2-byte-aligned weights), and each plain dtype — must batch
+    /// bitwise-identically, with N token dispatches collapsing to one.
+    @Test func gemvBatchMatchesPerTokenBitwise() throws {
+        let engine = try MetalEngine()
+        try Self.expectBatchMatches(engine, Self.quantizedLinear(engine, bits: 4, pad: 0), label: "q4 fast")
+        try Self.expectBatchMatches(engine, Self.quantizedLinear(engine, bits: 8, pad: 0), label: "q8 fast")
+        try Self.expectBatchMatches(engine, Self.quantizedLinear(engine, bits: 4, pad: 2), label: "q4 scalar")
+        try Self.expectBatchMatches(engine, Self.plainLinear(engine, dtype: 0), label: "plain f32")
+        try Self.expectBatchMatches(engine, Self.plainLinear(engine, dtype: 1), label: "plain f16")
+        try Self.expectBatchMatches(engine, Self.plainLinear(engine, dtype: 2), label: "plain bf16")
+    }
+
+    /// A single slot delegates to the unbatched encode (one dispatch, same
+    /// bytes as the decode schedule); a table past the setBytes ceiling
+    /// splits into ceil(n / 512) dispatches, still bitwise.
+    @Test func gemvBatchRespectsTableLimits() throws {
+        let engine = try MetalEngine()
+        let lin = Self.quantizedLinear(engine, bits: 4, pad: 0, outDim: 8, inDim: 32)
+        try Self.expectBatchMatches(engine, lin, label: "single slot", tokens: 1)
+        try Self.expectBatchMatches(
+            engine, lin, label: "split table", tokens: 513, expectedBatchDispatches: 2)
     }
 }

--- a/Tests/SwiftletCoreTests/MetalKernelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalKernelTests.swift
@@ -564,4 +564,96 @@ import Testing
         Self.expectBitwise(perToken.v, batched.v, cacheFloats, "attn_kv_append v cache")
         Self.expectBitwise(perToken.data, batched.data, tokens * stride, "attn_kv_append data")
     }
+
+    // MARK: - S1b chunked DeltaNet recurrence (T-step scan)
+
+    /// gated_delta_step's T parameter is a sequential in-dispatch scan: one
+    /// T=5 dispatch must reproduce five chained T=1 dispatches bitwise (all
+    /// y rows and the final state), because the step loop performs the
+    /// identical ascending arithmetic with state carried in f32 registers
+    /// instead of a per-token f32 device round trip. This is the oracle the
+    /// chunked prefill recurrence stands on.
+    @Test func gatedDeltaChunkedScanMatchesSequentialBitwise() throws {
+        let engine = try MetalEngine()
+        let T = 5, Hk = 2, Hv = 4, Dk = 32, Dv = 8
+        var rng = Rand(97)
+        let q = (0..<T * Hk * Dk).map { _ in rng.float() }
+        let k = (0..<T * Hk * Dk).map { _ in rng.float() }
+        let v = (0..<T * Hv * Dv).map { _ in rng.float() }
+        let g = (0..<T * Hv).map { _ in abs(rng.float()) * 0.9 }
+        let beta = (0..<T * Hv).map { _ in abs(rng.float()) }
+        let state0 = (0..<Hv * Dv * Dk).map { _ in rng.float() * 0.1 }
+
+        var seqY: [Float] = []
+        var seqState = state0
+        for t in 0..<T {
+            let (y, s) = try engine.gatedDeltaStep(
+                q: Array(q[t * Hk * Dk..<(t + 1) * Hk * Dk]),
+                k: Array(k[t * Hk * Dk..<(t + 1) * Hk * Dk]),
+                v: Array(v[t * Hv * Dv..<(t + 1) * Hv * Dv]),
+                g: Array(g[t * Hv..<(t + 1) * Hv]),
+                beta: Array(beta[t * Hv..<(t + 1) * Hv]),
+                state: seqState, T: 1, Hk: Hk, Hv: Hv, Dk: Dk, Dv: Dv
+            )
+            seqY.append(contentsOf: y)
+            seqState = s
+        }
+
+        let (y, state) = try engine.gatedDeltaStep(
+            q: q, k: k, v: v, g: g, beta: beta, state: state0,
+            T: T, Hk: Hk, Hv: Hv, Dk: Dk, Dv: Dv
+        )
+        #expect(y.map(\.bitPattern) == seqY.map(\.bitPattern),
+                "T-step scan y diverges bitwise from chained T=1 steps")
+        #expect(state.map(\.bitPattern) == seqState.map(\.bitPattern),
+                "T-step scan state diverges bitwise from chained T=1 steps")
+    }
+
+    /// delta_gather packs slot-strided q/k/v/g/beta into the contiguous
+    /// [T, row] staging blocks as pure copies — bitwise against a CPU
+    /// reference, one dispatch, sources untouched.
+    @Test func deltaGatherPacksSlotsBitwise() throws {
+        let engine = try MetalEngine()
+        let keyDim = 16, valueDim = 32, nv = 4, tokens = 3
+        let convOff = 7
+        let gbOff = convOff + 2 * keyDim + valueDim + 5
+        let slotStride = gbOff + 2 * nv + 9
+        let stageBase = tokens * slotStride
+        let qOut = stageBase
+        let kOut = qOut + tokens * keyDim
+        let vOut = kOut + tokens * keyDim
+        let gOut = vOut + tokens * valueDim
+        let bOut = gOut + tokens * nv
+        let total = bOut + tokens * nv
+        var rng = Rand(101)
+        let data = (0..<total).map { _ in rng.float() }
+
+        var expected = data
+        for t in 0..<tokens {
+            let slot = t * slotStride
+            for i in 0..<keyDim {
+                expected[qOut + t * keyDim + i] = data[slot + convOff + i]
+                expected[kOut + t * keyDim + i] = data[slot + convOff + keyDim + i]
+            }
+            for i in 0..<valueDim {
+                expected[vOut + t * valueDim + i] = data[slot + convOff + 2 * keyDim + i]
+            }
+            for i in 0..<nv {
+                expected[gOut + t * nv + i] = data[slot + gbOff + i]
+                expected[bOut + t * nv + i] = data[slot + gbOff + nv + i]
+            }
+        }
+
+        let buf = engine.makeBuffer(data)
+        let dispatches = try Self.runEncoded(engine) { enc in
+            try engine.encodeDeltaGather(
+                enc, data: buf, keyDim: keyDim, valueDim: valueDim, nv: nv,
+                slotStride: slotStride, convOff: convOff, gbOff: gbOff,
+                qOut: qOut, kOut: kOut, vOut: vOut, gOut: gOut, bOut: bOut,
+                tokens: tokens)
+        }
+        #expect(dispatches == 1, "delta_gather: dispatch count")
+        #expect(Self.floats(buf, total).map(\.bitPattern) == expected.map(\.bitPattern),
+                "delta_gather diverges from the CPU copy reference")
+    }
 }

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -56,7 +56,7 @@ import Testing
     }
 
     static func expectMatchingKV(
-        _ lhs: QwenCPUModel.DecodeState, _ rhs: QwenCPUModel.DecodeState,
+        _ lhs: QwenInferenceContext, _ rhs: QwenInferenceContext,
         label: String
     ) {
         #expect(lhs.position == rhs.position, "\(label): positions diverged")
@@ -194,13 +194,13 @@ import Testing
         elidingGPU.prefillMode = .tokenMajor
         let tokens = [1, 5, 9, 42, 7]
 
-        let cpuState = QwenCPUModel.DecodeState()
-        let sequentialState = QwenCPUModel.DecodeState()
+        let cpuState = cpu.makeQwenContext()
+        let sequentialState = sequentialGPU.makeQwenContext()
         var cpuLogits: [Float] = []
         var sequentialLogits: [Float] = []
         for t in tokens {
-            cpuLogits = try cpu.step([t], state: cpuState)
-            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            cpuLogits = try cpu.step([t], context: cpuState)
+            sequentialLogits = try sequentialGPU.step([t], context: sequentialState)
             #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
             #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
             #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
@@ -221,8 +221,8 @@ import Testing
 
         // S1a intermediate LM-head elision must retain token-at-a-time output
         // and state. Separate instances isolate GPU-resident recurrence.
-        let elidingState = QwenCPUModel.DecodeState()
-        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elidingState = elidingGPU.makeQwenContext()
+        let elidingLogits = try elidingGPU.step(tokens, context: elidingState)
         let multiMetrics = elidingGPU.lastStepMetrics
         let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
         #expect(elisionDiff < 2e-3, "\(modelName): LM-head elision logits maxAbsDiff \(elisionDiff)")
@@ -241,8 +241,8 @@ import Testing
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
 
         let continuation = 11
-        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
-        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let sequentialContinuation = try sequentialGPU.step([continuation], context: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], context: elidingState)
         let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
         #expect(continuationDiff < 2e-3, "\(modelName): continuation maxAbsDiff \(continuationDiff)")
         #expect(elidingGPU.lastStepMetrics.tokensProcessed == 1)
@@ -282,8 +282,8 @@ import Testing
         let model = try QwenMetalModel(modelDir: dir)
         // Pins the legacy token-major prompt schedule (S1a).
         model.prefillMode = .tokenMajor
-        let state = QwenCPUModel.DecodeState()
-        _ = try model.step([1, 5, 9], state: state)
+        let state = model.makeQwenContext()
+        _ = try model.step([1, 5, 9], context: state)
         let multi = model.lastStepMetrics
         Self.expectInstrumentation(multi, tokens: 3, label: "timeline multi")
         Self.expectFastPathBaseline(
@@ -298,7 +298,7 @@ import Testing
         #expect(encodeSum + multi.blockingWaitSeconds <= multi.stepWallSeconds + 1e-3,
                 "timeline multi: encode+wait exceeds the step wall clock")
 
-        _ = try model.step([11], state: state)
+        _ = try model.step([11], context: state)
         let single = model.lastStepMetrics
         Self.expectPhaseTimeline(
             single,
@@ -332,13 +332,13 @@ import Testing
         #expect(elidingGPU.expertCache != nil, "qpack mode not engaged")
 
         let tokens = [1, 5, 9, 42, 7, 99]
-        let cpuState = QwenCPUModel.DecodeState()
-        let sequentialState = QwenCPUModel.DecodeState()
+        let cpuState = cpu.makeQwenContext()
+        let sequentialState = sequentialGPU.makeQwenContext()
         var cpuLogits: [Float] = []
         var sequentialLogits: [Float] = []
         for t in tokens {
-            cpuLogits = try cpu.step([t], state: cpuState)
-            sequentialLogits = try sequentialGPU.step([t], state: sequentialState)
+            cpuLogits = try cpu.step([t], context: cpuState)
+            sequentialLogits = try sequentialGPU.step([t], context: sequentialState)
             #expect(sequentialGPU.lastStepMetrics.tokensProcessed == 1)
             #expect(sequentialGPU.lastStepMetrics.logitProjections == 1)
             #expect(sequentialGPU.lastStepMetrics.avoidedLogitProjections == 0)
@@ -356,8 +356,8 @@ import Testing
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
 
-        let elidingState = QwenCPUModel.DecodeState()
-        let elidingLogits = try elidingGPU.step(tokens, state: elidingState)
+        let elidingState = elidingGPU.makeQwenContext()
+        let elidingLogits = try elidingGPU.step(tokens, context: elidingState)
         let multiMetrics = elidingGPU.lastStepMetrics
         let elisionDiff = Self.maxAbsDiff(sequentialLogits, elidingLogits)
         #expect(elisionDiff < 2e-3, "qpack LM-head elision maxAbsDiff \(elisionDiff)")
@@ -377,8 +377,8 @@ import Testing
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
 
         let continuation = 11
-        let sequentialContinuation = try sequentialGPU.step([continuation], state: sequentialState)
-        let elidingContinuation = try elidingGPU.step([continuation], state: elidingState)
+        let sequentialContinuation = try sequentialGPU.step([continuation], context: sequentialState)
+        let elidingContinuation = try elidingGPU.step([continuation], context: elidingState)
         let continuationDiff = Self.maxAbsDiff(sequentialContinuation, elidingContinuation)
         #expect(continuationDiff < 2e-3, "qpack continuation maxAbsDiff \(continuationDiff)")
         #expect(elidingGPU.lastStepMetrics.logitProjections == 1)

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -92,20 +92,19 @@ import Testing
     }
 
     /// S3b: the committed command-buffer timeline must label every buffer,
-    /// follow the fast-path schedule exactly, and account for the S3a
+    /// follow the expected schedule exactly, and account for the S3a
     /// aggregates without inventing timing the buffers never reported.
     /// Only meaningful for a step that completed without throwing.
     static func expectPhaseTimeline(
         _ metrics: QwenMetalModel.StepMetrics,
-        config: QwenConfig,
-        tokens: Int,
+        expectedPhases: [[QwenMetalModel.StepPhase]],
         label: String
     ) {
         let timeline = metrics.commandBufferTimeline
         #expect(timeline.count == metrics.commandBuffersCommitted,
                 "\(label): timeline misses committed buffers")
-        #expect(timeline.map(\.phases) == Self.expectedTimelinePhases(config: config, tokens: tokens),
-                "\(label): phase labels diverged from the fast-path schedule")
+        #expect(timeline.map(\.phases) == expectedPhases,
+                "\(label): phase labels diverged from the expected schedule")
 
         let phaseDispatchTotal = metrics.phaseDispatchesEncoded.values.reduce(0, +)
         #expect(phaseDispatchTotal == metrics.computeDispatchesEncoded,
@@ -181,6 +180,11 @@ import Testing
         cpu.retainAllLayers = true
         let sequentialGPU = try QwenMetalModel(modelDir: dir)
         let elidingGPU = try QwenMetalModel(modelDir: dir)
+        // These baselines pin the legacy token-major prompt schedule (S1a).
+        // The layer-major S1b schedule has its own pinned baselines in
+        // LayerMajorPrefillTests.
+        sequentialGPU.prefillMode = .tokenMajor
+        elidingGPU.prefillMode = .tokenMajor
         let tokens = [1, 5, 9, 42, 7]
 
         let cpuState = QwenCPUModel.DecodeState()
@@ -200,7 +204,8 @@ import Testing
             singleMetrics, tokens: 1, baseline: baseline, label: "\(modelName) one token"
         )
         Self.expectPhaseTimeline(
-            singleMetrics, config: sequentialGPU.config, tokens: 1,
+            singleMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: sequentialGPU.config, tokens: 1),
             label: "\(modelName) one token"
         )
 
@@ -222,7 +227,8 @@ import Testing
             multiMetrics, tokens: tokens.count, baseline: baseline, label: "\(modelName) multi token"
         )
         Self.expectPhaseTimeline(
-            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            multiMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: elidingGPU.config, tokens: tokens.count),
             label: "\(modelName) multi token"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
@@ -243,7 +249,8 @@ import Testing
             baseline: baseline, label: "\(modelName) continuation"
         )
         Self.expectPhaseTimeline(
-            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            elidingGPU.lastStepMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: elidingGPU.config, tokens: 1),
             label: "\(modelName) continuation"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
@@ -266,6 +273,8 @@ import Testing
     @Test func phaseTimelineAccountsForWholeStep() throws {
         let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
         let model = try QwenMetalModel(modelDir: dir)
+        // Pins the legacy token-major prompt schedule (S1a).
+        model.prefillMode = .tokenMajor
         let state = QwenCPUModel.DecodeState()
         _ = try model.step([1, 5, 9], state: state)
         let multi = model.lastStepMetrics
@@ -274,7 +283,9 @@ import Testing
             multi, tokens: 3, baseline: Self.q4Baseline, label: "timeline multi"
         )
         Self.expectPhaseTimeline(
-            multi, config: model.config, tokens: 3, label: "timeline multi"
+            multi,
+            expectedPhases: Self.expectedTimelinePhases(config: model.config, tokens: 3),
+            label: "timeline multi"
         )
         let encodeSum = multi.commandBufferTimeline.reduce(0.0) { $0 + $1.encodeSeconds }
         #expect(encodeSum + multi.blockingWaitSeconds <= multi.stepWallSeconds + 1e-3,
@@ -283,7 +294,9 @@ import Testing
         _ = try model.step([11], state: state)
         let single = model.lastStepMetrics
         Self.expectPhaseTimeline(
-            single, config: model.config, tokens: 1, label: "timeline continuation"
+            single,
+            expectedPhases: Self.expectedTimelinePhases(config: model.config, tokens: 1),
+            label: "timeline continuation"
         )
         #expect(single.commandBufferTimeline.count == Self.commandBuffersPerToken,
                 "timeline continuation: timeline accumulated across steps")
@@ -304,6 +317,10 @@ import Testing
         cpu.retainAllLayers = true
         let sequentialGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
         let elidingGPU = try QwenMetalModel(modelDir: out, cacheBudgetGB: 0.05)
+        // Pins the legacy token-major prompt schedule (S1a); the layer-major
+        // qpack path is covered by LayerMajorPrefillTests.
+        sequentialGPU.prefillMode = .tokenMajor
+        elidingGPU.prefillMode = .tokenMajor
         #expect(sequentialGPU.expertCache != nil, "qpack mode not engaged")
         #expect(elidingGPU.expertCache != nil, "qpack mode not engaged")
 
@@ -325,7 +342,9 @@ import Testing
             singleMetrics, tokens: 1, baseline: Self.q4Baseline, label: "qpack one token"
         )
         Self.expectPhaseTimeline(
-            singleMetrics, config: sequentialGPU.config, tokens: 1, label: "qpack one token"
+            singleMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: sequentialGPU.config, tokens: 1),
+            label: "qpack one token"
         )
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
@@ -344,7 +363,8 @@ import Testing
             baseline: Self.q4Baseline, label: "qpack multi token"
         )
         Self.expectPhaseTimeline(
-            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            multiMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: elidingGPU.config, tokens: tokens.count),
             label: "qpack multi token"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
@@ -363,7 +383,8 @@ import Testing
             baseline: Self.q4Baseline, label: "qpack continuation"
         )
         Self.expectPhaseTimeline(
-            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            elidingGPU.lastStepMetrics,
+            expectedPhases: Self.expectedTimelinePhases(config: elidingGPU.config, tokens: 1),
             label: "qpack continuation"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -91,6 +91,90 @@ import Testing
                 "\(label): fast-path dispatch baseline changed")
     }
 
+    /// S3b: the committed command-buffer timeline must label every buffer,
+    /// follow the fast-path schedule exactly, and account for the S3a
+    /// aggregates without inventing timing the buffers never reported.
+    /// Only meaningful for a step that completed without throwing.
+    static func expectPhaseTimeline(
+        _ metrics: QwenMetalModel.StepMetrics,
+        config: QwenConfig,
+        tokens: Int,
+        label: String
+    ) {
+        let timeline = metrics.commandBufferTimeline
+        #expect(timeline.count == metrics.commandBuffersCommitted,
+                "\(label): timeline misses committed buffers")
+        #expect(timeline.map(\.phases) == Self.expectedTimelinePhases(config: config, tokens: tokens),
+                "\(label): phase labels diverged from the fast-path schedule")
+
+        let phaseDispatchTotal = metrics.phaseDispatchesEncoded.values.reduce(0, +)
+        #expect(phaseDispatchTotal == metrics.computeDispatchesEncoded,
+                "\(label): phase dispatch totals leak dispatches")
+        #expect(metrics.phaseDispatchesEncoded[.other, default: 0] == 0,
+                "\(label): dispatches encoded outside every labeled phase")
+
+        var waitSum = 0.0
+        var gpuSum = 0.0
+        var timed = 0
+        var untimed = 0
+        var failed = 0
+        var timelineDispatches = 0
+        for sample in timeline {
+            #expect(!sample.phases.isEmpty, "\(label): unlabeled command buffer")
+            #expect(sample.completed, "\(label): failed buffer in timeline")
+            #expect(sample.encodeSeconds >= 0 && sample.waitSeconds >= 0,
+                    "\(label): negative buffer timing")
+            let phaseEncode = sample.phaseEncodeSeconds.values.reduce(0, +)
+            #expect(phaseEncode <= sample.encodeSeconds + 1e-6,
+                    "\(label): phase encode time exceeds the buffer's encode span")
+            waitSum += sample.waitSeconds
+            if !sample.completed {
+                failed += 1
+            } else if let gpu = sample.gpuSeconds {
+                #expect(gpu >= 0, "\(label): negative GPU duration")
+                gpuSum += gpu
+                timed += 1
+            } else {
+                untimed += 1
+            }
+            timelineDispatches += sample.dispatchesEncoded
+        }
+        #expect(abs(waitSum - metrics.blockingWaitSeconds) < 1e-6,
+                "\(label): timeline wait diverged from the S3a aggregate")
+        #expect(abs(gpuSum - metrics.gpuExecutionSeconds) < 1e-6,
+                "\(label): timeline GPU time diverged from the S3a aggregate")
+        #expect(timed == metrics.gpuTimedCommandBuffers, "\(label): timed buffer count")
+        #expect(untimed == metrics.gpuUntimedCommandBuffers, "\(label): untimed buffer count")
+        #expect(failed == metrics.commandBufferErrors, "\(label): failed buffer count")
+        #expect(timelineDispatches == metrics.computeDispatchesEncoded,
+                "\(label): timeline dispatches diverged from the S3a aggregate")
+        #expect(timeline.filter { $0.phases.contains(.lmHead) }.count == metrics.logitProjections,
+                "\(label): LM-head buffer count")
+    }
+
+    /// The label sequence the current fast-path schedule must produce: per
+    /// token, one buffer per DeltaNet layer, two per attention layer, and a
+    /// tail buffer that flushes the last layer's experts (adding the LM head
+    /// only on the final token). Labels are in canonical declaration order.
+    static func expectedTimelinePhases(
+        config: QwenConfig, tokens: Int
+    ) -> [[QwenMetalModel.StepPhase]] {
+        var expected: [[QwenMetalModel.StepPhase]] = []
+        for token in 0..<tokens {
+            for layer in 0..<config.numHiddenLayers {
+                let flushesMoE = layer > 0
+                if config.isLinearLayer(layer) {
+                    expected.append(flushesMoE ? [.delta, .moe, .router] : [.delta, .router])
+                } else {
+                    expected.append(flushesMoE ? [.attention, .moe] : [.attention])
+                    expected.append([.attention, .router])
+                }
+            }
+            expected.append(token == tokens - 1 ? [.moe, .lmHead] : [.moe])
+        }
+        return expected
+    }
+
     static func compare(_ modelName: String, baseline: FastPathBaseline) throws {
         let dir = fixturesDir.appendingPathComponent(modelName)
         let cpu = try QwenCPUModel(modelDir: dir)
@@ -115,6 +199,10 @@ import Testing
         Self.expectFastPathBaseline(
             singleMetrics, tokens: 1, baseline: baseline, label: "\(modelName) one token"
         )
+        Self.expectPhaseTimeline(
+            singleMetrics, config: sequentialGPU.config, tokens: 1,
+            label: "\(modelName) one token"
+        )
 
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "\(modelName): GPU vs CPU logits maxAbsDiff \(maxDiff)")
@@ -133,6 +221,10 @@ import Testing
         Self.expectFastPathBaseline(
             multiMetrics, tokens: tokens.count, baseline: baseline, label: "\(modelName) multi token"
         )
+        Self.expectPhaseTimeline(
+            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            label: "\(modelName) multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) elision input")
 
         let continuation = 11
@@ -150,6 +242,10 @@ import Testing
             elidingGPU.lastStepMetrics, tokens: 1,
             baseline: baseline, label: "\(modelName) continuation"
         )
+        Self.expectPhaseTimeline(
+            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            label: "\(modelName) continuation"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "\(modelName) continuation")
 
         func argmax(_ v: [Float]) -> Int {
@@ -162,6 +258,35 @@ import Testing
 
     @Test func gpuMatchesCPUOnQuantizedTiny() throws {
         try Self.compare("tiny-model-q4", baseline: Self.q4Baseline)
+    }
+
+    /// S3b: the phase/timeline instrumentation must label the whole step,
+    /// stay within the step wall clock, and rebuild per step call rather than
+    /// accumulate across calls.
+    @Test func phaseTimelineAccountsForWholeStep() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let multi = model.lastStepMetrics
+        Self.expectInstrumentation(multi, tokens: 3, label: "timeline multi")
+        Self.expectFastPathBaseline(
+            multi, tokens: 3, baseline: Self.q4Baseline, label: "timeline multi"
+        )
+        Self.expectPhaseTimeline(
+            multi, config: model.config, tokens: 3, label: "timeline multi"
+        )
+        let encodeSum = multi.commandBufferTimeline.reduce(0.0) { $0 + $1.encodeSeconds }
+        #expect(encodeSum + multi.blockingWaitSeconds <= multi.stepWallSeconds + 1e-3,
+                "timeline multi: encode+wait exceeds the step wall clock")
+
+        _ = try model.step([11], state: state)
+        let single = model.lastStepMetrics
+        Self.expectPhaseTimeline(
+            single, config: model.config, tokens: 1, label: "timeline continuation"
+        )
+        #expect(single.commandBufferTimeline.count == Self.commandBuffersPerToken,
+                "timeline continuation: timeline accumulated across steps")
     }
 
     /// Full streaming path: repack tiny model to .qpack, run the GPU model in
@@ -199,6 +324,9 @@ import Testing
         Self.expectFastPathBaseline(
             singleMetrics, tokens: 1, baseline: Self.q4Baseline, label: "qpack one token"
         )
+        Self.expectPhaseTimeline(
+            singleMetrics, config: sequentialGPU.config, tokens: 1, label: "qpack one token"
+        )
         let maxDiff = Self.maxAbsDiff(cpuLogits, sequentialLogits)
         #expect(maxDiff < 2e-3, "qpack GPU vs CPU logits maxAbsDiff \(maxDiff)")
 
@@ -215,6 +343,10 @@ import Testing
             multiMetrics, tokens: tokens.count,
             baseline: Self.q4Baseline, label: "qpack multi token"
         )
+        Self.expectPhaseTimeline(
+            multiMetrics, config: elidingGPU.config, tokens: tokens.count,
+            label: "qpack multi token"
+        )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack elision input")
 
         let continuation = 11
@@ -229,6 +361,10 @@ import Testing
         Self.expectFastPathBaseline(
             elidingGPU.lastStepMetrics, tokens: 1,
             baseline: Self.q4Baseline, label: "qpack continuation"
+        )
+        Self.expectPhaseTimeline(
+            elidingGPU.lastStepMetrics, config: elidingGPU.config, tokens: 1,
+            label: "qpack continuation"
         )
         Self.expectMatchingKV(sequentialState, elidingState, label: "qpack continuation")
 

--- a/Tests/SwiftletCoreTests/MetalModelTests.swift
+++ b/Tests/SwiftletCoreTests/MetalModelTests.swift
@@ -23,16 +23,23 @@ import Testing
         }
     }
 
-    static let commandBuffersPerToken = 11
+    /// S2: moving attention decode on-GPU merged each attention layer's two
+    /// command buffers (projections / CPU round trip / finish+router) into
+    /// one, so a token costs one buffer per layer plus the tail. Was 11 with
+    /// the CPU attention core (8 layers, 2 of them attention).
+    static let commandBuffersPerToken = 9
+    /// S2 dispatch deltas: +3 per attention layer per token (q prep, KV
+    /// append, causal attention). Was 212/214 (q4) and 218/220 (q35) when
+    /// the attention core ran on CPU.
     static let q4Baseline = FastPathBaseline(
-        commandBuffersPerToken: commandBuffersPerToken,
-        intermediateDispatches: 212,
-        finalDispatches: 214
-    )
-    static let q35Baseline = FastPathBaseline(
         commandBuffersPerToken: commandBuffersPerToken,
         intermediateDispatches: 218,
         finalDispatches: 220
+    )
+    static let q35Baseline = FastPathBaseline(
+        commandBuffersPerToken: commandBuffersPerToken,
+        intermediateDispatches: 224,
+        finalDispatches: 226
     )
 
     static let fixturesDir = URL(fileURLWithPath: #filePath)
@@ -152,9 +159,10 @@ import Testing
     }
 
     /// The label sequence the current fast-path schedule must produce: per
-    /// token, one buffer per DeltaNet layer, two per attention layer, and a
-    /// tail buffer that flushes the last layer's experts (adding the LM head
-    /// only on the final token). Labels are in canonical declaration order.
+    /// token, one buffer per layer (S2 merged the attention layers' former
+    /// two-buffer CPU round trip), and a tail buffer that flushes the last
+    /// layer's experts (adding the LM head only on the final token). Labels
+    /// are in canonical declaration order.
     static func expectedTimelinePhases(
         config: QwenConfig, tokens: Int
     ) -> [[QwenMetalModel.StepPhase]] {
@@ -165,8 +173,7 @@ import Testing
                 if config.isLinearLayer(layer) {
                     expected.append(flushesMoE ? [.delta, .moe, .router] : [.delta, .router])
                 } else {
-                    expected.append(flushesMoE ? [.attention, .moe] : [.attention])
-                    expected.append([.attention, .router])
+                    expected.append(flushesMoE ? [.attention, .moe, .router] : [.attention, .router])
                 }
             }
             expected.append(token == tokens - 1 ? [.moe, .lmHead] : [.moe])

--- a/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
+++ b/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S3b follow-up: the per-phase GPU/wait split is real only where the device
+/// can sample timestamps inside a compute encoder (dispatch-boundary
+/// counters). Everywhere else the API must report absence instead of
+/// publishing zeros that look like measurements, and os_signpost intervals
+/// must cover exactly the scopes the timeline already reports so Instruments
+/// can see the phases.
+@Suite struct PhaseGpuSplitTests {
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    /// The probe is runtime evidence, not an assumption: capabilities are
+    /// read from the device, and when stage-boundary sampling is advertised a
+    /// real sample pass must have resolved. Probing twice must agree.
+    @Test func counterProbeIsStableAndFunctional() throws {
+        let engine = try MetalEngine()
+        let probe = engine.probeCounterSampling()
+        #expect(probe == engine.probeCounterSampling(), "probe not deterministic")
+        #expect(!probe.deviceName.isEmpty)
+        if probe.atStageBoundary && probe.hasTimestampCounterSet {
+            #expect(probe.stageBoundarySampleValid == true,
+                    "stage-boundary timestamp sampling advertised but a real sample pass did not resolve")
+        } else {
+            #expect(probe.stageBoundarySampleValid == nil,
+                    "functional stage probe ran without the advertised capability")
+        }
+    }
+
+    /// The model's split support must be derived from the probe, and an
+    /// unsupported verdict must carry a reason naming the device.
+    @Test func phaseGpuSplitSupportMatchesProbe() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let probe = model.counterSamplingSupport
+        switch model.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            #expect(probe.atDispatchBoundary && probe.hasTimestampCounterSet,
+                    "split claimed without the capability that makes it real")
+        case .unsupported(let reason):
+            #expect(!(probe.atDispatchBoundary && probe.hasTimestampCounterSet),
+                    "capability present but split reported unsupported")
+            #expect(!reason.isEmpty, "unsupported verdict without a reason")
+            #expect(reason.contains(probe.deviceName), "reason does not name the device")
+        }
+    }
+
+    /// The discriminator: with dispatch-boundary counters, per-phase GPU sums
+    /// must land near the per-buffer GPU totals; without them, the API must
+    /// report nil — absent, not zeros-that-look-real.
+    @Test func phaseGpuSecondsDiscriminateBySupport() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let metrics = model.lastStepMetrics
+        #expect(metrics.completedWithoutThrow)
+
+        switch model.phaseGpuSplitSupport {
+        case .dispatchBoundaryCounters:
+            let totals = try #require(
+                metrics.phaseGpuSeconds, "split supported but step totals absent")
+            #expect(totals.values.allSatisfy { $0 >= 0 }, "negative per-phase GPU time")
+            var attributed = 0.0
+            var attributedBuffers = 0
+            for sample in metrics.commandBufferTimeline {
+                guard let phaseGpu = sample.phaseGpuSeconds else { continue }
+                attributedBuffers += 1
+                let sum = phaseGpu.values.reduce(0, +)
+                #expect(phaseGpu.values.allSatisfy { $0 >= 0 },
+                        "negative per-phase GPU time in a buffer")
+                if let gpu = sample.gpuSeconds {
+                    // Counter clock vs command-buffer clock: generous but
+                    // discriminating — the phase sum must be the same order
+                    // as the buffer total, never wildly above it.
+                    #expect(sum <= gpu * 1.5 + 5e-4,
+                            "phase GPU sum exceeds the buffer's GPU span")
+                }
+                attributed += sum
+            }
+            #expect(attributedBuffers > 0, "split supported but no buffer was attributed")
+            let totalSum = totals.values.reduce(0, +)
+            #expect(abs(attributed - totalSum) < 1e-6,
+                    "step totals diverge from the per-buffer attribution")
+            #expect(abs(totalSum - metrics.gpuExecutionSeconds)
+                    <= max(0.5 * metrics.gpuExecutionSeconds, 2e-3),
+                    "per-phase GPU sum far from the per-buffer GPU total")
+        case .unsupported:
+            #expect(metrics.phaseGpuSeconds == nil,
+                    "unsupported split must be absent, not zeros")
+            for sample in metrics.commandBufferTimeline {
+                #expect(sample.phaseGpuSeconds == nil,
+                        "unsupported split leaked per-buffer phase GPU values")
+            }
+        }
+    }
+
+    /// Signpost intervals mirror the timeline exactly: one step interval, one
+    /// per committed command buffer, one per phase scope — so an Instruments
+    /// trace lines up with the published metrics. The tally rebuilds per step.
+    @Test func signpostIntervalsMirrorTheTimeline() throws {
+        let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let model = try QwenMetalModel(modelDir: dir)
+        let state = QwenCPUModel.DecodeState()
+        _ = try model.step([1, 5, 9], state: state)
+        let metrics = model.lastStepMetrics
+        let tally = model.lastSignpostTally
+        #expect(tally.stepIntervals == 1, "step interval count")
+        #expect(tally.commandBufferIntervals == metrics.commandBuffersCommitted,
+                "command-buffer intervals diverge from committed buffers")
+        let phaseScopes = metrics.commandBufferTimeline.reduce(0) { $0 + $1.phases.count }
+        #expect(tally.phaseIntervals == phaseScopes,
+                "phase intervals diverge from the timeline's phase scopes")
+
+        _ = try model.step([11], state: state)
+        let single = model.lastSignpostTally
+        #expect(single.stepIntervals == 1, "tally accumulated across steps")
+        #expect(single.commandBufferIntervals
+                == model.lastStepMetrics.commandBuffersCommitted,
+                "tally accumulated across steps")
+    }
+}

--- a/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
+++ b/Tests/SwiftletCoreTests/PhaseGpuSplitTests.swift
@@ -56,8 +56,8 @@ import Testing
     @Test func phaseGpuSecondsDiscriminateBySupport() throws {
         let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
         let model = try QwenMetalModel(modelDir: dir)
-        let state = QwenCPUModel.DecodeState()
-        _ = try model.step([1, 5, 9], state: state)
+        let state = model.makeQwenContext()
+        _ = try model.step([1, 5, 9], context: state)
         let metrics = model.lastStepMetrics
         #expect(metrics.completedWithoutThrow)
 
@@ -106,8 +106,8 @@ import Testing
     @Test func signpostIntervalsMirrorTheTimeline() throws {
         let dir = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
         let model = try QwenMetalModel(modelDir: dir)
-        let state = QwenCPUModel.DecodeState()
-        _ = try model.step([1, 5, 9], state: state)
+        let state = model.makeQwenContext()
+        _ = try model.step([1, 5, 9], context: state)
         let metrics = model.lastStepMetrics
         let tally = model.lastSignpostTally
         #expect(tally.stepIntervals == 1, "step interval count")
@@ -117,7 +117,7 @@ import Testing
         #expect(tally.phaseIntervals == phaseScopes,
                 "phase intervals diverge from the timeline's phase scopes")
 
-        _ = try model.step([11], state: state)
+        _ = try model.step([11], context: state)
         let single = model.lastSignpostTally
         #expect(single.stepIntervals == 1, "tally accumulated across steps")
         #expect(single.commandBufferIntervals

--- a/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
+++ b/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+@testable import SwiftletCore
+
+/// S1b-a: the expert-union plan is the executable oracle for layer-major
+/// prefill. Pure-logic properties first (union correctness, ordering,
+/// determinism, bounds), then equivalence against the actual per-token Metal
+/// routing on the tiny fixtures.
+@Suite struct PrefillExpertUnionPlanTests {
+    @Test func unionsExpertsPerLayer() throws {
+        let plan = try PrefillExpertUnionPlan(
+            tokenRoutes: [
+                [[3, 1], [0, 2]],
+                [[1, 5], [2, 0]],
+                [[3, 1], [7, 4]],
+            ],
+            expertCount: 8
+        )
+        #expect(plan.tokenCount == 3)
+        #expect(plan.layers.map(\.layerIndex) == [0, 1])
+        #expect(plan.layers[0].experts == [1, 3, 5])
+        #expect(plan.layers[1].experts == [0, 2, 4, 7])
+    }
+
+    @Test func planIsDeterministicAndTokenOrderInvariant() throws {
+        let routes: [[[Int]]] = [
+            [[2, 0], [1, 3]],
+            [[0, 4], [3, 5]],
+        ]
+        let plan = try PrefillExpertUnionPlan(tokenRoutes: routes, expertCount: 8)
+        let again = try PrefillExpertUnionPlan(tokenRoutes: routes, expertCount: 8)
+        #expect(plan == again)
+        // The union cannot depend on token order or per-token pick order.
+        let shuffled = try PrefillExpertUnionPlan(
+            tokenRoutes: [[[4, 0], [5, 3]], [[0, 2], [3, 1]]], expertCount: 8
+        )
+        #expect(plan.layers == shuffled.layers)
+    }
+
+    @Test func replayVisitsLayersInAscendingOrder() throws {
+        let plan = try PrefillExpertUnionPlan(
+            tokenRoutes: [[[1], [2], [0]]], expertCount: 4
+        )
+        var visited: [(Int, [Int])] = []
+        plan.replayLayerMajor { visited.append(($0, $1)) }
+        #expect(visited.map(\.0) == [0, 1, 2])
+        #expect(visited.map(\.1) == [[1], [2], [0]])
+    }
+
+    @Test func malformedRoutesAreRejected() {
+        #expect(throws: PrefillExpertUnionPlan.BuildError.emptyPrompt) {
+            try PrefillExpertUnionPlan(tokenRoutes: [], expertCount: 8)
+        }
+        #expect(throws: PrefillExpertUnionPlan.BuildError.inconsistentLayerCount(
+            token: 1, expected: 2, actual: 1
+        )) {
+            try PrefillExpertUnionPlan(tokenRoutes: [[[0], [1]], [[0]]], expertCount: 8)
+        }
+        #expect(throws: PrefillExpertUnionPlan.BuildError.emptyRoute(token: 0, layer: 1)) {
+            try PrefillExpertUnionPlan(tokenRoutes: [[[0], []]], expertCount: 8)
+        }
+        #expect(throws: PrefillExpertUnionPlan.BuildError.expertOutOfRange(
+            token: 0, layer: 0, expert: 8
+        )) {
+            try PrefillExpertUnionPlan(tokenRoutes: [[[8]]], expertCount: 8)
+        }
+        #expect(throws: PrefillExpertUnionPlan.BuildError.expertOutOfRange(
+            token: 0, layer: 0, expert: -1
+        )) {
+            try PrefillExpertUnionPlan(tokenRoutes: [[[-1]]], expertCount: 8)
+        }
+        #expect(throws: PrefillExpertUnionPlan.BuildError.duplicateExpert(
+            token: 0, layer: 0, expert: 3
+        )) {
+            try PrefillExpertUnionPlan(tokenRoutes: [[[3, 3]]], expertCount: 8)
+        }
+    }
+
+    @Test func unionSizeIsBounded() throws {
+        let plan = try PrefillExpertUnionPlan(
+            tokenRoutes: [[[0, 1]], [[2, 3]], [[0, 2]]], expertCount: 4
+        )
+        for layer in plan.layers {
+            #expect(layer.experts.count <= 4, "union exceeds the expert count")
+            #expect(layer.experts.count <= 3 * 2, "union exceeds tokens * top-k")
+            #expect(layer.experts == Array(Set(layer.experts)).sorted(),
+                    "experts not unique/ascending")
+        }
+    }
+
+    // MARK: - Equivalence against the current Metal token-by-token path
+
+    static let fixturesDir = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("fixtures")
+
+    /// Regroups the flat (layer, experts) router observations one step call
+    /// produced into token-major routes, checking the observation shape.
+    static func tokenMajor(
+        _ flat: [(layer: Int, experts: [Int])], tokens: Int, layerCount: Int
+    ) -> [[[Int]]] {
+        guard flat.count == tokens * layerCount else {
+            Issue.record("router observations \(flat.count) != \(tokens * layerCount)")
+            return []
+        }
+        var result: [[[Int]]] = []
+        for t in 0..<tokens {
+            var perLayer: [[Int]] = []
+            for l in 0..<layerCount {
+                let entry = flat[t * layerCount + l]
+                #expect(entry.layer == l, "layer order diverged at token \(t)")
+                perLayer.append(entry.experts)
+            }
+            result.append(perLayer)
+        }
+        return result
+    }
+
+    /// The plan replayed layer-by-layer must touch exactly the expert sets
+    /// the current token-by-token path touches for the same prompt.
+    static func expectPlanMatchesRouting(_ modelName: String) throws {
+        let dir = fixturesDir.appendingPathComponent(modelName)
+        let tokens = [1, 5, 9, 42, 7]
+
+        // Decode-style loop: one step call per token.
+        let loopModel = try QwenMetalModel(modelDir: dir)
+        let layerCount = loopModel.config.numHiddenLayers
+        var loopFlat: [(layer: Int, experts: [Int])] = []
+        loopModel.routedExpertObserver = { loopFlat.append(($0, $1)) }
+        let loopState = QwenCPUModel.DecodeState()
+        for t in tokens { _ = try loopModel.step([t], state: loopState) }
+        loopModel.routedExpertObserver = nil
+
+        // S1a prefill-style path: one multi-token prompt call.
+        let promptModel = try QwenMetalModel(modelDir: dir)
+        var promptFlat: [(layer: Int, experts: [Int])] = []
+        promptModel.routedExpertObserver = { promptFlat.append(($0, $1)) }
+        let promptState = QwenCPUModel.DecodeState()
+        _ = try promptModel.step(tokens, state: promptState)
+        promptModel.routedExpertObserver = nil
+
+        let loopRoutes = tokenMajor(loopFlat, tokens: tokens.count, layerCount: layerCount)
+        let promptRoutes = tokenMajor(promptFlat, tokens: tokens.count, layerCount: layerCount)
+        #expect(loopRoutes == promptRoutes,
+                "\(modelName): routing diverged between step loop and prompt call")
+        for perToken in loopRoutes {
+            for route in perToken {
+                #expect(route.count == loopModel.config.numExpertsPerTok,
+                        "\(modelName): route width diverged from top-k")
+            }
+        }
+
+        let plan = try PrefillExpertUnionPlan(
+            tokenRoutes: loopRoutes, expertCount: loopModel.config.numExperts
+        )
+        #expect(plan.tokenCount == tokens.count)
+        #expect(plan.layers.count == layerCount)
+
+        // Replay layer-by-layer and compare the touched expert sets against
+        // the token-by-token path, layer for layer.
+        var replayed: [Int: Set<Int>] = [:]
+        plan.replayLayerMajor { layer, experts in
+            replayed[layer] = Set(experts)
+        }
+        var touched: [Int: Set<Int>] = [:]
+        for perToken in loopRoutes {
+            for (layer, experts) in perToken.enumerated() {
+                touched[layer, default: []].formUnion(experts)
+            }
+        }
+        #expect(replayed == touched,
+                "\(modelName): plan does not touch the token-by-token expert set")
+        for layer in plan.layers {
+            #expect(layer.experts.count >= loopModel.config.numExpertsPerTok,
+                    "\(modelName): union smaller than a single token's route")
+        }
+    }
+
+    @Test func planMatchesMetalRoutingOnQuantizedTiny() throws {
+        try Self.expectPlanMatchesRouting("tiny-model-q4")
+    }
+
+    @Test func planMatchesMetalRoutingOnQwen35Tiny() throws {
+        try Self.expectPlanMatchesRouting("tiny-model-q35")
+    }
+}

--- a/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
+++ b/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
@@ -133,8 +133,12 @@ import Testing
         for t in tokens { _ = try loopModel.step([t], state: loopState) }
         loopModel.routedExpertObserver = nil
 
-        // S1a prefill-style path: one multi-token prompt call.
+        // S1a prefill-style path: one multi-token prompt call, pinned to the
+        // token-major schedule this equivalence was defined against. The S1b
+        // layer-major schedule's route/union equivalence is asserted in
+        // LayerMajorPrefillTests.
         let promptModel = try QwenMetalModel(modelDir: dir)
+        promptModel.prefillMode = .tokenMajor
         var promptFlat: [(layer: Int, experts: [Int])] = []
         promptModel.routedExpertObserver = { promptFlat.append(($0, $1)) }
         let promptState = QwenCPUModel.DecodeState()

--- a/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
+++ b/Tests/SwiftletCoreTests/PrefillExpertUnionPlanTests.swift
@@ -129,8 +129,8 @@ import Testing
         let layerCount = loopModel.config.numHiddenLayers
         var loopFlat: [(layer: Int, experts: [Int])] = []
         loopModel.routedExpertObserver = { loopFlat.append(($0, $1)) }
-        let loopState = QwenCPUModel.DecodeState()
-        for t in tokens { _ = try loopModel.step([t], state: loopState) }
+        let loopState = loopModel.makeQwenContext()
+        for t in tokens { _ = try loopModel.step([t], context: loopState) }
         loopModel.routedExpertObserver = nil
 
         // S1a prefill-style path: one multi-token prompt call, pinned to the
@@ -141,8 +141,8 @@ import Testing
         promptModel.prefillMode = .tokenMajor
         var promptFlat: [(layer: Int, experts: [Int])] = []
         promptModel.routedExpertObserver = { promptFlat.append(($0, $1)) }
-        let promptState = QwenCPUModel.DecodeState()
-        _ = try promptModel.step(tokens, state: promptState)
+        let promptState = promptModel.makeQwenContext()
+        _ = try promptModel.step(tokens, context: promptState)
         promptModel.routedExpertObserver = nil
 
         let loopRoutes = tokenMajor(loopFlat, tokens: tokens.count, layerCount: layerCount)

--- a/Tests/SwiftletCoreTests/QpackTests.swift
+++ b/Tests/SwiftletCoreTests/QpackTests.swift
@@ -107,13 +107,13 @@ import Testing
         let cpu = try QwenCPUModel(modelDir: src)
         cpu.retainAllLayers = true
         let gpu = try QwenMetalModel(modelDir: viaStream, cacheBudgetGB: 0.05)
-        let s1 = QwenCPUModel.DecodeState()
-        let s2 = QwenCPUModel.DecodeState()
+        let s1 = cpu.makeQwenContext()
+        let s2 = gpu.makeQwenContext()
         var a: [Float] = []
         var b: [Float] = []
         for t in [1, 5, 9] {
-            a = try cpu.step([t], state: s1)
-            b = try gpu.step([t], state: s2)
+            a = try cpu.step([t], context: s1)
+            b = try gpu.step([t], context: s2)
         }
         var maxDiff: Float = 0
         for i in 0..<a.count { maxDiff = max(maxDiff, abs(a[i] - b[i])) }

--- a/docs/BENCH_QWEN36_35B_M1_MINI.md
+++ b/docs/BENCH_QWEN36_35B_M1_MINI.md
@@ -1,0 +1,521 @@
+# Benchmark: Qwen3.6-35B-A3B (qpack Q4) on a base Apple M1 Mac mini (16 GB)
+
+Sibling of [`BENCH_QWEN36_35B_M4MAX.md`](BENCH_QWEN36_35B_M4MAX.md): the same
+model, prompts, sampler, flags and 1-warmup + 3-measured discipline, run on the
+low end of the hardware range from issue #18 — a 2020 Mac mini with the 8-core
+M1 GPU and 16 GB of unified memory. Two builds side by side: upstream `main`
+at `aaa910a` (which already contains merged #19 + #20) and the PR #24 tip
+`5d8b2ab` (S1b layer-major prefill + token-batched GEMVs + S2 Metal attention
++ S3a/S3b instrumentation + the conv scan / attend tiling). Run 2026-09-01
+22:47 → 2026-09-02 00:13 EDT on macmini2; 44 processes, every one reported.
+
+The question this run exists to answer is the #18 one: on 16 GB, does the
+expert-cache budget (`--cache-gb`) move throughput, and what does each GB cost?
+
+Headline (measured runs only, greedy, 64 new tokens, `--cache-gb 4`):
+
+| Metric | `aaa910a` (upstream) | `5d8b2ab` (PR #24) | delta |
+|---|---|---|---|
+| Decode, 16-tok prompt | 2.79–2.93 tok/s | **2.91–3.13 tok/s** | +4–8% (like-state pairs, see bimodality note) |
+| Decode, 503-tok prompt | 2.22–2.26 tok/s (token-major) | **2.47–2.54 tok/s** (chunk 32); 2.44–2.46 (token-major) | **+12%** / +9% |
+| TTFT, 503-tok prompt | 184.4–188.6 s (2.67–2.73 tok/s prefill) | **70.5–72.2 s** (6.97–7.13 tok/s) chunk 32; 157.4–163.8 s (3.07–3.20 tok/s) token-major | **2.6× faster** / −13% |
+| TTFT, 16-tok prompt | 5.69–5.92 s | **2.97–3.19 s** | −46% |
+| Prefill GPU execution, 503-tok | 75.91–75.97 s | 40.35–40.38 s chunk 32; 75.73–75.90 s token-major | −47% / 0% |
+| Command buffers per decode step | 51 (2052 dispatches) | 41 (2082 dispatches) | −10 cb |
+| Peak RSS | 6.4–6.8 GiB | 6.2–6.8 GiB | — |
+| Swap delta, any run | 0 | 0 | used swap 77.38 MB before and after all 44 runs |
+| Greedy output | identical | identical | bitwise equal across builds, cache sizes, schedules, and to the M4 Max logs |
+
+`--cache-gb` sweep, 503-token prompt, decode tok/s (3 measured runs each):
+
+| `--cache-gb` | slots | `5d8b2ab` chunk 32 | `aaa910a` token-major | process footprint | page cache at run start | SSD pageins per run (`5d8b2ab`) |
+|---|---|---|---|---|---|---|
+| 2 | 1213 | 2.42 / 2.40 / 2.40 | 2.20 / 2.19 / 2.21 | 3.5–3.6 GiB | 9.9–10.1 GiB | 17.4–19.0 GiB |
+| 4 | 2427 | 2.52 / 2.54 / 2.47 | 2.24 / 2.26 / 2.22 | 5.5–5.6 GiB | 7.9–8.0 GiB | 13.5–15.2 GiB |
+| 6 | 3640 | **2.73 / 2.74 / 2.74** | **2.38 / 2.37 / 2.38** | 7.5–7.6 GiB | 5.9–6.1 GiB | 12.1–13.4 GiB |
+
+Cache size moves decode by +14% (stack) / +8% (baseline) from 2 to 6 GB on
+this box (medians of the three measured runs), TTFT by −5% / −13%, and no
+budget up to 6 GB swapped. The cost side and the mechanism are in "What this
+says for #18" below.
+
+## Environment
+
+- **Machine**: macmini2 — Mac mini (2020, `Macmini9,1`), Apple M1, 8 CPU cores
+  (4 performance + 4 efficiency), **8-core GPU** (`system_profiler
+  SPDisplaysDataType`: "Chipset Model: Apple M1 / Total Number of Cores: 8",
+  Metal 4), **16 GB unified memory** (`hw.memsize` 17179869184 B), internal
+  APFS SSD (`/dev/disk3s5`, 994.7 GB container, 869 GiB free). macOS 26.6.2
+  (build 25G83). Swift 6.3.3 (swiftlang-6.3.3.1.3 clang-2100.1.1.101),
+  swift-driver 1.148.6, Command Line Tools only (no Xcode).
+  `sysctl -n machdep.cpu.brand_string` = `Apple M1`. Swap: 1024 MB backing
+  store, 77 MB in use at campaign start (uptime 12 days).
+- **Resident daemons** (present in every `ps` idle-check, not stoppable from
+  the bench account): WindowServer at a steady ~12% of one CPU core, Grafana
+  alloy, wazuh agent, tailscaled. No other swift/clang/make/benchmark
+  process during any timed run; `ps aux | sort -nrk3 | head`
+  logged into `<run>.pre` before every run plus a soft idle gate (waits for
+  any foreign process above 20% CPU).
+- **Builds** (fully separated from measurement; both finished before the
+  first timed run):
+  - baseline `aaa910a5124db3647fa91ef9b37e16091b49e581` (upstream main, "Add
+    aggregate Metal step instrumentation (#20)", i.e. #19 + #20 merged)
+    exported with `git archive` into `~/build/base-swiftlet`; binary sha256
+    `6ba7e741714cddf120c82e36af501b9dacd2473cbb2493a100d68869b0610ce4`.
+  - stack `5d8b2ab8c97114d14af4e54a34a60709fdba859c` (PR #24 tip,
+    `switftbri/s1b-token-batched-gemv`, 28 commits on top of `aaa910a`,
+    clean tree rsync'd into `~/build/s1c-swiftlet`); binary sha256
+    `124a35b046a7f19a5a63a0f0b5c6ba1198844335bb75e8d3294f753a7596a20e`.
+  - both: `swift build -c release --scratch-path <tree>/.swiftcache`, no
+    extra flags, identical `Package.swift`/`Package.resolved`; binaries run
+    directly from `.swiftcache/release/swiftlet`.
+- **Model**: the same `qwen3.6-35b.qpack` container as the M4 Max runs
+  (`hashes.json` pin `1605766290…`, 47 files size-verified), at
+  `~/models/qwen3.6-35b.qpack` on the mini, read-only. `hashes.json` sha256
+  logged before and after every run (unchanged throughout).
+
+## Protocol
+
+Identical to the M4 Max bench contract (`docs/BENCH_QWEN36_35B_M4MAX.md`,
+"Protocol"), restated where the small-RAM box changes anything:
+
+- **Sampler**: greedy argmax (CLI `generate`), EOS ids from the container's
+  `config.json`; `--max-new 64`; `--gpu` Metal runtime.
+- **Prompts**: the same 16-token fieldfare prompt (`p16.txt`) and the same
+  503-token pinned paragraph (`plong.txt`, sha256
+  `d5ff9b0a8d0a52935b04d71ad39e874e96176f9ea20f6a105ac5d5ff506fbc19`,
+  copied from macbook4's `~/bench-logs/` and re-hashed on the mini before
+  the first run). Both tokenize to the same counts as on the M4 Max (16 /
+  503 tokens per the `prefill S3a` line of every run).
+- **Cache budget**: `--cache-gb 4` is the reference setting on 16 GB
+  (2427 slots × 1 769 472 B); the sweep adds 2 (1213 slots) and 6 (3640
+  slots). The M4 Max default of 8 was not used: the M4 runs showed 10.9 GiB
+  RSS at 8 GB on the long prompt, which leaves no page cache on a 16 GB box.
+- **Prefill schedule**: baseline `aaa910a` has no `--prefill-chunk` knob and
+  is token-major by construction (one command-buffer chain per prompt
+  token); the stack was run token-major (`--prefill-chunk 0`) for the
+  like-for-like arm and layer-major chunk 32 (its default) for the headline.
+- **Runs**: per cell 1 warmup (`warm-0`) + 3 measured, every measured run
+  reported, no best-of; each run a fresh process under `/usr/bin/time -l`.
+  Cells were run back-to-back in the order listed in the results; the very
+  first process of the campaign (`base-A-c4-warm-0`) is the only one with a
+  page cache cold for the campaign, and is labeled so.
+- **"Warm" on 16 GB means something different from the M4 doc.** The
+  16.88 GiB expert pool cannot live in a 16 GB page cache alongside a 5-9 GiB
+  process, so steady state is *partially* warm: each run re-reads whatever
+  the previous run evicted from the page cache. Bytes read (misses × stride)
+  is therefore an upper bound on SSD traffic (some misses are page-cache
+  hits, some are real preads); the S3a/S3b counters do not separate the two.
+- **Swap / memory pressure**: `sysctl vm.swapusage` and `vm_stat` captured
+  before and after every run (`<run>.pre` / `<run>.post`); the swap column
+  below is the used-swap delta across the run. A run that swapped is labeled
+  as such, not dropped (reported in the sweep table and the caveats).
+- **Thermal**: the mini is a small passively-vented box; `pmset -g therm`
+  was logged around every run (it reports no thermal warning level on this
+  machine, so throttling is checked by comparing run 1 against run 3 within
+  each cell and by the across-cell drift of the repeated `stack-C32-c4`
+  configuration).
+- **Metric definitions** as in the M4 doc: TTFT = the `prefill S3a` wall
+  time (model + tokenizer load excluded; process `real` reported
+  separately); decode tok/s as printed over the 64-step loop; peak RSS from
+  `/usr/bin/time -l` "maximum resident set size"; bytes read = misses ×
+  1 769 472 B; wait = sum of blocking `waitUntilCompleted`; GPU = sum of
+  per-command-buffer GPU durations (100% of buffers timed, `err=0`, in
+  every run below). S3b phase/buffer split exists only on the stack build
+  (`aaa910a` predates S3b; it prints S3a totals and the cache line, which
+  are the same code on both sides).
+- **Parity**: greedy stdout compared by md5 after stripping the two
+  `[QwenMetalModel]` banner lines, across builds, cache sizes, chunk
+  settings, and against the M4 Max logs of the same prompts.
+
+Repro (on the mini, `$BIN` = either release binary, `$MODEL` = the qpack):
+
+```sh
+$BIN generate $MODEL --gpu --prompt "$(cat p16.txt)"   --max-new 64 --cache-gb {2,4}                      # A (both builds)
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --cache-gb {2,4,6}                    # B  baseline (token-major by construction)
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --cache-gb 4 --prefill-chunk 0        # B0 stack, token-major
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --cache-gb {2,4,6} --prefill-chunk 32 # C  stack, layer-major
+```
+
+## Results
+
+Cell labels follow the M4 doc (A = short prompt, B = 503-token token-major,
+C = 503-token layer-major chunk 32) with the cache budget suffixed. Cells are
+listed in the order they were run. "SSD pageins" is the system-wide `vm_stat`
+Pageins delta across the run (16 KiB pages), i.e. real disk reads — it
+includes the binary, dylibs and the dense `model.safetensors` when those are
+not cached (≤ ~1.5 GiB), and nothing else was running. "Nominal bytes" is the
+M4 doc's misses × 1 769 472 B, an upper bound that counts page-cache hits as
+if they were reads.
+
+### A — baseline `aaa910a`, 16-token prompt, 64 new, `--cache-gb 4` (token-major by construction)
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| cold-0 (warmup, first process of the campaign) | 6.494 s | 2.46 | 3.208 / 2.471 s | 816 / 32 802 | **2.87** | 13.765 / 9.925 s | 20270 / 5330 (79%) | 8.78 GiB | 7.1 GiB | 6.81 GiB | 32.26 s |
+| warm-1 | 5.924 s | 2.70 | 3.268 / 2.454 s | 816 / 32 802 | **2.91** | 13.090 / 9.931 s | 20270 / 5330 (79%) | 8.78 GiB | 3.2 GiB | 6.81 GiB | 29.29 s |
+| warm-2 | 5.689 s | 2.81 | 3.249 / 2.460 s | 816 / 32 802 | **2.79** | 14.290 / 9.810 s | 20270 / 5330 (79%) | 8.78 GiB | 3.3 GiB | 6.61 GiB | 30.82 s |
+| warm-3 | 5.914 s | 2.71 | 3.265 / 2.440 s | 816 / 32 802 | **2.93** | 13.056 / 9.926 s | 20270 / 5330 (79%) | 8.78 GiB | 3.3 GiB | 6.82 GiB | 29.13 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 84 850 / 26 / 35 468 / 42. Measured-run spread: decode 2.79–2.93 tok/s, TTFT 5.689–5.924 s, prefill GPU 2.440–2.460 s, decode GPU 9.810–9.931 s.
+
+### A — stack `5d8b2ab`, 16-token prompt, 64 new, `--cache-gb 4`, layer-major chunk 32 (default)
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 3.124 s | 5.12 | 1.443 / 1.318 s | 41 / 7 479 | **2.92** | 13.815 / 9.897 s | 17152 / 5437 (76%) | 8.96 GiB | 4.0 GiB | 6.47 GiB | 27.37 s |
+| warm-1 | 3.160 s | 5.06 | 1.431 / 1.314 s | 41 / 7 479 | **3.13** | 12.407 / 9.723 s | 17152 / 5437 (76%) | 8.96 GiB | 4.1 GiB | 6.82 GiB | 24.93 s |
+| warm-2 | 2.972 s | 5.38 | 1.431 / 1.308 s | 41 / 7 479 | **2.91** | 13.944 / 9.874 s | 17152 / 5437 (76%) | 8.96 GiB | 4.1 GiB | 6.59 GiB | 27.26 s |
+| warm-3 | 3.186 s | 5.02 | 1.450 / 1.326 s | 41 / 7 479 | **3.09** | 12.588 / 9.860 s | 17152 / 5437 (76%) | 8.96 GiB | 4.1 GiB | 6.82 GiB | 25.23 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 34 325 / 62 / 42 056 / 56. Measured-run spread: decode 2.91–3.13 tok/s, TTFT 2.972–3.186 s, prefill GPU 1.308–1.326 s, decode GPU 9.723–9.874 s.
+
+### A2 — baseline `aaa910a`, 16-token prompt, `--cache-gb 2`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 5.970 s | 2.68 | 3.252 / 2.449 s | 816 / 32 802 | **2.63** | 13.103 / 10.165 s | 16833 / 8767 (66%) | 14.45 GiB | 0.8 GiB | 4.81 GiB | 32.59 s |
+| warm-1 | 5.806 s | 2.76 | 3.341 / 2.448 s | 816 / 32 802 | **2.66** | 13.107 / 10.232 s | 16833 / 8767 (66%) | 14.45 GiB | 0.0 GiB | 4.81 GiB | 31.20 s |
+| warm-2 | 5.847 s | 2.74 | 3.350 / 2.450 s | 816 / 32 802 | **2.67** | 13.074 / 10.065 s | 16833 / 8767 (66%) | 14.45 GiB | 0.0 GiB | 4.81 GiB | 31.11 s |
+| warm-3 | 5.897 s | 2.71 | 3.380 / 2.449 s | 816 / 32 802 | **2.67** | 13.018 / 10.142 s | 16833 / 8767 (66%) | 14.45 GiB | 0.0 GiB | 4.81 GiB | 31.14 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 42 163 / 20 / 20 / 20. Measured-run spread: decode 2.66–2.67 tok/s, TTFT 5.806–5.897 s, prefill GPU 2.448–2.450 s, decode GPU 10.065–10.232 s.
+
+### A2 — stack `5d8b2ab`, 16-token prompt, `--cache-gb 2`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 2.325 s | 6.88 | 1.424 / 1.304 s | 41 / 7 479 | **2.80** | 12.690 / 10.033 s | 13773 / 8816 (61%) | 14.53 GiB | 0.4 GiB | 4.82 GiB | 26.46 s |
+| warm-1 | 2.347 s | 6.82 | 1.430 / 1.305 s | 41 / 7 479 | **2.81** | 12.752 / 10.157 s | 13773 / 8816 (61%) | 14.53 GiB | 0.0 GiB | 4.82 GiB | 26.46 s |
+| warm-2 | 2.368 s | 6.76 | 1.436 / 1.305 s | 41 / 7 479 | **2.81** | 12.655 / 9.976 s | 13773 / 8816 (61%) | 14.53 GiB | 0.0 GiB | 4.82 GiB | 26.41 s |
+| warm-3 | 2.323 s | 6.89 | 1.417 / 1.302 s | 41 / 7 479 | **2.89** | 12.489 / 10.052 s | 13773 / 8816 (61%) | 14.53 GiB | 0.1 GiB | 4.82 GiB | 25.79 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 40 / 20 / 20 / 20. Measured-run spread: decode 2.81–2.89 tok/s, TTFT 2.323–2.368 s, prefill GPU 1.302–1.305 s, decode GPU 9.976–10.157 s.
+
+### B — baseline `aaa910a`, 503-token prompt, 64 new, `--cache-gb 4` (token-major by construction)
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 183.899 s | 2.74 | 103.215 / 75.921 s | 25653 / 1 031 152 | **2.24** | 13.141 / 10.438 s | 148791 / 32649 (82%) | 53.80 GiB | 10.3 GiB | 6.81 GiB | 213.76 s |
+| warm-1 | 188.466 s | 2.67 | 109.826 / 75.972 s | 25653 / 1 031 152 | **2.24** | 13.713 / 10.493 s | 148791 / 32649 (82%) | 53.80 GiB | 11.3 GiB | 6.43 GiB | 219.36 s |
+| warm-2 | 184.449 s | 2.73 | 103.641 / 75.959 s | 25653 / 1 031 152 | **2.26** | 13.093 / 10.486 s | 148791 / 32649 (82%) | 53.80 GiB | 10.3 GiB | 6.81 GiB | 214.14 s |
+| warm-3 | 188.589 s | 2.67 | 109.867 / 75.906 s | 25653 / 1 031 152 | **2.22** | 13.881 / 10.482 s | 148791 / 32649 (82%) | 53.80 GiB | 11.2 GiB | 6.44 GiB | 219.73 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 156 / 40 280 / 56 / 38 372. Measured-run spread: decode 2.22–2.26 tok/s, TTFT 184.449–188.589 s, prefill GPU 75.906–75.972 s, decode GPU 10.482–10.493 s.
+
+### B0 — stack `5d8b2ab`, 503-token prompt, `--cache-gb 4`, token-major (`--prefill-chunk 0`)
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 157.452 s | 3.19 | 101.132 / 75.947 s | 20623 / 1 046 242 | **2.43** | 13.166 / 10.399 s | 148791 / 32649 (82%) | 53.80 GiB | 10.4 GiB | 6.81 GiB | 185.15 s |
+| warm-1 | 163.818 s | 3.07 | 107.994 / 75.818 s | 20623 / 1 046 242 | **2.45** | 13.714 / 10.428 s | 148791 / 32649 (82%) | 53.80 GiB | 11.3 GiB | 6.42 GiB | 192.26 s |
+| warm-2 | 157.354 s | 3.20 | 100.969 / 75.731 s | 20623 / 1 046 242 | **2.46** | 13.074 / 10.431 s | 148791 / 32649 (82%) | 53.80 GiB | 10.4 GiB | 6.81 GiB | 184.83 s |
+| warm-3 | 163.642 s | 3.07 | 107.900 / 75.898 s | 20623 / 1 046 242 | **2.44** | 13.732 / 10.342 s | 148791 / 32649 (82%) | 53.80 GiB | 11.3 GiB | 6.40 GiB | 192.04 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 159 / 37 206 / 56 / 38 485. Measured-run spread: decode 2.44–2.46 tok/s, TTFT 157.354–163.818 s, prefill GPU 75.731–75.898 s, decode GPU 10.342–10.431 s.
+
+### C — stack `5d8b2ab`, 503-token prompt, `--cache-gb 4`, layer-major chunk 32 (default)
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 69.448 s | 7.24 | 45.267 / 40.309 s | 656 / 148 809 | **2.52** | 12.856 / 10.375 s | 36452 / 27497 (57%) | 45.31 GiB | 12.2 GiB | 6.06 GiB | 96.17 s |
+| warm-1 | 72.210 s | 6.97 | 46.278 / 40.374 s | 656 / 148 809 | **2.52** | 13.549 / 10.246 s | 36452 / 27497 (57%) | 45.31 GiB | 15.2 GiB | 6.25 GiB | 99.85 s |
+| warm-2 | 70.505 s | 7.13 | 45.440 / 40.354 s | 656 / 148 809 | **2.54** | 12.787 / 10.298 s | 36452 / 27497 (57%) | 45.31 GiB | 13.5 GiB | 6.61 GiB | 97.06 s |
+| warm-3 | 72.106 s | 6.98 | 46.298 / 40.376 s | 656 / 148 809 | **2.47** | 13.728 / 10.388 s | 36452 / 27497 (57%) | 45.31 GiB | 15.2 GiB | 6.27 GiB | 100.32 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 56 / 42 060 / 56 / 40 287. Measured-run spread: decode 2.47–2.54 tok/s, TTFT 70.505–72.210 s, prefill GPU 40.354–40.376 s, decode GPU 10.246–10.388 s.
+
+### C2 — stack `5d8b2ab`, 503-token prompt, chunk 32, `--cache-gb 2`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 74.359 s | 6.76 | 41.967 / 40.332 s | 656 / 148 809 | **2.41** | 12.580 / 10.437 s | 13888 / 50061 (22%) | 82.50 GiB | 18.0 GiB | 4.81 GiB | 102.20 s |
+| warm-1 | 73.555 s | 6.84 | 41.950 / 40.343 s | 656 / 148 809 | **2.42** | 12.541 / 10.407 s | 13888 / 50061 (22%) | 82.50 GiB | 19.0 GiB | 4.91 GiB | 102.17 s |
+| warm-2 | 73.362 s | 6.86 | 41.904 / 40.288 s | 656 / 148 809 | **2.40** | 12.658 / 10.421 s | 13888 / 50061 (22%) | 82.50 GiB | 17.4 GiB | 4.81 GiB | 101.33 s |
+| warm-3 | 73.734 s | 6.82 | 41.973 / 40.357 s | 656 / 148 809 | **2.40** | 12.643 / 10.401 s | 13888 / 50061 (22%) | 82.50 GiB | 19.0 GiB | 4.91 GiB | 102.53 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 58 / 37 697 / 56 / 37 066. Measured-run spread: decode 2.40–2.42 tok/s, TTFT 73.362–73.734 s, prefill GPU 40.288–40.357 s, decode GPU 10.401–10.421 s.
+
+### C6 — stack `5d8b2ab`, 503-token prompt, chunk 32, `--cache-gb 6`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 68.848 s | 7.31 | 48.072 / 40.396 s | 656 / 148 809 | **2.74** | 13.513 / 10.037 s | 49573 / 14376 (78%) | 23.69 GiB | 11.2 GiB | 6.51 GiB | 93.73 s |
+| warm-1 | 70.075 s | 7.18 | 48.821 / 40.409 s | 656 / 148 809 | **2.73** | 13.656 / 10.063 s | 49573 / 14376 (78%) | 23.69 GiB | 13.2 GiB | 6.45 GiB | 95.62 s |
+| warm-2 | 68.999 s | 7.29 | 47.978 / 40.367 s | 656 / 148 809 | **2.74** | 13.523 / 10.100 s | 49573 / 14376 (78%) | 23.69 GiB | 12.1 GiB | 6.63 GiB | 93.86 s |
+| warm-3 | 69.910 s | 7.19 | 48.603 / 40.399 s | 656 / 148 809 | **2.74** | 13.507 / 10.029 s | 49573 / 14376 (78%) | 23.69 GiB | 13.4 GiB | 6.44 GiB | 95.74 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 56 / 36 553 / 56 / 42 057. Measured-run spread: decode 2.73–2.74 tok/s, TTFT 68.999–70.075 s, prefill GPU 40.367–40.409 s, decode GPU 10.029–10.100 s.
+
+### B2 — baseline `aaa910a`, 503-token prompt, `--cache-gb 2`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 206.258 s | 2.44 | 100.549 / 76.853 s | 25653 / 1 031 152 | **2.21** | 12.903 / 10.588 s | 109814 / 71626 (61%) | 118.04 GiB | 10.1 GiB | 4.82 GiB | 236.53 s |
+| warm-1 | 204.939 s | 2.45 | 100.383 / 76.774 s | 25653 / 1 031 152 | **2.20** | 12.925 / 10.575 s | 109814 / 71626 (61%) | 118.04 GiB | 9.9 GiB | 4.88 GiB | 236.31 s |
+| warm-2 | 205.109 s | 2.45 | 100.493 / 76.883 s | 25653 / 1 031 152 | **2.19** | 12.949 / 10.602 s | 109814 / 71626 (61%) | 118.04 GiB | 8.9 GiB | 4.82 GiB | 235.63 s |
+| warm-3 | 204.694 s | 2.46 | 100.158 / 76.669 s | 25653 / 1 031 152 | **2.21** | 12.862 / 10.545 s | 109814 / 71626 (61%) | 118.04 GiB | 10.2 GiB | 4.88 GiB | 235.92 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 173 / 42 050 / 46 / 42 060. Measured-run spread: decode 2.19–2.21 tok/s, TTFT 204.694–205.109 s, prefill GPU 76.669–76.883 s, decode GPU 10.545–10.602 s.
+
+### B6 — baseline `aaa910a`, 503-token prompt, `--cache-gb 6`
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | Prefill cb / dispatches | Decode tok/s | Decode wait / GPU (64 steps) | Hits / misses (rate) | Nominal bytes (misses × stride) | SSD pageins (vm_stat) | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 177.444 s | 2.83 | 111.608 / 75.379 s | 25653 / 1 031 152 | **2.36** | 13.748 / 10.303 s | 165329 / 16111 (91%) | 26.55 GiB | 9.8 GiB | 7.18 GiB | 206.07 s |
+| warm-1 | 178.951 s | 2.81 | 112.940 / 75.526 s | 25653 / 1 031 152 | **2.38** | 13.661 / 10.321 s | 165329 / 16111 (91%) | 26.55 GiB | 11.7 GiB | 6.56 GiB | 208.27 s |
+| warm-2 | 177.557 s | 2.83 | 111.313 / 75.428 s | 25653 / 1 031 152 | **2.37** | 13.808 / 10.285 s | 165329 / 16111 (91%) | 26.55 GiB | 10.7 GiB | 7.42 GiB | 206.12 s |
+| warm-3 | 179.009 s | 2.81 | 113.080 / 75.564 s | 25653 / 1 031 152 | **2.38** | 13.703 / 10.345 s | 165329 / 16111 (91%) | 26.55 GiB | 11.7 GiB | 6.56 GiB | 208.36 s |
+
+Major page faults per run (`/usr/bin/time -l` "page faults"): 56 / 42 052 / 56 / 42 056. Measured-run spread: decode 2.37–2.38 tok/s, TTFT 177.557–179.009 s, prefill GPU 75.428–75.564 s, decode GPU 10.285–10.345 s.
+
+## `--cache-gb` sweep (the #18 table)
+
+Measured runs only; the 2 / 4 / 6 GB rows of each build share prompt, schedule, binary and evening. Slots = ⌊budget × 2³⁰ / 1 769 472⌋. "Page cache at run start" = `vm_stat` file-backed pages in the `warm-1` `.pre` snapshot; footprint = `time -l` "peak memory footprint" (max of the 3 runs).
+
+| Build / schedule | `--cache-gb` | slots | Decode tok/s (3 runs) | TTFT (3 runs) | Hits / misses (rate) | Nominal bytes | SSD pageins per run | Page cache at run start | Peak RSS | Peak footprint | Swap delta |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| stack, chunk 32 | 2 | 1213 | **2.42 / 2.40 / 2.40** | 73.6 s / 73.4 s / 73.7 s | 13888 / 50061 (22%) | 82.5 GiB | 17.4–19.0 GiB | 9.9 GiB | 4.81–4.91 GiB | 3.58 GiB | 0 (77.38 → 77.38 MB) |
+| stack, chunk 32 | 4 | 2427 | **2.52 / 2.54 / 2.47** | 72.2 s / 70.5 s / 72.1 s | 36452 / 27497 (57%) | 45.3 GiB | 13.5–15.2 GiB | 7.9 GiB | 6.25–6.61 GiB | 5.59 GiB | 0 (77.38 → 77.38 MB) |
+| stack, chunk 32 | 6 | 3640 | **2.73 / 2.74 / 2.74** | 70.1 s / 69.0 s / 69.9 s | 49573 / 14376 (78%) | 23.7 GiB | 12.1–13.4 GiB | 5.9 GiB | 6.44–6.63 GiB | 7.59 GiB | 0 (77.38 → 77.38 MB) |
+| baseline, token-major | 2 | 1213 | **2.20 / 2.19 / 2.21** | 204.9 s / 205.1 s / 204.7 s | 109814 / 71626 (61%) | 118.0 GiB | 8.9–10.2 GiB | 10.1 GiB | 4.82–4.88 GiB | 3.53 GiB | 0 (77.38 → 77.38 MB) |
+| baseline, token-major | 4 | 2427 | **2.24 / 2.26 / 2.22** | 188.5 s / 184.4 s / 188.6 s | 148791 / 32649 (82%) | 53.8 GiB | 10.3–11.3 GiB | 8.0 GiB | 6.43–6.81 GiB | 5.53 GiB | 0 (77.38 → 77.38 MB) |
+| baseline, token-major | 6 | 3640 | **2.38 / 2.37 / 2.38** | 179.0 s / 177.6 s / 179.0 s | 165329 / 16111 (91%) | 26.6 GiB | 10.7–11.7 GiB | 6.1 GiB | 6.56–7.42 GiB | 7.53 GiB | 0 (77.38 → 77.38 MB) |
+| stack, 16-tok prompt | 2 | 1213 | **2.81 / 2.81 / 2.89** | 2.3 s / 2.4 s / 2.3 s | 13773 / 8816 (61%) | 14.5 GiB | 0.0–0.1 GiB | 10.0 GiB | 4.82–4.82 GiB | 3.47 GiB | 0 (77.38 → 77.38 MB) |
+| stack, 16-tok prompt | 4 | 2427 | **3.13 / 2.91 / 3.09** | 3.2 s / 3.0 s / 3.2 s | 17152 / 5437 (76%) | 9.0 GiB | 4.1–4.1 GiB | 8.0 GiB | 6.59–6.82 GiB | 5.47 GiB | 0 (77.38 → 77.38 MB) |
+| baseline, 16-tok prompt | 2 | 1213 | **2.66 / 2.67 / 2.67** | 5.8 s / 5.8 s / 5.9 s | 16833 / 8767 (66%) | 14.4 GiB | 0.0–0.0 GiB | 9.6 GiB | 4.81–4.81 GiB | 3.45 GiB | 0 (77.38 → 77.38 MB) |
+| baseline, 16-tok prompt | 4 | 2427 | **2.91 / 2.79 / 2.93** | 5.9 s / 5.7 s / 5.9 s | 20270 / 5330 (79%) | 8.8 GiB | 3.2–3.3 GiB | 8.1 GiB | 6.61–6.82 GiB | 5.46 GiB | 0 (77.38 → 77.38 MB) |
+
+## S3a / S3b breakdowns
+
+S3b on the M1 reports the same counter capability as the M4 Max
+(`timestampSet=yes stage=yes(sample resolved) dispatch=no`): per-phase GPU
+split is honestly unsupported, encode-side phase times are exact, wait/GPU are
+per command-buffer label. The baseline prints S3a totals only (no encode
+split), so its "CPU gap" below also contains its encode time — on the stack
+that is 4–6 ms per decode step and 0.1–3 s per prefill, so the baseline gap
+is overstated by about that much relative to the stack's.
+
+### Decode step decomposition (64-step totals ÷ 64; wall = 1 / tok/s)
+
+CPU gap = wall − wait − encode: everything the CPU thread does between
+command buffers — expert-cache misses (pread + copy into the cache slot),
+per-layer router readback and top-k, the 248 320-wide argmax, the Swift loop.
+
+| Configuration (warm-1) | tok/s | wall / step | wait | GPU | encode | CPU gap (share) | cb / step | (wait − GPU) per cb |
+|---|---|---|---|---|---|---|---|---|
+| A baseline, 16-tok, 4 GB | 2.91 | 343.6 ms | 204.5 ms | 155.2 ms | n/a (S3a only) | **139.1 ms (40%)** | 51 | 0.97 ms |
+| A stack, 16-tok, 4 GB | 3.13 | 319.5 ms | 193.9 ms | 151.9 ms | 5.4 ms | **120.2 ms (38%)** | 41 | 1.02 ms |
+| A2 baseline, 16-tok, 2 GB | 2.66 | 375.9 ms | 204.8 ms | 159.9 ms | n/a (S3a only) | **171.1 ms (46%)** | 51 | 0.88 ms |
+| A2 stack, 16-tok, 2 GB | 2.81 | 355.9 ms | 199.2 ms | 158.7 ms | 6.3 ms | **150.4 ms (42%)** | 41 | 0.99 ms |
+| B2 baseline, 503-tok, 2 GB | 2.20 | 454.5 ms | 202.0 ms | 165.2 ms | n/a (S3a only) | **252.6 ms (56%)** | 51 | 0.72 ms |
+| B baseline, 503-tok, 4 GB | 2.24 | 446.4 ms | 214.3 ms | 164.0 ms | n/a (S3a only) | **232.2 ms (52%)** | 51 | 0.99 ms |
+| B6 baseline, 503-tok, 6 GB | 2.38 | 420.2 ms | 213.5 ms | 161.3 ms | n/a (S3a only) | **206.7 ms (49%)** | 51 | 1.02 ms |
+| B0 stack token-major, 503-tok, 4 GB | 2.45 | 408.2 ms | 214.3 ms | 162.9 ms | 4.2 ms | **189.7 ms (46%)** | 41 | 1.25 ms |
+| C2 stack chunk 32, 503-tok, 2 GB | 2.42 | 413.2 ms | 196.0 ms | 162.6 ms | 4.6 ms | **212.6 ms (51%)** | 41 | 0.81 ms |
+| C stack chunk 32, 503-tok, 4 GB | 2.52 | 396.8 ms | 211.7 ms | 160.1 ms | 4.4 ms | **180.7 ms (46%)** | 41 | 1.26 ms |
+| C6 stack chunk 32, 503-tok, 6 GB | 2.73 | 366.3 ms | 213.4 ms | 157.2 ms | 4.8 ms | **148.1 ms (40%)** | 41 | 1.37 ms |
+
+On the M4 Max (`3dfd004`) the same gap was 9.6 ms of a 37.9 ms step (25%)
+short-context and 15.6 of 45.7 ms (34%) long-context. Here it is **38–56% of
+the step** and it
+is the only component that moves with the cache budget: stack chunk 32 at
+2 / 4 / 6 GB has GPU 162.6 / 160.1 / 157.2 ms and wait 196.0 / 211.7 /
+213.4 ms per step, while the gap goes 212.6 → 180.7 → 148.1 ms and the step
+413 → 397 → 366 ms. Dispatch latency is also ~5× the M4's: (wait − GPU) per
+command buffer is 0.7–1.4 ms on the M1 (0.2 ms on the M4 Max), 41 buffers per
+step = 34–56 ms of a decode step that is pure scheduling.
+
+Stack decode S3b (C, warm-1, `--cache-gb 4`, 64 steps): encode attention
+0.017 s / delta 0.064 s / moe 0.190 s / router 0.011 s / lmHead 0.001 s;
+buffers attention+moe+router cb=640 wait 3.044 s gpu 2.181 s |
+delta+moe+router cb=1856 wait 8.993 s gpu 6.664 s | delta+router cb=64 wait
+0.122 s gpu 0.081 s | moe+lmHead cb=64 wait 1.389 s gpu 1.320 s. The
+per-buffer shape matches the M4 run (same 640/1856/64/64 buffer counts and
+5760/24960/97280/5120/128 dispatch counts); only the durations scale.
+
+### Prefill decomposition (whole prefill, warm-1)
+
+| Configuration (warm-1) | TTFT | wait | GPU | encode | CPU gap (share) | cb | dispatches | (wait − GPU) per cb |
+|---|---|---|---|---|---|---|---|---|
+| A baseline, 16-tok, 4 GB | 5.924 s | 3.268 s | 2.454 s | n/a | **2.66 s (45%)** | 816 | 32 802 | 1.00 ms |
+| A stack, 16-tok, 4 GB, chunk 32 | 3.160 s | 1.431 s | 1.314 s | 0.006 s | **1.72 s (55%)** | 41 | 7 479 | 2.85 ms |
+| B2 baseline token-major, 2 GB | 204.939 s | 100.383 s | 76.774 s | n/a | **104.56 s (51%)** | 25 653 | 1 031 152 | 0.92 ms |
+| B baseline token-major, 4 GB | 188.466 s | 109.826 s | 75.972 s | n/a | **78.64 s (42%)** | 25 653 | 1 031 152 | 1.32 ms |
+| B6 baseline token-major, 6 GB | 178.951 s | 112.940 s | 75.526 s | n/a | **66.01 s (37%)** | 25 653 | 1 031 152 | 1.46 ms |
+| B0 stack token-major, 4 GB | 163.818 s | 107.994 s | 75.818 s | 3.059 s | **52.77 s (32%)** | 20 623 | 1 046 242 | 1.56 ms |
+| C2 stack chunk 32, 2 GB | 73.555 s | 41.950 s | 40.343 s | 0.125 s | **31.48 s (43%)** | 656 | 148 809 | 2.45 ms |
+| C stack chunk 32, 4 GB | 72.210 s | 46.278 s | 40.374 s | 0.189 s | **25.74 s (36%)** | 656 | 148 809 | 9.00 ms |
+| C6 stack chunk 32, 6 GB | 70.075 s | 48.821 s | 40.409 s | 0.259 s | **21.00 s (30%)** | 656 | 148 809 | 12.82 ms |
+
+Reading the prefill table:
+
+- **Token-major prefill is GPU-identical on both builds** (75.97 vs 75.82 s
+  of GPU execution for the same 503 tokens) even though the stack's total
+  includes the attention it moved onto the GPU. The attend-tiling GPU gain
+  that cut the M4 Max's token-major prefill GPU time by 40% (15.29 → 9.11 s)
+  does not show on the 8-core M1's token-major arm. The stack's 25 s
+  token-major TTFT gain is on the CPU side: 51 → 41 command buffers per
+  token (10 fewer — one per GQA layer, matching S2's GPU attention with a
+  GPU-resident KV cache replacing the per-layer round trip) and a CPU gap of
+  52.8 vs 78.6 s.
+- **Layer-major chunk 32 halves GPU execution** (75.8 → 40.4 s) at 656 vs
+  20 623 command buffers and 148 809 vs 1 046 242 dispatches, which is where
+  the 2.6× TTFT comes from. Stack chunk-32 S3b (C, warm-1): encode attention
+  0.003 s / delta 0.010 s / moe 0.174 s / router 0.002 s; buffers
+  attention+moe+router cb=160 wait 10.642 s gpu 9.325 s | delta+moe+router
+  cb=464 wait 34.363 s gpu 29.925 s | delta+router cb=16 wait 0.648 s gpu
+  0.621 s | moe cb=15 wait 0.572 s gpu 0.466 s | moe+lmHead cb=1 wait
+  0.053 s gpu 0.038 s.
+- **Where the cache budget goes during prefill**: with chunk 32, GPU time is
+  40.3–40.4 s at every budget; the CPU gap shrinks 31.5 → 25.7 → 21.0 s
+  (2 → 4 → 6 GB) while (wait − GPU) grows 1.6 → 5.9 → 8.4 s, so TTFT only
+  moves 73.6 → 72.2 → 70.1 s. The traces cannot attribute the growth in
+  wait − GPU (no per-phase split, no storage timer); it is reported, not
+  explained.
+
+## Output parity (production scale)
+
+Same mechanism as the M4 doc — greedy token/text equality, not a logit diff.
+Stdout compared by md5 after stripping the two `[QwenMetalModel]` banner
+lines:
+
+- **16-token prompt**: all 16 processes (both builds × cache 2/4 × 4 runs)
+  produce the identical 64-token continuation (`63de7116…`), and it is
+  byte-identical to macbook4's `69820f7` and `3dfd004` A-cell logs.
+- **503-token prompt**: all 28 processes (baseline at 2/4/6 GB, stack
+  token-major at 4 GB, stack chunk 32 at 2/4/6 GB, 4 runs each) produce the
+  identical 64-token continuation (`5f2821bc…`), byte-identical to
+  macbook4's B/C/D logs at both `69820f7` and `3dfd004`.
+- No divergence at any token position between builds, between token-major
+  and layer-major, between cache budgets, or between the M1 and the M4 Max.
+- Cache counters are bit-identical run to run within every cell, and the
+  token-major counters (148 791 / 32 649 at 4 GB) are identical between the
+  two builds — same routing on the same schedule. (Hit *rates* are not
+  comparable across schedules: layer-major looks up the expert union once
+  per chunk, so it makes 63 949 lookups where token-major makes 181 440;
+  misses and bytes are comparable.)
+- The `--ids` parity arm was not repeated; on the M4 Max it produced one
+  token before EOS, and the 64-token natural-prompt arms above carry the
+  sequence-level claim.
+
+## Thermal / drift check
+
+`pmset -g therm` reports "No thermal warning level has been recorded" before
+and after every run on this machine (it exposes no CPU speed limit), so
+throttling is checked by drift:
+
+- Run 1 vs run 3 inside each cell: prefill GPU execution differs by ≤ 0.1%
+  (B: 75.972 vs 75.906 s; C: 40.374 vs 40.376 s; C6: 40.409 vs 40.399 s),
+  decode GPU by ≤ 1.4%, decode tok/s by ≤ 2% (C: 2.52 vs 2.47; B: 2.24 vs
+  2.22; C6: 2.73 vs 2.74).
+- Across the 86-minute campaign the same GPU work drifted the other way: the
+  baseline's token-major prefill GPU time was 75.91–75.97 s at 23:10 (B) and
+  75.43–75.56 s at 00:05 (B6, the last cell); the stack's chunk-32 prefill
+  GPU was 40.35–40.38 s at 22:58 (C) and 40.37–40.41 s at 23:50 (C6).
+- No evidence of throttling. The visible run-to-run structure is not
+  thermal (next section).
+
+## Caveats
+
+- **Runs alternate between two page-cache states.** In every cell with
+  `--cache-gb ≥ 4`, `/usr/bin/time -l` "page faults" (major faults)
+  alternates between ~50 and 35 000–42 000 (≈ 0.6 GiB at 16 KiB/page) on
+  consecutive runs, and the faulting runs are the slower ones: B 214.1 vs
+  219.4–219.7 s real (wait 103.6 vs 109.8 s, GPU 75.9 s in all four); A
+  stack 3.13 / 3.09 (fast state) vs 2.91 / 2.92 tok/s (faulting state); A
+  baseline 2.91 / 2.93 vs 2.79. The 2 GB cells show no alternation (20 major
+  faults per run) and correspondingly tight spreads (2.66–2.67, 2.19–2.21).
+  The build-vs-build comparisons above are therefore quoted as ranges, and
+  the short-prompt delta as like-state pairs. Mechanism not established from
+  these traces; the observation is consistent with each run's expert preads
+  evicting file pages the next run then faults back in, which is an
+  inference, not a measurement.
+- **Steady state is partially cold.** The 16.88 GiB expert pool never fits
+  the page cache next to a 3.5–7.6 GiB process: file-backed pages at run
+  start were 9.9–10.1 / 7.9–8.1 / 5.9–6.1 GiB at 2 / 4 / 6 GB, and each
+  503-token run paged in 9–19 GiB from SSD. "Warm" here means "after a
+  warmup run", not "in RAM". The M4 doc's cold-vs-warm distinction does not
+  transfer; there was no `sudo purge` (no sudo from the bench account) and
+  the first process of the campaign (A baseline `cold-0`) started with
+  12.2 GiB of file-backed pages already present from the container's hash
+  verification and paged in 7.1 GiB.
+- **Memory pressure without swap.** Used swap was 77.38 MB before and after
+  all 44 runs, `time -l` recorded 0 swaps in every run, pageouts were ≤ 140
+  pages (≤ 2.2 MiB) per run. The compressor did engage: `vm_stat` "Pages
+  occupied by compressor" was 5.7–6.8 k pages (~100 MB) at every run start
+  but read 83 931 / 105 454 / 177 397 pages (1.3 / 1.6 / 2.7 GiB) in the
+  post-run snapshot of C warm-1, B0 warm-3 and C6 warm-1 respectively,
+  back to baseline before the next run. Those three runs are not outliers
+  in wall time (99.85 vs 97.06–100.32 s; 192.04 vs 184.83–192.26 s; 95.62
+  vs 93.86–95.74 s). Peak footprint (`time -l`) exceeds peak RSS at 6 GB
+  (7.59 vs 6.44–6.63 GiB), i.e. part of the process was compressed or not
+  resident at its peak. `--cache-gb 8` (the CLI default) was not run.
+- **Resident load.** WindowServer sits at a steady ~12% of one CPU core on
+  this mini (headless, no user session) along with Grafana alloy, wazuh and
+  tailscaled; no other swift/clang/benchmark process appeared in any of the
+  44 `ps` idle-checks (`<run>.pre`).
+- Peak RSS at 6 GB (6.4–7.4 GiB) is not "4 GB RSS + 2 GB": the kernel was
+  reclaiming pages from the process at that budget; footprint is the
+  better memory number on this box.
+- Per-phase GPU split is unsupported on the M1 exactly as on the M4 Max; the
+  CPU-gap decomposition is arithmetic and an upper bound that mixes expert
+  fetches with router readback and sampling; there is still no dedicated
+  storage timer in `StepMetrics`, so fetch cost is isolated by the cache
+  differential only.
+- SSD pageins are a system-wide counter over the run window on an otherwise
+  idle box; they include the process's own binary/dylib/dense-weight faults.
+- Single machine, single evening; builds separated from measurement (both
+  binaries built before the first timed run: stack 792 s compile including
+  the first package fetch, baseline 114 s with packages cached).
+- Raw logs (`<cell>-warm-N.{out,err,pre,post}`, `campaign.log`,
+  `build.log`, the prompt files, `runcell.sh`, `campaign.sh`) are on
+  macmini2 in `~/bench-logs/`.
+
+## What this says for #18
+
+Numbers only, from the tables above:
+
+1. **On a base M1 with 16 GB, `--cache-gb` is a throughput knob, modestly,
+   on both builds.** 503-token prompt, decode (medians of the three measured
+   runs): stack chunk 32 2.40 → 2.52 → 2.74 tok/s at 2 → 4 → 6 GB (+5.0%,
+   then +8.7%; +14.2% end to end); baseline 2.20 → 2.24 → 2.38 (+1.8%, then
+   +6.3%; +8.2% end to end). 16-token prompt, 2 → 4 GB: baseline 2.66–2.67
+   → 2.79–2.93 (+4–10%), stack 2.81–2.89 → 2.91–3.13 (+1–11%, bimodal).
+   TTFT moves less: −5.0% (stack chunk 32) and −12.7% (baseline) from 2 to
+   6 GB. The README's #18 note that "`--cache-gb 2` matches `--cache-gb 8`"
+   on this class of machine was measured at `f44e29f`; at `aaa910a` and
+   `5d8b2ab` the 2-vs-4 decode gap is +2% (baseline, long prompt) to +10%
+   (stack, short prompt) and the 2-vs-6 gap is +8% (baseline) to +14%
+   (stack).
+2. **Each GB of expert cache is taken from the page cache.** Footprint
+   3.5–3.6 / 5.5–5.6 / 7.5–7.6 GiB and file-backed pages at run start
+   9.9–10.1 / 7.9–8.0 / 5.9–6.1 GiB sum to ~13.5 GiB at every budget. Real SSD reads per 503-token run do not
+   fall with the miss count: stack 17.4–19.0 / 13.5–15.2 / 12.1–13.4 GiB
+   against 82.5 / 45.3 / 23.7 GiB of nominal misses; baseline 8.9–10.2 /
+   10.3–11.3 / 10.7–11.7 GiB against 118.0 / 53.8 / 26.6 GiB — the baseline
+   reads *more* from disk at 6 GB than at 2 GB while decoding 8% faster,
+   because an in-process hit costs nothing and a page-cache hit still costs
+   a 1.7 MiB copy. No budget up to 6 GB swapped; 8 GB was not tested.
+3. **What moves is the CPU gap, and it is the largest component of a step
+   here.** Wall − wait − encode is 38–56% of a decode step on the M1
+   (22–34% on the M4 Max) and is the only term that changes with the cache
+   budget (stack chunk 32: 213 → 181 → 148 ms of a 413 → 397 → 366 ms step;
+   GPU 163 → 160 → 157 ms; wait 196 → 212 → 213 ms). The wall differential
+   the M4 doc used to bound the marginal fetch cost (F − C: 6.8 ms, 9.5% of
+   a step, for 8 → 20 GB) is 47 ms, 11% of a step, here for 2 → 6 GB — a
+   64 ms drop in the CPU gap partly offset by 17 ms more wait.
+4. **The PR #24 stack on this hardware**: 503-token TTFT 188.5 → 72.2 s
+   (2.6×) via layer-major chunk 32 (GPU execution 75.8 → 40.4 s, 20 623 →
+   656 command buffers); token-major to token-major 188.5 → 163.8 s (−13%)
+   with identical GPU time (75.97 vs 75.82 s), from 51 → 41 command buffers
+   per token and a 78.6 → 52.8 s CPU gap; decode +12% long context (2.24 →
+   2.52) and +4–8% short context (2.91/2.93 → 3.13/3.09 in the fast
+   page-cache state, 2.79 → 2.91 in the faulting state), with 41 instead of
+   51 buffers per step and identical greedy output.
+5. The M4 doc deferred S4 (async expert-miss loading) pending "a trace from
+   a RAM-constrained target (… `--cache-gb 2` … on a small-RAM Mac where the
+   pool cannot live in page cache) [that] shows the cold-decode profile as
+   steady state". This is that trace: page cache 6–10 GiB against a
+   16.9 GiB pool, 9–19 GiB of SSD reads per 503-token run at steady state,
+   and a CPU gap of 148–253 ms per decode step that tracks the cache budget.

--- a/docs/BENCH_QWEN36_35B_M4MAX.md
+++ b/docs/BENCH_QWEN36_35B_M4MAX.md
@@ -1,0 +1,300 @@
+# Benchmark: Qwen3.6-35B-A3B (qpack Q4) on Apple M4 Max
+
+First real-model benchmark of the full Swiftlet stack (S1a + S1b layer-major
+prefill + token-batched GEMVs + S2 Metal attention/GPU KV + S3a/S3b
+instrumentation) on the production 35B qpack. Run 2026-08-31 on macbook4.
+
+Headline (warm, greedy, 64 new tokens):
+
+| Metric | Value |
+|---|---|
+| Decode, short context (16-tok prompt) | **25.0 tok/s** (25.00–25.08 across 3 runs) |
+| Decode, long context (503-tok prompt, default 8 GB cache) | 13.8–13.9 tok/s |
+| Decode, long context, 20 GB expert cache | 15.4–15.5 tok/s |
+| TTFT, 503-tok prompt, layer-major chunk 32 (default) | **11.65–11.70 s** (43.0–43.2 tok/s prefill) |
+| TTFT, 503-tok prompt, layer-major chunk 128 | 10.92–10.93 s (46.0–46.1 tok/s prefill) |
+| TTFT, 503-tok prompt, token-major (`--prefill-chunk 0`) | 23.69–23.81 s (21.1–21.2 tok/s prefill) |
+| Layer-major (32) vs token-major prefill | **2.04× faster** |
+| Cold-start decode (page cache purged) | 13.92 tok/s (1.80× slower than warm) |
+| Peak RSS | 9.7 GiB (short ctx) / 10.9 GiB (long ctx) / 14.5 GiB (20 GB cache) |
+| Greedy parity across all three prefill schedules | identical outputs, bit for bit |
+
+S4 verdict: **NO-GO (defer async expert loading)** — traces attribute the
+warm-path cost to command-buffer waits and GPU execution, not storage. Details
+in "S4 go/no-go" below.
+
+## Environment
+
+Per the Benchmark contract in the port roadmap (`ROADMAP.md`, origin/main of
+the `switftbri` planning repo).
+
+- **Commit**: `69820f7c6abd872c899ae9067eef224a5271cd81`
+  (`switftbri/s1b-token-batched-gemv`, clean tree; "Chunk the DeltaNet
+  recurrence into one T-step scan per layer"). Worktree rsync'd to
+  `~/build/s1c-swiftlet` on the Mac.
+- **Build**: `swift build -c release --scratch-path ~/build/s1c-swiftlet/.swiftcache`;
+  binary invoked directly (`.swiftcache/release/swiftlet`). No extra flags; the
+  CLT Testing-framework flags are needed only for `swift test`. Build step was
+  fully separated from all timed runs.
+- **Machine**: macbook4 — Apple M4 Max, 40-core GPU, 64 GB unified memory
+  (68719476736 B), internal APFS SSD (`/dev/disk3s5`, 926 GiB). macOS 26.6.2
+  (build 25G83). Swift 6.3.3 (swiftlang-6.3.3.1.3 clang-2100.1.1.101),
+  swift-driver 1.148.6, Command Line Tools only (no Xcode).
+- **Exclusive box**: `ps aux` idle-check before every batch; only resident
+  daemons (node_exporter, tailscaled) present, no other swift/clang/make jobs.
+- **Model**: `~/models/qwen3.6-35b.qpack` — QPACK v1 container of
+  Qwen3.6-35B-A3B (repack source `mlx-community/Qwen3.6-35B-A3B-4bit`), MLX
+  affine Q4 group-64. 40 layers (30 DeltaNet + 10 GQA), 256 routed experts per
+  layer (top-8) + 1 shared expert, hidden 2048, vocab 248320. Expert stride
+  1 769 472 B; 40 × 432 MiB `packed_experts/layer_NN.bin`; dense
+  `model.safetensors` 1.39 GB; container total 18 GB. Installed 2026-08-31 via
+  the C6d hash-pinned streaming transfer (dual-vantage pin, `hashes.json` in
+  container), hash-verified.
+- **Runtime config**: `--gpu` Metal runtime; expert cache budget default
+  `--cache-gb 8` (= 4854 slots of 1.69 MiB) except run set F (`--cache-gb 20`
+  = 10240 slots, the full expert pool). S3b counter probe on this device:
+  `timestampSet=yes stage=yes(sample resolved) dispatch=no` — the per-phase
+  GPU split honestly reports **unsupported** (M4 Max samples timestamps only
+  at encoder boundaries; the fast path encodes several phases per encoder), so
+  GPU/wait times below are per command-buffer label, encode-side phase times
+  are exact.
+
+## Protocol
+
+- **Sampler**: greedy argmax (the CLI `generate` path), no temperature, EOS
+  ids [248046, 248044] from the container's `config.json`.
+- **Output length**: `--max-new 64`; all A–F runs generated the full 64 tokens
+  (no early EOS).
+- **Short prompt** (run set A), exactly 16 tokens:
+  `The fieldfare is a large thrush that breeds across northern Europe and winters in`
+- **Long prompt** (run sets B/C/D/F), exactly 503 tokens: a fixed 2787-byte
+  English paragraph about MoE inference scheduling, stored verbatim at
+  `~/bench-logs/plong.txt` on macbook4, sha256
+  `d5ff9b0a8d0a52935b04d71ad39e874e96176f9ea20f6a105ac5d5ff506fbc19`.
+  Tokenized by the container's own tokenizer assets (hash-pinned, so the
+  encoding is reproducible).
+- **Parity prompt** (run set E): 200 deterministic raw ids bypassing the
+  tokenizer: `ids[i] = 1000 + 211*i` for `i = 0..199` (max 42 989 < vocab),
+  passed via `--ids`.
+- **Runs**: per configuration 1 warmup + 3 measured, every measured run
+  reported (no best-of). Each run is a fresh process (in-process expert cache
+  always starts empty). "Warm" = OS page cache warm from prior runs; on this
+  64 GB machine the 16.88 GiB expert pool fits in page cache entirely. The
+  labeled **cold** run was taken immediately after `sudo purge` with no
+  intervening file access.
+- **Metric definitions**: TTFT = the S3a prefill step wall time (model +
+  tokenizer load excluded; process totals reported separately). Decode tok/s
+  as printed by the harness over the 64-step loop. Peak RSS from
+  `/usr/bin/time -l`. Bytes read = expert-cache misses × stride (each miss is
+  exactly one pread of 1 769 472 B). Wait = the sum of blocking
+  `waitUntilCompleted` calls; GPU = sum of per-command-buffer GPU durations
+  (all 100% of buffers timed in every run below, `err=0` throughout).
+
+Repro (on the Mac, release binary `$BIN`, container `$MODEL`):
+
+```sh
+$BIN generate $MODEL --gpu --prompt "<short prompt>" --max-new 64                       # A
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --prefill-chunk 0   # B
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --prefill-chunk 32  # C
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --prefill-chunk 128 # D
+$BIN generate $MODEL --gpu --ids "1000,1211,...,42989" --max-new 32 --prefill-chunk N   # E
+$BIN generate $MODEL --gpu --prompt "$(cat plong.txt)" --max-new 64 --prefill-chunk 32 --cache-gb 20  # F
+```
+
+## Results
+
+### A — decode-focused: 16-token prompt, 64 new tokens, chunk 32 (default), 8 GB cache
+
+| Run | TTFT (prefill wall) | Decode tok/s | Decode wait / GPU (64 steps) | Cache hits/misses (hit rate) | Bytes read | Peak RSS | Process real |
+|---|---|---|---|---|---|---|---|
+| cold-1 (purged) | 1.853 s | **13.92** | 2.900 s / 2.226 s | 18429 / 4160 (82%) | 6.86 GiB (SSD) | 9.68 GiB | 8.79 s |
+| warm-0 (warmup) | 0.593 s | 25.07 | 1.908 s / 1.377 s | 18429 / 4160 (82%) | 6.86 GiB (page cache) | 9.67 GiB | 3.95 s |
+| warm-1 | 0.595 s | **25.02** | 1.910 s / 1.379 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.94 s |
+| warm-2 | 0.596 s | **25.00** | 1.911 s / 1.377 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.96 s |
+| warm-3 | 0.594 s | **25.08** | 1.905 s / 1.378 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.94 s |
+
+Spread of measured warm decode: 25.00–25.08 tok/s (0.3%). Per-step schedule is
+fixed: 41 command buffers and 2082 dispatches per decode token (2624 cb /
+133 248 dispatches per 64 steps). 4160 unique (layer, expert) blobs touched —
+below the 4854-slot budget, so **zero evictions** in this configuration; the
+identical hit/miss counts across cold and warm confirm identical routing.
+Greedy continuation (identical in all five runs) is coherent and factually
+reasonable: " southern Europe. It is a common winter visitor to the UK, …".
+
+### B — prefill token-major (`--prefill-chunk 0`): 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Cache hits/misses (rate) | Bytes read | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 23.689 s | 21.23 | 19.604 / 15.261 s | 20623 / 1 046 242 | 13.17 | 171983 / 9457 (95%) | 15.58 GiB | 10.93 GiB | 29.37 s |
+| warm-1 | **23.791 s** | 21.14 | 19.686 / 15.299 s | 20623 / 1 046 242 | 13.82 | 171983 / 9457 (95%) | 15.58 GiB | 10.92 GiB | 29.29 s |
+| warm-2 | **23.806 s** | 21.13 | 19.671 / 15.285 s | 20623 / 1 046 242 | 13.78 | 171983 / 9457 (95%) | 15.58 GiB | 10.91 GiB | 29.33 s |
+| warm-3 | **23.800 s** | 21.13 | 19.635 / 15.275 s | 20623 / 1 046 242 | 13.70 | 171983 / 9457 (95%) | 15.58 GiB | 10.94 GiB | 29.34 s |
+
+41 cb per prompt token (503 × 41 = 20 623). Miss count 9457 exceeds the
+4854-slot budget → LFU eviction churn; re-reads served from page cache.
+
+### C — prefill layer-major chunk 32 (default): 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Cache hits/misses (rate) | Bytes read | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 11.647 s | 43.19 | 8.377 / 8.004 s | 656 / 226 729 | 13.89 | 54768 / 9181 (86%) | 15.13 GiB | 10.92 GiB | 17.13 s |
+| warm-1 | **11.670 s** | 43.10 | 8.360 / 7.982 s | 656 / 226 729 | 13.89 | 54768 / 9181 (86%) | 15.13 GiB | 10.89 GiB | 17.15 s |
+| warm-2 | **11.679 s** | 43.07 | 8.373 / 8.000 s | 656 / 226 729 | 13.86 | 54768 / 9181 (86%) | 15.13 GiB | 10.90 GiB | 17.18 s |
+| warm-3 | **11.702 s** | 42.98 | 8.389 / 8.014 s | 656 / 226 729 | 13.79 | 54768 / 9181 (86%) | 15.13 GiB | 10.89 GiB | 17.22 s |
+
+16 chunks × 41 cb = 656 cb; **2.04× faster TTFT than token-major** with 4.6×
+fewer dispatches and 31× fewer command buffers.
+
+### D — prefill layer-major chunk 128: 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Cache hits/misses (rate) | Bytes read | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 10.921 s | 46.06 | 7.618 / 7.324 s | 164 / 136 267 | 14.12 | 28796 / 8959 (76%) | 14.76 GiB | 10.91 GiB | 16.32 s |
+| warm-1 | **10.915 s** | 46.08 | 7.618 / 7.322 s | 164 / 136 267 | 14.11 | 28796 / 8959 (76%) | 14.76 GiB | 10.92 GiB | 16.33 s |
+| warm-2 | **10.927 s** | 46.03 | 7.622 / 7.320 s | 164 / 136 267 | 14.10 | 28796 / 8959 (76%) | 14.76 GiB | 10.91 GiB | 16.35 s |
+| warm-3 | **10.932 s** | 46.01 | 7.622 / 7.324 s | 164 / 136 267 | 14.08 | 28796 / 8959 (76%) | 14.76 GiB | 10.92 GiB | 16.35 s |
+
+4 chunks × 41 cb = 164 cb — the chunk-128 scratch allocation succeeded (no
+token-major fallback; the cb count proves the schedule). 6.9% faster than
+chunk 32; the curve is flattening as prefill becomes GPU-execution-bound
+(wait 7.62 s of which GPU is 7.32 s).
+
+### F — cache-size knob: chunk 32, 503-token prompt, `--cache-gb 20` (full pool cacheable)
+
+| Run | TTFT | Prefill tok/s | Decode tok/s | Cache hits/misses (rate) | Bytes read | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 11.347 s | 44.33 | 15.38 | 56931 / 7018 (89%) | 11.57 GiB | 13.82 GiB | 16.40 s |
+| warm-1 | **11.251 s** | 44.71 | **15.41** | 56931 / 7018 (89%) | 11.57 GiB | 14.46 GiB | 17.05 s |
+| warm-2 | **11.293 s** | 44.54 | **15.49** | 56931 / 7018 (89%) | 11.57 GiB | 14.46 GiB | 16.34 s |
+| warm-3 | **11.325 s** | 44.42 | **15.40** | 56931 / 7018 (89%) | 11.57 GiB | 14.48 GiB | 16.38 s |
+
+With 10240 slots every miss is a first touch (7018 unique blobs, zero
+evictions). Versus C (same schedule, 8 GB): long-context decode improves
+13.86 → 15.43 tok/s (**+11%**), prefill ~3% faster, and 2163 eviction
+re-reads (3.6 GiB of page-cache preads) disappear. Output identical to C.
+
+## S3b breakdowns
+
+Encode-side phase split is exact; wait/GPU can only be attributed per
+command-buffer label because one buffer spans several phases (per-phase GPU
+split is unsupported on M4 Max — encoder-boundary timestamps only).
+
+Decode, A warm-1 (64 steps, totals):
+
+| | attention | delta | moe | router | lmHead |
+|---|---|---|---|---|---|
+| dispatches | 5760 | 24960 | 97280 | 5120 | 128 |
+| encode s | 0.002 | 0.007 | 0.029 | 0.002 | 0.000 |
+
+| buffer label | cb | wait s | GPU s |
+|---|---|---|---|
+| attention+moe+router | 640 | 0.554 | 0.425 |
+| delta+moe+router | 1856 | 1.157 | 0.814 |
+| delta+router | 64 | 0.073 | 0.025 |
+| moe+lmHead | 64 | 0.127 | 0.114 |
+
+Decode step decomposition (A warm-1, 40.0 ms/step wall): GPU execution
+21.5 ms + command-buffer scheduling latency (wait − GPU, 41 waits/step ≈
+0.20 ms each) 8.3 ms + encode 0.6 ms + **unattributed CPU gap 9.5 ms** (expert
+preads/memcpy, per-layer router readback + CPU top-k, argmax over the 248 320
+vocab, Swift loop).
+
+Same decomposition elsewhere:
+
+| Configuration | wall | wait | GPU | encode | CPU gap (share) |
+|---|---|---|---|---|---|
+| A decode warm (per step) | 40.0 ms | 29.8 ms | 21.5 ms | 0.6 ms | 9.5 ms (24%) |
+| A decode **cold** (per step) | 71.9 ms | 45.3 ms | 34.8 ms | 0.9 ms | 25.7 ms (36%) |
+| C decode warm, 8 GB (per step) | 72.0 ms | 55.8 ms | 46.4 ms | 0.6 ms | 15.5 ms (22%) |
+| F decode warm, 20 GB (per step) | 64.9 ms | 55.6 ms | 46.3 ms | 0.6 ms | 8.7 ms (13%) |
+| B prefill (whole, warm-1) | 23.79 s | 19.69 s | 15.30 s | 0.37 s | 3.73 s (16%) |
+| C prefill (whole, warm-1) | 11.67 s | 8.36 s | 7.98 s | 0.08 s | 3.23 s (28%) |
+| D prefill (whole, warm-1) | 10.92 s | 7.62 s | 7.32 s | 0.05 s | 3.25 s (30%) |
+
+Token-major prefill's extra 8 s over chunk 32 is almost entirely
+command-buffer round-trips: wait−GPU = 4.39 s across 20 623 cb (0.21 ms each)
+vs 0.38 s across 656 cb, plus lower GPU efficiency on single-token GEMVs
+(15.3 s vs 8.0 s GPU for identical math).
+
+## Output parity across schedules (production scale)
+
+Mechanism reported honestly: **greedy token/text equality**, not a logit-level
+comparison (the CLI surfaces no logits at 35B and an in-process dual-model
+harness was out of scope for a docs-only run; numerical logit parity remains
+pinned by the tiny-model gates on the S1b/S2 branches).
+
+- 503-token natural prompt, 64 greedy tokens: stdout is **bitwise identical**
+  across token-major, chunk 32, chunk 128 (`diff` of B/C/D `warm-1.out`), and
+  also identical for F (chunk 32, 20 GB cache). The continuation is a coherent
+  markdown table about MoE routing overhead.
+- 200-id deterministic prompt (`--ids`, formula above), all three schedules:
+  identical output — greedy token 220 followed by EOS. (EOS after one token
+  limits this arm's sequence length; the 64-token text runs above carry the
+  sequence-level claim.)
+- A cold vs warm: identical continuation and identical hit/miss counts —
+  routing is unaffected by cache temperature.
+
+## S4 go/no-go: are storage/expert-fetch stalls a material cost?
+
+**Verdict: NO-GO — defer S4 (async expert miss loading). The measured warm
+bottleneck is command-buffer wait and GPU execution, not storage.**
+
+Evidence from the S3a/S3b traces above:
+
+1. **Warm decode wait dominates.** 41 blocking `waitUntilCompleted` per token
+   spanning 74–78% of decode wall (29.8 of 40.0 ms/step short-context; 55.8 of
+   72.0 ms/step long-context), of which GPU execution is 21.5 / 46.4 ms.
+   Expert fetches do not sit inside these waits — they happen on the CPU
+   thread before commit, inside the unattributed gap.
+2. **The storage-attributable share is bounded and small when warm.** The
+   entire CPU gap — which also contains router readback, CPU top-k, and the
+   248 320-wide argmax — is 9.5 ms/step (24%) short-context and 15.5 ms/step
+   (22%) long-context. The direct differential F−C (only variable: eviction
+   re-reads, 3.6 GiB fewer preads) is **6.8 ms/step ≈ 9.5% of the step** —
+   that is the actual marginal fetch cost at the default 8 GB budget, and it
+   is removable by cache sizing alone (`--cache-gb 20`), no async loader
+   needed on this machine.
+3. **Prefill is GPU-bound, not storage-bound.** Layer-major chunk 128: wait
+   7.62 s of 10.92 s wall with GPU execution 7.32 s of that wait; wait−GPU is
+   only 0.30 s. Faster expert loading cannot shorten it materially.
+4. **Storage is material exactly once: cold start.** After `purge`, the first
+   pass preads 6.86 GiB from SSD: decode 13.92 vs 25.05 tok/s (1.80×
+   penalty), TTFT 1.85 vs 0.59 s, and the CPU gap grows 9.5 → 25.7 ms/step
+   with wait inflating alongside (I/O contending with the GPU on unified
+   memory). On this 64 GB machine that is a one-time-per-boot window — the
+   16.88 GiB pool then lives in page cache.
+
+Phase-4 gate check ("add async miss loading only after timeline data
+distinguishes storage wait from command dispatch and GPU compute"): the data
+now distinguishes them — dispatch wait ~0.2 ms × 41 cb/token plus GPU
+execution dominate; storage contributes ≤ ~10% warm and ~1.8× only when cold.
+S4 should be revisited, not resurrected, when a trace from a RAM-constrained
+target (iPhone-class device, or `--cache-gb 2` server default on a small-RAM
+Mac where the pool cannot live in page cache) shows the cold-decode profile as
+steady state. The higher-leverage next steps on this hardware are dispatch
+reduction (fewer than 41 cb/token; batching the per-layer router readback) and
+S2 attention tiling.
+
+## Caveats
+
+- Parity is greedy-sequence/text equality at production scale, not a
+  35B logit-level diff (see mechanism note above).
+- Per-phase GPU split is honestly unsupported on M4 Max (encoder-boundary
+  counters only); wait/GPU attribution is per command-buffer label, and the
+  CPU-gap decomposition is arithmetic (wall − wait − encode), an upper bound
+  that mixes expert fetches with router readback and sampling.
+- There is no dedicated storage-fetch timer in `StepMetrics`; storage cost was
+  isolated by differentials (purged-cold vs warm; 8 GB vs 20 GB cache), which
+  is indirect but consistent across all runs.
+- "Warm" bytes read are page-cache preads (the pool fits in 64 GB RAM); on
+  smaller-RAM machines the cold profile (1.8× decode penalty) is the realistic
+  steady state and the S4 verdict would likely flip there.
+- Decode throughput depends on context length (25.0 tok/s at ~16+64 ctx vs
+  13.9 at 503+64 ctx with the default cache); single machine, single day;
+  resident daemons (node_exporter, tailscaled) idle but present.
+- The `--ids` parity arm produced only one token before EOS; sequence-level
+  parity rests on the 64-token natural-prompt runs.
+- Warmup runs are shown but excluded from claims; B-warm-0's 13.17 tok/s
+  decode reflects residual page-cache warming.
+- Raw logs (`*.out`/`*.err` per run, prompt file) retained on macbook4 in
+  `~/bench-logs/`.

--- a/docs/BENCH_QWEN36_35B_M4MAX.md
+++ b/docs/BENCH_QWEN36_35B_M4MAX.md
@@ -23,6 +23,11 @@ S4 verdict: **NO-GO (defer async expert loading)** — traces attribute the
 warm-path cost to command-buffer waits and GPU execution, not storage. Details
 in "S4 go/no-go" below.
 
+Low-end sibling: the same protocol on a base M1 Mac mini (8-core GPU, 16 GB),
+upstream `aaa910a` vs PR #24 `5d8b2ab` with a `--cache-gb` 2/4/6 sweep, is in
+[`BENCH_QWEN36_35B_M1_MINI.md`](BENCH_QWEN36_35B_M1_MINI.md) — the
+RAM-constrained trace the S4 note below asks for.
+
 ## Environment
 
 Per the Benchmark contract in the port roadmap (`ROADMAP.md`, origin/main of

--- a/docs/BENCH_QWEN36_35B_M4MAX.md
+++ b/docs/BENCH_QWEN36_35B_M4MAX.md
@@ -298,3 +298,247 @@ S2 attention tiling.
   decode reflects residual page-cache warming.
 - Raw logs (`*.out`/`*.err` per run, prompt file) retained on macbook4 in
   `~/bench-logs/`.
+
+---
+
+# Re-run 2026-08-31: conv scan + attend tiling (`3dfd004`), SG sweep, colibri head-to-head
+
+Second benchmark on the same box, model, prompts, sampler, and protocol as
+the baseline above (code `69820f7`, doc commit `0f6a9a8`). Everything in the
+Environment and Protocol sections holds unchanged (same binary invocation,
+same 8 GB default cache, same 1 warmup + 3 measured discipline, `ps aux`
+idle-check logged before every timed run, builds fully separated from
+measurement; raw logs in `~/bench-logs-3dfd004/` on macbook4). This section
+measures the eight commits that landed since the baseline:
+
+- `ef264e5` + `b4a986c` — token-grid batch twin for the causal attend;
+  chunk pass attends batched across tokens.
+- `7bc850f` + `848128f` — stride twins for the DeltaNet prep chain; prep
+  chain batched across the chunk.
+- `1cf3dbf` + `9661248` — cross-token scan twin for the depthwise conv;
+  chunk pass conv encoded as one scan dispatch per layer.
+- `d15ca75` + `3dfd004` — attention parity gate widened; causal attend
+  tiled across KV rows over `ATTN_DECODE_SG` cooperating simdgroups with
+  float4-vectorized K/V loads.
+
+Benchmark commit: `3dfd004` (clean tree, rsync'd to `~/build/s1c-swiftlet`),
+followed by the sweep-driven `7352871` (below). Swift 6.3.3, macOS 26.6.2,
+same M4 Max.
+
+## Headline vs the 69820f7 baseline (warm, greedy, 64 new tokens, 8 GB cache)
+
+| Metric | `69820f7` | `3dfd004` | delta |
+|---|---|---|---|
+| Decode, short context (16-tok prompt) | 25.00-25.08 tok/s | **26.36-26.45 tok/s** | **+5.4%** |
+| Decode, long context (503-tok prompt, chunk 32) | 13.79-13.89 tok/s | **21.57-21.87 tok/s** | **+57%** |
+| TTFT, 503-tok prompt, chunk 32 (default) | 11.67-11.70 s | **8.76-8.84 s** | **-24.7%** |
+| TTFT, 503-tok prompt, chunk 128 | 10.92-10.93 s | **8.17-8.18 s** | **-25.1%** |
+| TTFT, 503-tok prompt, token-major | 23.79-23.81 s | **17.43-17.68 s** | **-26.5%** |
+| Prefill dispatches, chunk 32 | 226 729 | **148 809** | -34% |
+| Prefill dispatches, chunk 128 | 136 267 | **56 427** | -59% |
+| Greedy outputs vs the 69820f7 logs | — | **bitwise identical, every arm** | — |
+
+## Results (same run-set labels as the baseline)
+
+### A — decode-focused: 16-token prompt, 64 new, chunk 32, 8 GB cache
+
+| Run | TTFT | Decode tok/s | Decode wait / GPU (64 steps) | Hits/misses (rate) | Bytes read | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 0.903 s | 22.25 | 1.910 s / 1.369 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 5.01 s |
+| warm-1 | 0.580 s | **26.38** | 1.773 s / 1.234 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.83 s |
+| warm-2 | 0.586 s | **26.36** | 1.775 s / 1.235 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.83 s |
+| warm-3 | 0.586 s | **26.45** | 1.765 s / 1.234 s | 18429 / 4160 (82%) | 6.86 GiB | 9.67 GiB | 3.83 s |
+
+Decode schedule unchanged: 41 cb / 2082 dispatches per token (2624 cb /
+133 248 per 64 steps) — the decode gain is per-dispatch, not fewer
+dispatches. The 16-token prefill dropped 9879 → 7479 dispatches (-24%):
+attention 240 → 90 (batched attends), delta 2670 → 420 (conv scan + prep
+chain), moe/router/lmHead unchanged — the conv scan moves dispatch counts
+exactly as designed. Cache hits/misses identical to the baseline.
+
+### B — token-major prefill (`--prefill-chunk 0`): 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 17.684 s | 28.44 | 13.123 / 9.141 s | 20623 / 1 046 242 | 21.09 | 10.91 GiB | 21.58 s |
+| warm-1 | **17.431 s** | 28.86 | 13.090 / 9.106 s | 20623 / 1 046 242 | 21.31 | 10.95 GiB | 21.32 s |
+| warm-2 | **17.522 s** | 28.71 | 13.241 / 9.167 s | 20623 / 1 046 242 | 21.13 | 10.93 GiB | 21.44 s |
+| warm-3 | **17.512 s** | 28.72 | 13.300 / 9.212 s | 20623 / 1 046 242 | 21.04 | 10.92 GiB | 21.44 s |
+
+Same 20 623 cb and 1 046 242 dispatches as the baseline (token-major takes
+the per-token path; batching/scan don't apply), so this arm isolates the
+attend tiling: prefill GPU execution 15.29 → 9.11 s (-40%) with identical
+math, TTFT -6.3 s. Cache counters unchanged (171983 / 9457, 95%).
+
+### C — layer-major chunk 32 (default): 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 8.776 s | 57.32 | 5.479 / 5.163 s | 656 / 148 809 | 22.05 | 10.90 GiB | 12.54 s |
+| warm-1 | **8.781 s** | 57.28 | 5.511 / 5.190 s | 656 / 148 809 | 21.87 | 10.91 GiB | 12.58 s |
+| warm-2 | **8.763 s** | 57.40 | 5.480 / 5.148 s | 656 / 148 809 | 21.61 | 10.91 GiB | 12.60 s |
+| warm-3 | **8.836 s** | 56.93 | 5.538 / 5.190 s | 656 / 148 809 | 21.57 | 10.91 GiB | 12.67 s |
+
+Dispatches 226 729 → 148 809 (-34%; prefill phases now attention 1440,
+delta 6720, moe 139 367, router 1280) at the same 656 cb. Layer-major
+chunk 32 vs token-major is now 1.99× on TTFT (was 2.04×; both schedules
+sped up). Cache counters identical to baseline (54768 / 9181, 86%).
+
+### D — layer-major chunk 128: 503-token prompt, 64 new
+
+| Run | TTFT | Prefill tok/s | Prefill wait / GPU | cb / dispatches | Decode tok/s | Peak RSS | Real |
+|---|---|---|---|---|---|---|---|
+| warm-0 (warmup) | 8.182 s | 61.48 | 4.876 / 4.583 s | 164 / 56 427 | 22.33 | 10.91 GiB | 11.93 s |
+| warm-1 | **8.182 s** | 61.48 | 4.880 / 4.588 s | 164 / 56 427 | 22.43 | 10.91 GiB | 11.91 s |
+| warm-2 | **8.170 s** | 61.57 | 4.878 / 4.581 s | 164 / 56 427 | 22.45 | 10.91 GiB | 11.89 s |
+| warm-3 | **8.184 s** | 61.46 | 4.880 / 4.588 s | 164 / 56 427 | 22.34 | 10.91 GiB | 11.94 s |
+
+Dispatches 136 267 → 56 427 (-59%): the bigger the chunk, the more the
+scan/batching amortize. Chunk 128 over chunk 32 is now +7.4% (was +6.9%).
+
+## Decode step decomposition (vs baseline)
+
+| Configuration | wall | wait | GPU | encode | CPU gap (share) |
+|---|---|---|---|---|---|
+| A decode warm (per step), 69820f7 | 40.0 ms | 29.8 ms | 21.5 ms | 0.6 ms | 9.5 ms (24%) |
+| A decode warm (per step), 3dfd004 | 37.9 ms | 27.7 ms | 19.3 ms | 0.6 ms | 9.6 ms (25%) |
+| C decode warm (per step), 69820f7 | 72.0 ms | 55.8 ms | 46.4 ms | 0.6 ms | 15.5 ms (22%) |
+| C decode warm (per step), 3dfd004 | 45.7 ms | 29.5 ms | 20.8 ms | 0.6 ms | 15.6 ms (34%) |
+
+The attend tiling removed ~26 ms of GPU execution per long-context step —
+long-context decode GPU time is now nearly flat versus short context
+(20.8 vs 19.3 ms/step; it was 46.4 vs 21.5). The unattributed CPU gap is
+untouched (same expert preads, router readback, argmax) and is now the
+largest single lever at long context (34% of the step), ahead of dispatch
+wait (wait − GPU ≈ 8.7 ms) — reinforcing the baseline's "dispatch
+reduction + CPU-side work" priority over any storage work (S4 stays NO-GO;
+nothing in this re-run moves that verdict).
+
+## ATTN_DECODE_SG sweep (2 / 4 / 8 simdgroups per (head, token))
+
+Decode case, 1 warmup + 3 measured per point, separate binaries + resource
+bundles built per value (both the Swift dispatch width and the kernel's
+`#define` move together), builds separated from measurement:
+
+| SG | Decode tok/s, 16-tok prompt | Decode tok/s, 503-tok prompt (chunk 32) | Decode GPU s/64 steps (long) |
+|---|---|---|---|
+| 2 | 26.10-26.19 | 20.80-21.00 | 1.455-1.456 |
+| 4 (3dfd004 default) | 26.36-26.45 | 21.57-21.87 | 1.328-1.332 |
+| 8 | **26.42-26.51** | **22.06-22.12** | 1.282-1.283 |
+
+SG=8 wins both: +1.9% decode at 567-row KV, level-to-slightly-ahead at
+80-row KV. Greedy outputs bitwise identical across all three values on both
+prompts. Committed as **`7352871`** ("Raise the attend tiling to eight
+simdgroups per (head, token)", the two matched constant lines only); the
+full test suite (96 tests / 18 suites, CLT framework flags) passes at that
+commit on this machine. The A/B/C/D tables above are the pre-sweep
+`3dfd004` numbers; SG=8 adds its ~+2% on top of the long-context decode
+column.
+
+## Output parity vs the 69820f7 run (production scale)
+
+Same mechanism as the baseline (greedy token/text equality, not logit
+diff), now also a cross-code-revision check. The attend tiling changed the
+attention reduction order (strided per-simdgroup online softmax merged by
+exp-rescale, float4 dots), so greedy tie flips were possible — none
+occurred:
+
+- A/B/C/D `warm-1..3` stdout: **bitwise identical to the corresponding
+  69820f7 logs** (`diff` against `~/bench-logs/*.out`), and identical
+  across schedules (B = C = D md5) and across SG = 2/4/8.
+- `--ids` parity arm (200 deterministic ids, chunk 0/32/128): identical to
+  the baseline logs.
+- Cache hit/miss counts identical in every arm — routing untouched.
+
+## Colibri head-to-head (same box, same qpack container, same prompt)
+
+Colibri's C engine (`~/build/c3-colibri`, mirror of branch tip `08c24b2`;
+the mirror carries no git metadata, so the commit is taken from the sync
+record, not verified against a local clone). Rebuilt for this run:
+`make -C c qwen36 METAL=1` — OpenMP engaged (`-Xclang -fopenmp` +
+Homebrew `libomp` linked, 8 parallel regions; no single-thread warning)
+and the C3 qpack Metal expert path compiled in (`-DCOLI_METAL
+-DQWEN36_QPACK`). Run line: `SNAP=<snap> QWEN36_QPACK=<qpack> N_NEW=n
+./qwen36 n 4 <prompt file>`, `COLI_TIMERS=1`, greedy, same fieldfare
+16-token prompt (colibri tokenizes it to 16 tokens, matching Swiftlet's count; both engines open with the same first two greedy tokens)
+and the standard 5-token "capital of France" smoke.
+
+### Decode-focused: 16-token prompt, 64 new tokens
+
+| Run | TTFT | Whole-run tok/s | Decode step time | Peak RSS | Real |
+|---|---|---|---|---|---|
+| warm-0 (warmup) | 2.00 s | 4.76 | 181.4 ms/tok | 11.31 GiB | 15.33 s |
+| warm-1 | **1.92 s** | 4.84 | 179.1 ms/tok | 11.31 GiB | 14.84 s |
+| warm-2 | **1.89 s** | 4.84 | 179.5 ms/tok | 11.31 GiB | 14.84 s |
+| warm-3 | **1.95 s** | 4.82 | 179.3 ms/tok | 11.31 GiB | 14.89 s |
+
+"Whole-run tok/s" is the harness's `Speed` (64 tokens over the full
+generate call including prefill); decode-only from the step timer is
+**5.57-5.58 tok/s** (63 steps at 179.1-179.5 ms). Phase split (warm-1,
+ms/token): deltanet 65.3 (of which projections 45.4), moe 74.2 (shared
+12.6, router 3.1), lm_head 22.0, attention 17.0. CPU threading is real:
+94.0 s user / 14.84 s real ≈ 6.3 cores busy on the 12P+4E M4 Max.
+
+qpack counters, identical across all four runs: `metal=75840 cpu=0`
+(every routed projection on Metal, zero CPU fallbacks), `blocks=2640
+pairs=25280 binds=23266 stalls=0 redirects=0 fallbacks=0`,
+**`stage_reuse=2640 stage_grow=0`** (every begin served from a bound
+arena, no steady-state growth), `slots=96 fills=22264 evictions=22168`
+(the 96-slot bounded pool churns hard at this cache size — the legacy
+snapshot expert cache reports 0/0 because qpack mode bypasses it).
+
+### Smoke: 5-token prompt ("The capital of France is"), 16 new
+
+TTFT 0.68 s (0.72 warmup), Speed 4.74-4.75 tok/s, RSS 11.31 GiB;
+counters `metal=19200 cpu=0`, `stage_reuse=640 stage_grow=0`, fills=5914 /
+evictions=5818. Output stable across runs: " Paris, a city renowned for
+its iconic landmarks such as the Eiffel Tower,".
+
+### Head-to-head (identical prompt/params: fieldfare 16-tok, 64 new, greedy)
+
+| | Swiftlet `3dfd004`+SG8 | colibri `08c24b2` | ratio |
+|---|---|---|---|
+| Decode tok/s (short ctx) | **26.4-26.5** | 5.57-5.58 (step timer) | **4.7×** |
+| TTFT (16-tok prompt) | **0.58 s** | 1.89-1.95 s | 3.3× |
+| Peak RSS | **9.67 GiB** | 11.31 GiB | 0.86× |
+| Routed experts | Metal (bounded 8 GB cache) | Metal via qpack (96 slots) | — |
+| Attention / DeltaNet / dense / lm_head | Metal | CPU (OpenMP, int8 dense) | — |
+
+Architectural caveat, stated plainly: this is not a like-for-like GPU
+race. Colibri's C3 stage puts only the routed-expert projections on
+Metal by design; attention, DeltaNet, the shared expert, router, and the
+248 320-wide lm_head all run on CPU threads, and its decode is
+correspondingly CPU-bound (deltanet + moe + lm_head ≈ 161 of 179
+ms/token). Swiftlet runs the whole forward pass on the GPU. The
+comparison pins where the colibri port is on the same container today,
+not a verdict on its ceiling.
+
+**Cross-engine output divergence (surfaced, not smoothed):** colibri's
+64-token fieldfare continuation is byte-identical across its own runs
+but **diverges from Swiftlet's at the 3rd generated token** — both open
+" southern Europe", then Swiftlet continues ". It is a common winter
+visitor to the UK, …" while colibri continues " and Britain. It is a
+migratory bird, …". The two engines compute in different arithmetic
+(colibri: CPU f32 with int8-quantized dense matrices; Swiftlet: Metal
+kernels), so a greedy tie flipping between them is expected behaviour
+and is not a parity claim either engine makes; each engine's own
+determinism and its own parity gates (Swiftlet: bitwise vs its 69820f7
+logs; colibri: metal=…/cpu=0 with fallbacks=0) all hold. No pinned
+cross-engine text exists in either repo's docs; the "byte-identical"
+note in the prior colibri session's record matches its internal
+qpack-vs-reference parity gate, not a cross-engine pin.
+
+## Caveats (delta from the baseline's list, which still applies)
+
+- The A-D tables above are `3dfd004` with the then-default SG=4; SG=8
+  (`7352871`) adds ~+1.9% long-context decode on top and is the new
+  default. Short-context A numbers under SG=8: 26.42-26.51 tok/s.
+- Colibri's decode tok/s depends on which number you quote: 4.8 whole-run
+  vs 5.6 step-timer; both are given above. The earlier session's "~4.4
+  tok/s" was measured before this rebuild; today's binary is faster and
+  the number to carry forward is 5.57-5.58 step-timer / 4.82-4.84
+  whole-run.
+- Colibri `cache=64/layer bits=4` per the established run line; its
+  96-slot qpack pool evicts heavily (22 168 evictions / 64 tokens), so
+  its expert-fetch regime is not comparable to Swiftlet's 8 GB cache.
+- Single day, single machine; same resident daemons as the baseline.

--- a/docs/STATE_FORMAT.md
+++ b/docs/STATE_FORMAT.md
@@ -1,0 +1,160 @@
+# Conversation-state snapshot format (v1)
+
+A snapshot is the byte image of one `QwenInferenceContext`: everything a Qwen
+engine needs to continue a sequence exactly where it stopped — the attention
+KV rows, each DeltaNet layer's conv history and delta recurrence, and the
+position. Written by `PersistableInferenceModel.snapshot(of:)`, read by
+`restoreContext(from:)`, on either engine (CPU reference or Metal), in the
+same process or a later one. Implementation: `Sources/SwiftletCore/ConversationState.swift`;
+byte offsets pinned by `ConversationStateTests.headerLayoutIsPinned`.
+
+What a snapshot is **not**: it holds no pending logits, no sampler or
+repetition-penalty history, no chat-template history, and no expert-cache
+contents. Continuing needs at least one new token (`step` on the restored
+context). `SwiftletSession`'s message-level continuation matching is a layer
+above this and is not persisted here.
+
+## Container
+
+All integers little-endian. Offsets in bytes.
+
+```
+Header (128 bytes)
+  0    8   magic          "SWLSTATE"
+  8    4   version        u32  = 1
+  12   4   headerLength   u32  = 128
+  16   4   dtype          u32  1 = float32 (the only value in v1)
+  20   4   identityScheme u32  how `identity` was derived (see below)
+  24   32  identity       SHA-256 of the model, per `identityScheme`
+  56   44  geometry       11 x u32, in this order:
+             numHiddenLayers, fullAttentionInterval, numKeyValueHeads,
+             headDim, linearNumValueHeads, linearNumKeyHeads,
+             linearKeyHeadDim, linearValueHeadDim, linearConvKernelDim,
+             hiddenSize, vocabSize
+  100  8   position       u64  tokens the context has consumed
+  108  4   sectionCount   u32
+  112  8   totalLength    u64  whole file, header through trailer
+  120  8   reserved       zero
+Sections (sectionCount of, back to back, from offset 128)
+  0    4   layer          u32  0-based decoder layer
+  4    4   kind           u32  1 = K rows, 2 = V rows, 3 = conv tail, 4 = delta state
+  8    8   count          u64  float32 elements that follow
+  16   4*count  float32 data
+Trailer (32 bytes)
+  SHA-256 over every byte before it (header + sections)
+```
+
+Section layouts are the ones both engines hold in memory (the Metal fast
+path's GPU buffers use the same ones, so a Metal snapshot is a memcpy of the
+GPU state and a CPU restore of it needs no transposition):
+
+| kind | shape | expected `count` |
+|---|---|---|
+| 1 K rows | `[position][numKeyValueHeads][headDim]` | `position * numKeyValueHeads * headDim` |
+| 2 V rows | same as K | same |
+| 3 conv tail | `[linearConvKernelDim - 1][convDim]`, `convDim = 2 * linearNumKeyHeads * linearKeyHeadDim + linearNumValueHeads * linearValueHeadDim` | `(linearConvKernelDim - 1) * convDim` |
+| 4 delta state | `[linearNumValueHeads][linearValueHeadDim][linearKeyHeadDim]` | product of the three |
+
+Layer `i` is a DeltaNet layer unless `(i + 1) % fullAttentionInterval == 0`.
+DeltaNet layers carry kinds 3 and 4; attention layers carry kinds 1 and 2.
+Each `(layer, kind)` appears at most once. Once `position > 0` every layer's
+sections must be present; at `position == 0` the section table is empty.
+
+## Model identity
+
+Snapshots must never be restored into a different model. The identity is a
+SHA-256 that reads no weight bytes, so it is cheap on an 18 GB container, and
+is as strong as the container allows:
+
+- **scheme 1 — qpack container with `hashes.json`**: digest over `config.json`
+  and `hashes.json`. `hashes.json` lists a SHA-256 per file in the container,
+  so this transitively pins every weight byte.
+- **scheme 2 — plain checkpoint, or a container without `hashes.json`**:
+  digest over `config.json`, `manifest.json` if present, and for each
+  safetensors shard (sorted by name) its file name, header JSON, and byte
+  size. This pins the architecture, tensor names, dtypes, shapes, and sizes,
+  **not the weight values**: two checkpoints that differ only in weight bytes
+  but share their headers would share an identity under scheme 2.
+
+Each label and length is fed to the hash before its bytes, so a shard rename
+or a boundary shift changes the digest.
+
+## Refusals
+
+`restoreContext(from:)` throws `ConversationStateError`, in this order, and
+restores nothing on any failure:
+
+| check | error |
+|---|---|
+| first 8 bytes are not the magic | `badMagic` |
+| `version != 1` | `unsupportedVersion(found:supported:)` |
+| fewer bytes than `totalLength` | `truncated` |
+| more bytes than `totalLength`, bad `headerLength`, trailer digest mismatch | `corrupt(...)` |
+| `dtype != 1` | `dtypeMismatch(found:)` |
+| a section whose layer, kind, or size does not fit the header's own geometry and position; a duplicate; a missing layer at `position > 0` | `corrupt(...)` |
+| identity scheme or digest differs from the model's | `modelMismatch(expected:found:)` |
+| any geometry field differs from the model's | `geometryMismatch(field:expected:found:)` |
+
+The digest is checked before any header field beyond version and length is
+interpreted, so everything after it is what the writer wrote. Geometry is
+compared after identity: a foreign model reports `modelMismatch`, not the
+first dimension that happens to differ.
+
+## Engines
+
+- **CPU reference**: the context's fields are the snapshot's sections,
+  directly.
+- **Metal fast path**: the bound context's conv history and delta recurrence
+  live in per-layer GPU buffers; `snapshot(of:)` reads them back into the
+  context first. KV comes from the context's mirror, which the engine copies
+  out of the GPU KV rows after every attention layer.
+  `ConversationStateTests.metalSnapshotMatchesDirectGPUReadback` proves both
+  paths bitwise against direct GPU readback. A restored context is unbound;
+  its first step loads it into the GPU buffers through `bindContext`, which
+  also validates every layer's shape against the model.
+
+Correctness bar (tests in `ConversationStateTests`): save after N greedy
+tokens → restore into a fresh model instance → continue → logits and greedy
+tokens bitwise identical to the uninterrupted run, on CPU and on Metal,
+including across a layer-major chunked prefill. A Metal snapshot restored
+into the CPU reference continues within the engines' usual parity band
+(2e-3), not bitwise, because the state itself carries GPU-vs-CPU
+accumulation noise.
+
+## CLI
+
+```
+swiftlet generate <model> --gpu --prompt "..." --max-new 32 --save-state /tmp/s.swlstate
+swiftlet generate <model> --gpu --ids 1234,567 --max-new 32 --load-state /tmp/s.swlstate
+```
+
+`--save-state` writes the context as it stands after the last generated token
+was fed (prompt plus every generated token). `--load-state` restores it and
+feeds `--prompt`/`--ids` as the continuation — raw tokens, no chat template
+is applied to a resumed sequence, and at least one token is required.
+`--max-new 0` saves right after the prompt.
+
+## Versioning
+
+`version` bumps on any change to the header layout, section kinds, layouts,
+or the trailer. A v1 reader refuses anything else. Adding a section kind or a
+dtype is a version bump, not a flag; the reserved bytes stay zero in v1.
+
+## Validation log
+
+2026-09-02, macmini2 (Apple M1, 8-core GPU, 16 GB, macOS 26.6.2, Swift
+6.3.3), `swift build -c release`, Qwen3.6-35B-A3B 4-bit qpack, `--gpu
+--cache-gb 4`, greedy, prompt "The fieldfare is a bird that" (7 tokens).
+Log: `~/bench-logs/s6-state-check-20260902-105315.log` on macmini2.
+
+| run | command | generated ids |
+|---|---|---|
+| A | `--max-new 32` | `369,1669,303,4357,11,13229,11,321,4634,4994,13,1049,369,264,4314,314,279,8541,1080,2902,11,321,424,369,14706,5265,310,279,3567,95180,13,561` |
+| B | `--max-new 16 --save-state s` | `369,...,4314,314` = A[1..16]; wrote 66 807 200 bytes at position 23, sha256 `e85f4c11…eae26e4` |
+| C | fresh process, `--load-state s --ids 279 --max-new 15` (279 = A[17]) | `8541,1080,2902,11,321,424,369,14706,5265,310,279,3567,95180,13,561` = A[18..32] |
+
+Snapshot identity scheme 1 (the container ships `hashes.json`). Decode
+2.9–3.3 tok/s in every run; the resumed run's first step processed one token
+(41 command buffers, position 23 → 24). Tiny-fixture equivalents, including
+the CPU engine resuming a Metal snapshot and the `modelMismatch` /
+`truncated` refusals through the CLI, ran the same day.


### PR DESCRIPTION
## What this does

Two changes toward a model-backend boundary, in dependency order. Stacked on #24 (on #23, #22, #21); the diff includes those until they merge — the four commits from `8ef1753` on are this PR.

### 1. Model-owned inference context (source-breaking)

`InferenceModel` no longer exposes Qwen-typed decode state. Models hand out an opaque `InferenceContext` they own and advance; the KV cache, conv history, DeltaNet recurrence, position, and the GPU-resident KV from #23 are internals of `QwenInferenceContext`. `QwenCPUModel.DecodeState` is off the public surface.

```swift
protocol InferenceContext: AnyObject { var position: Int { get }; func reset() }
protocol InferenceModel {
    var vocabSize: Int { get }; var modelDir: URL { get }
    func makeContext() -> any InferenceContext
    func step(_ ids: [Int], context: any InferenceContext) throws -> [Float]
}
```

A context is owned by the instance that created it; a foreign one (other instance, or a CPU context on a Metal model) throws `InferenceContextError.foreignContext`. Call-site churn (CLI, server, session, tests) is mechanical.

This also fixed a latent bug: on the Metal fast path the DeltaNet recurrence lives in model-owned GPU buffers bound to one state, so before this a *second* context used mid-sequence on the same model was silently wrong. Binding a context now captures the outgoing recurrence from the GPU and loads the incoming one's (host-side memcpy only, no dispatches). The interleaved-contexts test was red before that commit and is bitwise-green after.

Tests: a Qwen-free stub backend drives `TextGenerator` end to end (compile-level proof the protocol carries no Qwen types); the protocol file is source-scanned; foreign contexts are refused on both engines; create → step → reset → step is bitwise equal to a fresh context on CPU and Metal; interleaved contexts on one model are bitwise equal to isolated runs. All dispatch/command-buffer baselines and parity pins unchanged. `QwenMetalModel.swift` footprint: +11/−13 lines.

### 2. Conversation-state snapshots

`PersistableInferenceModel` + a versioned binary format (`SWLSTATE` v1, 128-byte header: magic, version, dtype, identity scheme, SHA-256 model identity, 11-value geometry table, position, section table, total length; sections for K, V, conv tail, delta state; trailing SHA-256 over all preceding bytes). Identity scheme 1 pins every weight byte via a qpack's `hashes.json`; scheme 2 (plain safetensors) pins structure only and says so. Strict refusals, each tested: bad magic, unsupported version, truncated, corrupt digest/section table, dtype mismatch, model mismatch, forged geometry, section-vs-position, foreign-context snapshot.

Correctness: save after N tokens → restore into a **fresh model instance** → continue: logits and greedy picks bitwise equal to the uninterrupted run on CPU and Metal, and across a layer-major chunked prefill. GPU KV round-trips through the CPU mirror and is proven equal to a direct GPU readback; conv-tail/delta sections likewise; snapshotting leaves the live context undisturbed. Mutation check: zeroing the restored delta state fails all four round-trip tests. Real-model spot check (35B qpack, base M1): 16 tokens + save (67 MB) → new process → 15 more tokens, id-for-id equal to the straight 32-token run.

CLI: `--save-state` / `--load-state`. Format documented in `docs/STATE_FORMAT.md`. Not persisted (documented): session-level message matching in `SwiftletSession`.

116 tests / 20 suites on a base M1 (CLT Swift 6.3.3). Rebase note vs #25: the only textual overlap is the `step(...)` signature line in `QwenMetalModel.swift`.
