### PR TITLE
Record expert quantization in the qpack manifest, not the checkpoint default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ demand. The result:
 Those figures are on an M5. For a low end anchor, a base M1 (8-core GPU, 16 GB)
 decodes the 4-bit 35B at about 2.45 tok/s and the 8-bit at about 1.74 tok/s, and
 prefill runs at roughly decode speed, so a long system prompt is expensive on
-this class of machine. On so few GPU cores the decode loop is fully compute
-bound, so the expert cache is a memory knob rather than a speed one there:
-`--cache-gb 2` matches `--cache-gb 8` while saving several GB of RAM, which is
-the better setting on a 16 GB machine.
+this class of machine. On so few GPU cores the decode loop is close to compute
+bound, so the expert cache is mostly a memory knob there: on a short prompt
+`--cache-gb 2` matches `--cache-gb 8` while saving several GB of RAM. Long
+context is the exception, since that is where cold expert reads cluster: on a
+503-token prompt a larger cache lifts decode about 8 percent from 2 to 6 GB by
+trimming the CPU gap between command buffers. On a 16 GB machine the low setting
+is still usually the right trade.
 
 At the other end, an M4 Max (40-core GPU, 64 GB) decodes the 4-bit 35B at about
 19.5 tok/s. The configuration that shows why streaming matters is the 8-bit 80B:
@@ -131,8 +134,10 @@ routes every token to 10 of 512 experts (80B) or 8 of 256 (35B). Swiftlet:
   a `.qpack` container, so fetching one expert is exactly one `pread` from
   SSD, no mmap and no page-cache thrash;
 - caches hot experts in a bounded pool with LFU plus recency eviction. Cache
-  size barely affects speed (measured 43 to 70 percent hit rates at the same
-  throughput), because Apple SSDs absorb the misses;
+  size is more a cold-start and memory knob than a throughput one (measured 43
+  to 70 percent hit rates at nearly the same throughput), because Apple SSDs
+  absorb the misses, though a larger cache does help long-context decode where
+  cold reads cluster;
 - runs the whole forward pass on Metal with runtime-compiled shaders, so no
   Metal toolchain is needed at build time and the same code ships on iOS.
 

--- a/Sources/SwiftletCore/Qpack.swift
+++ b/Sources/SwiftletCore/Qpack.swift
@@ -46,6 +46,32 @@ public enum Qpack {
     }
 
     static func align(_ n: Int, to a: Int) -> Int { (n + a - 1) / a * a }
+
+    /// Logical inner dimension of a quantized expert projection, cross-checked
+    /// against the manifest's quantization. A quantized weight stores
+    /// `inDim / (32 / bits)` uint32 words per row; its scales store
+    /// `inDim / groupSize` groups per row. Both describe the same `inDim`, so
+    /// when the manifest's bits/groupSize make them disagree the container's
+    /// recorded quantization does not match its packed bytes, and dequantizing
+    /// anyway would decode garbage. This catches an already-built bad container
+    /// at load with a clear error instead of silent garbage (issue #30).
+    static func expertLogicalInDim(weightLastDim: Int, scalesLastDim: Int,
+                                   bits: Int, groupSize: Int,
+                                   section: String) throws -> Int {
+        guard bits > 0, groupSize > 0, 32 % bits == 0 else {
+            throw Checkpoint.Error.badShape(
+                "qpack section \(section): invalid quantization \(bits)-bit/g\(groupSize)")
+        }
+        let fromWeight = weightLastDim * (32 / bits)
+        let fromScales = scalesLastDim * groupSize
+        guard fromWeight > 0, fromWeight == fromScales else {
+            throw Checkpoint.Error.badShape(
+                "qpack section \(section): manifest \(bits)-bit/g\(groupSize) disagrees with the packed "
+                + "shapes (weight inner \(weightLastDim), scales inner \(scalesLastDim)); the container's "
+                + "recorded quantization does not match its expert bytes (issue #30)")
+        }
+        return fromWeight
+    }
 }
 
 /// Repacks a local mlx-lm checkpoint directory into a `.qpack` container.
@@ -59,7 +85,46 @@ public struct QpackRepacker {
         self.outputDir = outputDir
     }
 
+    public enum Error: Swift.Error, CustomStringConvertible {
+        /// The packed expert projections do not share one quantization, which a
+        /// single-valued manifest cannot represent (issue #30).
+        case mixedExpertQuant(String)
+        public var description: String {
+            switch self { case .mixedExpertQuant(let m): return m }
+        }
+    }
+
     static let expertTensorSuffixes = ["gate_proj", "up_proj", "down_proj"]
+
+    /// The quantization the packed EXPERT tensors were stored with, which is
+    /// what the runtime must dequantize them by, resolved from the checkpoint's
+    /// per-tensor overrides and falling back to its default. This is not always
+    /// the checkpoint's top-level default: a mixed-precision checkpoint (for
+    /// example an 8-bit dense default with 4-bit `switch_mlp` experts, as in the
+    /// DWQ variants) carries the expert precision as per-tensor overrides.
+    /// Returns nil for an unquantized checkpoint. Throws when the expert
+    /// projections disagree with each other, since the manifest records one
+    /// value for all of them (issue #30).
+    static func expertQuant(_ ckpt: Checkpoint) throws -> Checkpoint.QuantSpec? {
+        var resolved: [(module: String, spec: Checkpoint.QuantSpec)] = []
+        for proj in expertTensorSuffixes {
+            // Layer 0 is representative: the section table is derived from it,
+            // and mlx-lm quantizes a given module identically across layers.
+            let module = "model.layers.0.mlp.switch_mlp." + proj
+            guard ckpt.contains(module + ".weight") else { continue }
+            guard let spec = ckpt.quantSpec(for: module) else { continue }
+            resolved.append((module, spec))
+        }
+        guard let first = resolved.first else { return ckpt.defaultQuant }
+        for entry in resolved
+        where entry.spec.bits != first.spec.bits || entry.spec.groupSize != first.spec.groupSize {
+            throw Error.mixedExpertQuant(
+                "expert projection \(entry.module) is \(entry.spec.bits)-bit/g\(entry.spec.groupSize) "
+                + "but \(first.module) is \(first.spec.bits)-bit/g\(first.spec.groupSize); a container "
+                + "records one expert quantization and cannot represent both")
+        }
+        return first.spec
+    }
 
     /// Follows a (possibly relative, possibly chained) symlink to the real file
     /// it points at, returning the input unchanged when it is not a symlink.
@@ -85,6 +150,12 @@ public struct QpackRepacker {
         let fm = FileManager.default
         let config = try QwenConfig(url: checkpointDir.appendingPathComponent("config.json"))
         let ckpt = try Checkpoint(dir: checkpointDir)
+
+        // Resolve (and validate) the expert quantization up front so a
+        // mixed-precision checkpoint fails before packing gigabytes rather than
+        // after, and so the manifest records the experts' real precision instead
+        // of the checkpoint's dense default (issue #30).
+        let expertQuant = try Self.expertQuant(ckpt)
 
         let expertsDir = outputDir.appendingPathComponent("packed_experts")
         try fm.createDirectory(at: expertsDir, withIntermediateDirectories: true)
@@ -188,13 +259,15 @@ public struct QpackRepacker {
             files[aux] = try fm.attributesOfItem(atPath: dst.path)[.size] as? Int ?? 0
         }
 
+        // quantBits/quantGroupSize describe the packed EXPERT tensors (resolved
+        // and validated above), not the checkpoint's dense default (issue #30).
         let manifest = Qpack.Manifest(
             magic: "QPACK",
             version: Qpack.manifestVersion,
             modelName: config.modelType,
             sourceCheckpoint: checkpointDir.lastPathComponent,
-            quantBits: ckpt.defaultQuant?.bits,
-            quantGroupSize: ckpt.defaultQuant?.groupSize,
+            quantBits: expertQuant?.bits,
+            quantGroupSize: expertQuant?.groupSize,
             files: files
         )
         try JSONEncoder.sorted.encode(manifest).write(to: outputDir.appendingPathComponent("manifest.json"))

--- a/Sources/SwiftletCore/QwenMetalModel.swift
+++ b/Sources/SwiftletCore/QwenMetalModel.swift
@@ -398,9 +398,12 @@ public final class QwenMetalModel {
                 if w.dtype == "U32", let bits = manifest.quantBits, let group = manifest.quantGroupSize,
                    let sSec = cache.reader.section(name + ".scales"),
                    let bSec = cache.reader.section(name + ".biases") {
+                    let inDim = try Qpack.expertLogicalInDim(
+                        weightLastDim: w.shape.last ?? 0, scalesLastDim: sSec.shape.last ?? 0,
+                        bits: bits, groupSize: group, section: name)
                     return ExpertProj(
                         wOff: w.offset, sOff: sSec.offset, bOff: bSec.offset,
-                        outDim: outDim, inDim: w.shape.last! * (32 / bits),
+                        outDim: outDim, inDim: inDim,
                         groupSize: group, bits: bits,
                         scalesType: MetalEngine.ScalesType(dtype: sSec.dtype)?.rawValue ?? 2,
                         isQuantized: true, plainDtype: 0

--- a/Tests/SwiftletCoreTests/QpackTests.swift
+++ b/Tests/SwiftletCoreTests/QpackTests.swift
@@ -119,4 +119,89 @@ import Testing
         for i in 0..<a.count { maxDiff = max(maxDiff, abs(a[i] - b[i])) }
         #expect(maxDiff < 2e-3, "streamed container logits diff \(maxDiff)")
     }
+
+    // MARK: - Mixed-precision expert quantization (issue #30)
+
+    /// Copies the tiny 4-bit fixture and rewrites its quantization config to a
+    /// dense default with per-module `switch_mlp` overrides, reproducing the
+    /// mixed-precision shape (8-bit dense, 4-bit experts) of the DWQ variants.
+    /// The expert bytes stay 4-bit; only the recorded precision changes.
+    static func mixedPrecisionCheckpoint(defaultBits: Int, expertBits: [String: Int],
+                                         group: Int = 32) throws -> URL {
+        let src = Self.fixturesDir.appendingPathComponent("tiny-model-q4")
+        let dst = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tiny-mixed-\(UUID().uuidString)")
+        try FileManager.default.copyItem(at: src, to: dst)
+        let cfgURL = dst.appendingPathComponent("config.json")
+        var cfg = try JSONSerialization.jsonObject(with: Data(contentsOf: cfgURL)) as! [String: Any]
+        var quant: [String: Any] = ["group_size": group, "bits": defaultBits]
+        for (module, bits) in expertBits {
+            quant[module] = ["group_size": group, "bits": bits]
+        }
+        cfg["quantization"] = quant
+        try JSONSerialization.data(withJSONObject: cfg).write(to: cfgURL)
+        return dst
+    }
+
+    /// A checkpoint whose experts are 4-bit under an 8-bit dense default must
+    /// repack a manifest that records 4-bit, not the 8-bit default. Recording
+    /// the default made the runtime dequantize the 4-bit expert payload as
+    /// 8-bit and decode garbage with no error (issue #30).
+    @Test func repackRecordsExpertQuantNotCheckpointDefault() throws {
+        let src = try Self.mixedPrecisionCheckpoint(defaultBits: 8, expertBits: [
+            "model.layers.0.mlp.switch_mlp.gate_proj": 4,
+            "model.layers.0.mlp.switch_mlp.up_proj": 4,
+            "model.layers.0.mlp.switch_mlp.down_proj": 4,
+        ])
+        let out = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mixed-\(UUID().uuidString).qpack")
+        defer {
+            try? FileManager.default.removeItem(at: src)
+            try? FileManager.default.removeItem(at: out)
+        }
+        var repacker = QpackRepacker(checkpointDir: src, outputDir: out)
+        repacker.log = { _ in }
+        try repacker.repack()
+
+        let manifest = try JSONDecoder().decode(
+            Qpack.Manifest.self,
+            from: Data(contentsOf: out.appendingPathComponent("manifest.json")))
+        #expect(manifest.quantBits == 4, "manifest must record the 4-bit expert precision, not the 8-bit default")
+        #expect(manifest.quantGroupSize == 32)
+    }
+
+    /// When the expert projections carry different precisions, no single
+    /// manifest value is correct, so repack must refuse rather than ship a
+    /// container that decodes garbage for some projections (issue #30).
+    @Test func repackRejectsDisagreeingExpertQuant() throws {
+        let src = try Self.mixedPrecisionCheckpoint(defaultBits: 8, expertBits: [
+            "model.layers.0.mlp.switch_mlp.gate_proj": 4,
+            "model.layers.0.mlp.switch_mlp.up_proj": 8,
+            "model.layers.0.mlp.switch_mlp.down_proj": 4,
+        ])
+        let out = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mixed-bad-\(UUID().uuidString).qpack")
+        defer {
+            try? FileManager.default.removeItem(at: src)
+            try? FileManager.default.removeItem(at: out)
+        }
+        var repacker = QpackRepacker(checkpointDir: src, outputDir: out)
+        repacker.log = { _ in }
+        #expect(throws: QpackRepacker.Error.self) { try repacker.repack() }
+    }
+
+    /// The load-time guard rejects a container whose manifest quantization does
+    /// not match its packed expert shapes (issue #30). For the tiny geometry
+    /// (hidden 64, group 32) a 4-bit weight stores 8 words per row and its
+    /// scales store 2 groups per row; reading those bytes as 8-bit makes the
+    /// two disagree.
+    @Test func expertLogicalInDimRejectsQuantMismatch() throws {
+        let inDim = try Qpack.expertLogicalInDim(
+            weightLastDim: 8, scalesLastDim: 2, bits: 4, groupSize: 32, section: "gate_proj.weight")
+        #expect(inDim == 64)
+        #expect(throws: (any Swift.Error).self) {
+            _ = try Qpack.expertLogicalInDim(
+                weightLastDim: 8, scalesLastDim: 2, bits: 8, groupSize: 32, section: "gate_proj.weight")
+        }
+    }
 }


### PR DESCRIPTION
Fixes #30.

## Problem

`swiftlet-repack` writes the checkpoint's top-level `quantization` default into `manifest.json` (`quantBits` / `quantGroupSize`), and the Metal runtime uses that one value to dequantize every expert section. A mixed-precision checkpoint whose dense default is 8-bit while the `switch_mlp.*` experts are 4-bit via per-tensor overrides (the DWQ variants) therefore repacked into a container that recorded 8-bit, then read the 4-bit expert payload as 8-bit and decoded garbage on every request, with no error anywhere. @Avicennasis reproduced this precisely in #30, control container included.

## Fix

- Repack resolves the expert precision from the per-tensor overrides the checkpoint already carries (`Checkpoint.quantSpec(for:)`), falling back to the default, and records that in the manifest instead of the dense default.
- It refuses to repack when the expert projections carry different precisions, since one manifest value cannot represent them, and does this up front so a mixed checkpoint fails before packing gigabytes rather than after.
- Load adds a cross-check: a quantized expert weight stores `inDim / (32 / bits)` words per row and its scales store `inDim / groupSize` groups per row, so a container whose manifest does not match its packed bytes now fails with a clear error instead of decoding garbage. That also catches containers already built with the wrong manifest, turning the silent failure into a refusal.

Uniform 4-bit and 8-bit checkpoints are unaffected: the resolved expert spec equals the default, so their manifests are byte-for-byte the same as before.

## Also

Scopes the README cache-size note from #18: `--cache-gb` barely moves short-prompt decode on a small GPU, but a larger cache does help long-context decode, where cold expert reads cluster.

## Tests

Full suite green (165 tests). New `QpackTests` cases:

- `repackRecordsExpertQuantNotCheckpointDefault` records 4-bit, not the 8-bit default.
- `repackRejectsDisagreeingExpertQuant` refuses gate 4-bit with up 8-bit.
- `expertLogicalInDimRejectsQuantMismatch` rejects a manifest that disagrees with the packed shapes.

One caveat on verification: I do not have the DWQ checkpoint locally, so I could not reproduce the end-to-end garbage-then-correct output on that exact model. The evidence here is the unit tests, the full suite, and the load-time cross-check rather than a before-and-after generation.
